### PR TITLE
build: Make monitor.pyz byte-deterministic

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -190,6 +190,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../compliance_process");
     println!("cargo:rerun-if-changed=../python-3.12.10-amd64.exe");
     println!("cargo:rerun-if-changed=../browser-extension");
+    println!("cargo:rerun-if-changed=build_pyz.py");
 
     // 最后，调用 tauri_build
     tauri_build::build();
@@ -223,7 +224,7 @@ fn locate_python() -> (String, Vec<String>) {
 
     panic!(
         "Build failed: no usable Python interpreter found. \
-         carbonPaper's build.rs needs Python 3.x on PATH to run `python -m zipapp` for \
+         carbonPaper's build.rs needs Python 3.x on PATH to run `build_pyz.py` for \
          the monitor integrity-check package. Install Python 3.12 or ensure `python` / `py -3` \
          resolves on your PATH."
     );
@@ -235,7 +236,12 @@ fn locate_python() -> (String, Vec<String>) {
 /// 这里**重新走一遍源目录**而不是用 pre-bundle/monitor/，
 /// 因为 pre-bundle 可能积累了源中已删除的陈旧文件（旧 build.rs 只复制不清理）。
 /// 我们把通过过滤的文件复制到 `target/pyz-staging-monitor/`（每次清空），
-/// 然后用 `python -m zipapp` 打包这个干净目录。
+/// 然后用 `build_pyz.py`（项目自带的确定性打包器）把 staging 目录打成 zipapp。
+///
+/// 为什么不直接 `python -m zipapp`：标准 zipapp 把每个 entry 的文件系统 mtime
+/// 写进 zip header，于是同一份源代码两次 build 产出字节不同的 .pyz，hash 漂移。
+/// `build_pyz.py` 固定 entry timestamp / external_attr / 排序 / compresslevel，
+/// 保证字节稳定，从而 `MONITOR_PYZ_SHA256` 可重现。
 ///
 /// 过滤规则与 main() 中的复制循环保持一致：
 ///   - 排除 `.venv` / `__pycache__` / `tests` 子目录
@@ -243,7 +249,8 @@ fn locate_python() -> (String, Vec<String>) {
 ///   - 仅收录扩展名为 `.py` / `.txt` / `.md` / `.json` 的文件
 ///   - `model/` 和 `models/` 全部收录（含权重等二进制）
 ///
-/// 入口点通过 `-m "main:main"` 生成（zipapp 自动写一个 __main__.py 调用 main.main()）。
+/// 入口点通过 `"main:main"` 生成（脚本自动写一个 __main__.py 调用 main.main()，
+/// 与 zipapp 的 MAIN_TEMPLATE 一致）。
 fn build_monitor_pyz(source_dir: &Path, out_pyz: &Path) -> String {
     // 先确认源目录确实存在主入口
     let main_py = source_dir.join("main.py");
@@ -325,29 +332,38 @@ fn build_monitor_pyz(source_dir: &Path, out_pyz: &Path) -> String {
         }
     }
 
-    // 3. 跑 python -m zipapp <staging> -o <out_pyz> -m "main:main" --compress
+    // 3. 跑 build_pyz.py <staging> <out_pyz> "main:main"
+    //    自定义打包脚本：固定 entry mtime / create_system / external_attr，
+    //    排序写入 + 显式 compresslevel，保证 .pyz 字节稳定（同源代码 → 同 hash），
+    //    这样 build.rs 嵌入到 Rust 二进制里的 SHA-256 可以重现。
+    //    `python -m zipapp` 会把每个成员的文件系统 mtime 写进 zip header，
+    //    导致两次 build 产出字节不同的 .pyz，hash 永远漂移——所以这里弃用。
+    let helper_script = Path::new("build_pyz.py");
+    if !helper_script.is_file() {
+        panic!(
+            "Build failed: missing helper script {}; expected at src-tauri/build_pyz.py",
+            helper_script.display()
+        );
+    }
+
     let (program, prefix_args) = locate_python();
     let mut zipapp_cmd = Command::new(&program);
     for a in &prefix_args {
         zipapp_cmd.arg(a);
     }
     zipapp_cmd
-        .arg("-m")
-        .arg("zipapp")
+        .arg(helper_script)
         .arg(staging)
-        .arg("-o")
         .arg(out_pyz)
-        .arg("-m")
-        .arg("main:main")
-        .arg("--compress");
+        .arg("main:main");
 
     let output = zipapp_cmd
         .output()
-        .unwrap_or_else(|e| panic!("Failed to spawn python -m zipapp: {}", e));
+        .unwrap_or_else(|e| panic!("Failed to spawn build_pyz.py: {}", e));
 
     if !output.status.success() {
         panic!(
-            "python -m zipapp failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+            "build_pyz.py failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
             output.status.code(),
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr),

--- a/src-tauri/build_pyz.py
+++ b/src-tauri/build_pyz.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Deterministic zipapp packager for monitor.pyz (replaces `python -m zipapp`).
+
+Used by ``src-tauri/build.rs`` to produce a byte-stable zip archive whose
+SHA-256 can be safely embedded into the Rust binary at compile time.
+
+Unlike ``python -m zipapp``, every entry written here uses a fixed timestamp,
+fixed external_attr / create_system / create_version, fixed compresslevel,
+and entries are written in sorted order — so the output is identical for
+identical input regardless of filesystem mtimes, OS, or walk order.
+
+Note on cross-machine reproducibility: the underlying ``zlib`` deflate stream
+is byte-identical given the same input and same compresslevel on the same
+``zlib`` version. CPython on Windows bundles a fixed ``zlib``, so as long as
+all builders use the same Python minor version the bytes match. Across
+Python upgrades the hash may shift — that's fine because the binary and the
+.pyz are produced together.
+
+Usage:
+    python build_pyz.py <source_dir> <output_pyz> <module>:<function>
+
+The generated archive mimics what ``python -m zipapp -m "module:function"``
+would produce, including the auto-generated ``__main__.py`` entry point.
+"""
+
+import os
+import sys
+import zipfile
+
+
+# Earliest representable date in ZIP format: 1980-01-01 00:00:00.
+# Using the absolute minimum makes the timestamp deterministic and obviously
+# synthetic (no real source file ever has this mtime).
+FIXED_DT = (1980, 1, 1, 0, 0, 0)
+
+# Mirrors ``zipapp.MAIN_TEMPLATE`` from CPython's ``Lib/zipapp.py``.
+MAIN_TEMPLATE = "# -*- coding: utf-8 -*-\nimport {module}\n{module}.{fn}()\n"
+
+
+def _add_entry(zf: zipfile.ZipFile, archive_name: str, data: bytes) -> None:
+    info = zipfile.ZipInfo(filename=archive_name, date_time=FIXED_DT)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.create_system = 3        # Unix; chosen for cross-platform determinism
+    info.create_version = 20
+    info.extract_version = 20
+    info.external_attr = (0o100644 & 0xFFFF) << 16  # regular file, rw-r--r--
+    zf.writestr(info, data)
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(
+            f"Usage: {sys.argv[0]} <source_dir> <output_pyz> <module>:<function>",
+            file=sys.stderr,
+        )
+        return 2
+
+    src_dir = os.path.abspath(sys.argv[1])
+    out_pyz = os.path.abspath(sys.argv[2])
+    main_spec = sys.argv[3]
+    if ":" not in main_spec:
+        print(
+            f"main spec must be in 'module:function' form (got {main_spec!r})",
+            file=sys.stderr,
+        )
+        return 2
+    main_module, main_fn = main_spec.split(":", 1)
+
+    if not os.path.isdir(src_dir):
+        print(f"source dir does not exist: {src_dir}", file=sys.stderr)
+        return 2
+
+    # Walk in sorted order so entry order is deterministic across filesystems.
+    entries = []
+    for root, dirs, files in os.walk(src_dir):
+        dirs.sort()
+        for fname in sorted(files):
+            full = os.path.join(root, fname)
+            rel = os.path.relpath(full, src_dir).replace(os.sep, "/")
+            entries.append((rel, full))
+
+    # Ensure parent dir exists for the output file.
+    out_parent = os.path.dirname(out_pyz)
+    if out_parent:
+        os.makedirs(out_parent, exist_ok=True)
+
+    with zipfile.ZipFile(
+        out_pyz,
+        mode="w",
+        compression=zipfile.ZIP_DEFLATED,
+        compresslevel=6,
+    ) as zf:
+        for archive_name, full_path in entries:
+            with open(full_path, "rb") as f:
+                data = f.read()
+            _add_entry(zf, archive_name, data)
+        # Auto-generated entry point, matching ``python -m zipapp -m "main:main"``.
+        main_src = MAIN_TEMPLATE.format(module=main_module, fn=main_fn)
+        _add_entry(zf, "__main__.py", main_src.encode("utf-8"))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add `src-tauri/build_pyz.py` — a small zipapp packager that fixes entry timestamps (1980-01-01), `external_attr`, `create_system`, sort order, and compresslevel.
- `build.rs` now invokes `build_pyz.py` instead of `python -m zipapp`. Same Python build-time dependency, same output contents and entry point (`main:main`) — just deterministic.

## Why
`python -m zipapp` records each file's filesystem mtime in the zip header, so successive `cargo build` runs produce different bytes for the same source. The SHA-256 baked into the Rust binary by `build.rs` therefore only matched the .pyz produced **in that same build invocation**. Reproducible builds were broken, and any future split of the pipeline (build .pyz once, link/sign .exe separately) would silently break the integrity check.

## Verification
- `cargo check` passes (build.rs runs, no warnings beyond the pre-existing `stop_power_monitor` dead-code one).
- Two independent invocations of `build_pyz.py target/pyz-staging-monitor … main:main` produce byte-identical .pyz → same SHA-256 (`9bc918b9608e4ec92b9e42c95165c1bc90b58a92965ca91334f03e4903423a3b` locally).
- Resulting `.pyz` still contains the expected entries (`__main__.py`, `main.py`, `monitor/__init__.py`, `classifier.py`, …) and every entry's date_time is `(1980, 1, 1, 0, 0, 0)`.

## Test plan
- [ ] `cargo build` succeeds; `pre-bundle/monitor.pyz` is a valid zipapp.
- [ ] `pytest monitor/tests/test_prebundle_sync.py` passes (existing tests cover entry-point + exclusion rules).
- [ ] Run `cargo build` twice with no source changes and verify `pre-bundle/monitor.pyz` is byte-identical between runs.