### PR TITLE
i18n: Translate SecurityAlertMask and debug trigger button

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -832,6 +832,21 @@
     "hideSocial": "Hide social tasks",
     "socialTasks": "Social"
   },
+  "aboutSection": {
+    "debug": {
+      "trigger_security_alert": "Preview Security Alert Mask"
+    }
+  },
+  "securityAlert": {
+    "title": "Monitor integrity compromised",
+    "debug_title": "Security alert — debug trigger",
+    "default_message": "A required monitor component failed its integrity check. Startup has been blocked to protect your data.",
+    "code_label": "Code",
+    "detail_label": "Detail",
+    "recovery_hint": "If you did not install or update CarbonPaper yourself, please reinstall from a trusted source. A log entry has been written to security.log under your CarbonPaper AppData directory.",
+    "dismiss": "Dismiss",
+    "exit": "Exit application"
+  },
   "errorWindow": {
     "title": "Critical Error",
     "unknownError": "Unknown error",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -834,6 +834,21 @@
     "hideSocial": "隐藏社交任务",
     "socialTasks": "社交"
   },
+  "aboutSection": {
+    "debug": {
+      "trigger_security_alert": "预览安全告警蒙层"
+    }
+  },
+  "securityAlert": {
+    "title": "监控完整性已被破坏",
+    "debug_title": "安全告警 — 调试触发",
+    "default_message": "所需的监控组件未通过完整性检查。为保护你的数据，启动已被阻止。",
+    "code_label": "错误代码",
+    "detail_label": "详细信息",
+    "recovery_hint": "如果你没有亲自安装或更新 CarbonPaper，请从可信来源重新安装。已在 CarbonPaper AppData 目录下的 security.log 写入日志条目。",
+    "dismiss": "关闭",
+    "exit": "退出应用程序"
+  },
   "errorWindow": {
     "title": "程序出现关键错误",
     "unknownError": "未知错误",


### PR DESCRIPTION
## Summary
Add the missing `securityAlert.*` and `aboutSection.debug.trigger_security_alert` keys to both `en.json` and `zh-CN.json` so the security-alert mask and the new About-page debug button render in the user's language.

Keys added:
- `aboutSection.debug.trigger_security_alert`
- `securityAlert.title`
- `securityAlert.debug_title`
- `securityAlert.default_message`
- `securityAlert.code_label`
- `securityAlert.detail_label`
- `securityAlert.recovery_hint`
- `securityAlert.dismiss`
- `securityAlert.exit`

## Why
The components already shipped with `t(key, fallback)` so they don't crash without translations, but Chinese users currently see English fallback strings in an otherwise-Chinese UI. Filling the keys removes that visible inconsistency.

## Test plan
- [ ] `python -c "import json; json.load(open('src/i18n/locales/en.json'))"` and same for zh-CN — both parse (verified locally).
- [ ] Switch UI language to zh-CN, navigate to Settings → About → Debug, click "预览安全告警蒙层", verify the mask shows fully Chinese content (title, code label, detail label, recovery hint, dismiss button).
- [ ] Same flow under en locale shows English copy unchanged.