### PR TITLE
chore(monitor): Remove dead monitor/monitor.pyz candidate

### DIFF
--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -539,9 +539,6 @@ pub async fn start_monitor(
         if let Some(p) = find_existing_file_in_resources(&app, "monitor.pyz") {
             pyz_candidates.push(p);
         }
-        if let Some(p) = find_existing_file_in_resources(&app, "monitor/monitor.pyz") {
-            pyz_candidates.push(p);
-        }
 
         // .py 候选（仅 dev 回退用）
         if let Ok(exe_path) = std::env::current_exe() {


### PR DESCRIPTION
## Summary
Delete the `find_existing_file_in_resources(&app, "monitor/monitor.pyz")` candidate from `start_monitor` in `src-tauri/src/monitor.rs`. `build.rs` writes only to `pre-bundle/monitor.pyz`, and `tauri.conf.json`'s `"pre-bundle": "."` maps that to `resource_dir/monitor.pyz` (matched by the surviving `"monitor.pyz"` lookup). There is no path under which a nested `monitor/monitor.pyz` would exist.

## Why
Dead code path. Trimming it makes the candidate list match reality and removes a tiny source of confusion the next time someone audits the integrity-check chain.

## Test plan
- [ ] `cargo check` passes locally (only the pre-existing `stop_power_monitor` dead-code warning remains).
- [ ] Run-time check: `cargo build && cargo tauri dev` — monitor starts normally; the surviving `.pyz` candidates (`exe_dir/monitor.pyz`, `exe_dir/monitor/monitor.pyz`, `resource_dir/monitor.pyz`) cover both dev and release layouts.