### PR TITLE
docs(script_integrity): Clarify threat model in module header

### DIFF
--- a/src-tauri/src/script_integrity.rs
+++ b/src-tauri/src/script_integrity.rs
@@ -1,11 +1,32 @@
 //! Monitor script integrity verification.
 //!
-//! Design points:
-//! - `EXPECTED_PYZ_SHA256` is injected at compile time by `build.rs` via `cargo:rustc-env=MONITOR_PYZ_SHA256=...`,
-//!   so it is distributed with the Rust binary itself; attackers who modify `.pyz` cannot simultaneously modify this constant.
-//! - `verify_monitor_pyz()` reads the disk `.pyz`, computes SHA-256, and compares with the expected value; any mismatch/read failure returns Err.
-//! - `log_security_event()` appends the event to `<LocalAppData>/CarbonPaper/security.log` when verification fails,
-//!   independent of the tracing logging system for forensic purposes.
+//! ## Threat model — what this actually mitigates
+//!
+//! This is an *integrity* check, **not** anti-tamper protection against a
+//! privileged attacker. The expected SHA-256 of `monitor.pyz` is injected at
+//! compile time by `build.rs` via `cargo:rustc-env=MONITOR_PYZ_SHA256=...` and
+//! ends up as a `&'static str` constant in the Rust binary's `.rodata`. That
+//! raises the bar — an attacker now has to coherently patch **both** the
+//! `.exe` (rewriting the constant) and the `.pyz`, which breaks any
+//! Authenticode signature on the NSIS installer — but anyone with write
+//! access to the `.pyz` typically has comparable access to the `.exe`, so
+//! this is not proof against a determined adversary. For real anti-tamper,
+//! sign the installer and rely on Windows code-signing / SmartScreen.
+//!
+//! What the check *does* reliably catch:
+//!   - accidental corruption (disk error, half-written update)
+//!   - drive-by replacement of only the `.pyz` (e.g. malware that drops a
+//!     malicious monitor script next to an untouched executable)
+//!   - shipping a release binary against a stale or wrong-version `.pyz`
+//!
+//! ## Operational pieces
+//!
+//! - `verify_monitor_pyz()` reads the disk `.pyz`, computes SHA-256, and
+//!   compares with the expected value; any mismatch / read failure returns
+//!   `Err`.
+//! - `log_security_event()` appends the event to
+//!   `<LocalAppData>/CarbonPaper/security.log` when verification fails,
+//!   independent of the tracing logging system, for forensic purposes.
 
 use std::fs::{self, OpenOptions};
 use std::io::Write;


### PR DESCRIPTION
## Summary
Rewrite the file header docstring at the top of `src-tauri/src/script_integrity.rs` so it accurately describes what the SHA-256 check actually mitigates.

## Why
The original wording —

> attackers who modify `.pyz` cannot simultaneously modify this constant

— overstates the protection. Patching a `&'static str` in the `.rodata` section of the .exe takes roughly the same level of access as replacing the .pyz next to it. The integrity check primarily helps against:

- accidental corruption (disk error, partial update)
- drive-by replacement of only the `.pyz` (e.g. malware drops a malicious monitor script but leaves the executable untouched)
- shipping a release binary with a stale or wrong-version `.pyz`

For real anti-tamper against a determined attacker, the installer needs Authenticode signing — not this check.

## Test plan
- [ ] `cargo check` passes (doc-comment-only change).
- [ ] No behavior change.