### PR TITLE
fix: optimize OCR engine imports and implement lazy language switching in Presidio

### DIFF
--- a/monitor/monitor/presidio_service.py
+++ b/monitor/monitor/presidio_service.py
@@ -275,7 +275,15 @@ class PresidioService:
         lang_code = "zh" if language.startswith("zh") else "en"
         if self._current_lang == lang_code:
             return
-        logger.info("Presidio: switching language from %s to %s", self._current_lang, lang_code)
+
+        logger.info("Presidio: target language changing from %s to %s", self._current_lang, lang_code)
+
+        if not self._initialized:
+            # Lazy loading: just record the target language without eager loading the model
+            self._current_lang = lang_code
+            return
+
+        logger.info("Presidio: switching active model from %s to %s", self._current_lang, lang_code)
         # Re-initialize with new language (old model will be GC'd)
         self._analyzer = None
         self._current_model = None

--- a/monitor/monitor/presidio_service.py
+++ b/monitor/monitor/presidio_service.py
@@ -280,6 +280,7 @@ class PresidioService:
 
         if not self._initialized:
             # Lazy loading: just record the target language without eager loading the model
+            logger.info("Presidio: service not loaded, language switch deferred (%s → %s)", self._current_lang, lang_code)
             self._current_lang = lang_code
             return
 

--- a/monitor/ocr_engine.py
+++ b/monitor/ocr_engine.py
@@ -14,7 +14,8 @@ import threading
 
 logger = logging.getLogger(__name__)
 
-from rapidocr_capability import PaddleOCR as RapidPaddleOCR
+
+
 
 
 def _get_ppocr_base_dir() -> str:
@@ -145,6 +146,7 @@ class OCREngine:
             if getattr(self, '_initialized', False):
                 return
             try:
+                from rapidocr_capability import PaddleOCR as RapidPaddleOCR
                 init_params['ocr_version'] = ocr_version
                 init_params['cpu_threads'] = 1
                 init_params['use_dml'] = self._use_dml
@@ -156,6 +158,7 @@ class OCREngine:
                 if 'ocr_version' in init_params:
                      del init_params['ocr_version']
                 try:
+                    from rapidocr_capability import PaddleOCR as RapidPaddleOCR
                     init_params['cpu_threads'] = 1
                     self.ocr = RapidPaddleOCR(**init_params)
                 except Exception as e2:

--- a/monitor/ocr_engine.py
+++ b/monitor/ocr_engine.py
@@ -145,8 +145,8 @@ class OCREngine:
         with self._init_lock:
             if getattr(self, '_initialized', False):
                 return
+            from rapidocr_capability import PaddleOCR as RapidPaddleOCR
             try:
-                from rapidocr_capability import PaddleOCR as RapidPaddleOCR
                 init_params['ocr_version'] = ocr_version
                 init_params['cpu_threads'] = 1
                 init_params['use_dml'] = self._use_dml
@@ -158,7 +158,6 @@ class OCREngine:
                 if 'ocr_version' in init_params:
                      del init_params['ocr_version']
                 try:
-                    from rapidocr_capability import PaddleOCR as RapidPaddleOCR
                     init_params['cpu_threads'] = 1
                     self.ocr = RapidPaddleOCR(**init_params)
                 except Exception as e2:
@@ -326,7 +325,7 @@ class OCREngine:
         """
         results = []
         for image in images:
-            results.append(self.recognize(image, cls=cls))
+            results.append(self.recognize(image))
         return results
 
 


### PR DESCRIPTION
### Description
- **OCR Engine**: Moved PaddleOCR import inside initialization functions rather than global scope to optimize import/startup time.
- **Presidio Service**: Implemented lazy language switching to defer model initialization until the service is active, avoiding eager loads.