### PR TITLE
feat: improve monitor IPC and OCR worker resilience

### DIFF
--- a/monitor/monitor/__init__.py
+++ b/monitor/monitor/__init__.py
@@ -132,7 +132,7 @@ def _delete_vectors_by_hashes(image_hashes):
     if not image_hashes:
         return {"deleted": 0, "requested": 0, "skipped": True}
 
-    if not _ocr_worker or not _ocr_worker.enable_vector_store or not _ocr_worker.vector_store:
+    if not _ocr_worker:
         return {"deleted": 0, "requested": len(image_hashes), "skipped": True}
 
     deleted = 0
@@ -140,7 +140,12 @@ def _delete_vectors_by_hashes(image_hashes):
         if not isinstance(image_hash, str) or not image_hash:
             continue
         try:
-            ok = _ocr_worker.vector_store.delete_image(f"memory://{image_hash}")
+            if hasattr(_ocr_worker, 'delete_vector_image'):
+                ok = _ocr_worker.delete_vector_image(image_hash)
+            elif getattr(_ocr_worker, 'vector_store', None):
+                ok = _ocr_worker.vector_store.delete_image(f"memory://{image_hash}")
+            else:
+                ok = False
             if ok:
                 deleted += 1
         except Exception:
@@ -271,11 +276,13 @@ def _handle_command_impl(req: dict):
     if cmd == 'update_advanced_config':
         capture_on_ocr_busy = bool(req.get('capture_on_ocr_busy', False))
         ocr_queue_max_size = int(req.get('ocr_queue_max_size', 1))
-        update_advanced_capture_config(capture_on_ocr_busy, ocr_queue_max_size)
+        ocr_timeout_secs = int(req.get('ocr_timeout_secs', getattr(config, '_ocr_timeout_secs', 120)))
+        update_advanced_capture_config(capture_on_ocr_busy, ocr_queue_max_size, ocr_timeout_secs)
         return {
             'status': 'success',
             'capture_on_ocr_busy': capture_on_ocr_busy,
             'ocr_queue_max_size': ocr_queue_max_size,
+            'ocr_timeout_secs': ocr_timeout_secs,
         }
 
     if cmd == 'update_feature_config':
@@ -453,6 +460,39 @@ def _handle_command_impl(req: dict):
             req.get('process_name', ''),
         )
 
+        if hasattr(_ocr_worker, 'request'):
+            timeout_secs = int(req.get('timeout_secs', getattr(config, '_ocr_timeout_secs', 120)))
+            try:
+                result = _ocr_worker.request(
+                    'process_ocr',
+                    {'request': req},
+                    timeout=max(30, min(600, timeout_secs)),
+                )
+                if result.get('status') == 'success':
+                    ocr_text = result.get('ocr_text', '')
+                    category = result.get('category')
+                    clustering_allowed = _clustering_scheduler_active and _last_clustering_session_valid and config.CLUSTERING_ENABLED
+                    if _clustering_manager and clustering_allowed:
+                        try:
+                            _clustering_manager.add_snapshot(
+                                screenshot_id=screenshot_id,
+                                process_name=req.get('process_name', ''),
+                                window_title=req.get('window_title', ''),
+                                ocr_text=ocr_text,
+                                timestamp=req.get('timestamp', 0),
+                                category=category or '',
+                            )
+                        except Exception as te:
+                            logger.warning('Task vector add failed: %s', te)
+                    result.pop('ocr_text', None)
+                return result
+            except TimeoutError as e:
+                logger.error('[DIAG:process_ocr] worker timeout screenshot_id=%s error=%s', screenshot_id, e)
+                return {'error': str(e)}
+            except Exception as e:
+                logger.error('[DIAG:process_ocr] worker failed screenshot_id=%s error=%s', screenshot_id, e, exc_info=True)
+                return {'error': str(e)}
+
         try:
             from PIL import Image
             import io as _io
@@ -465,10 +505,7 @@ def _handle_command_impl(req: dict):
                 logger.error('[DIAG:process_ocr] screenshot_id=%s storage client unavailable', screenshot_id)
                 return {'error': 'Storage client not available'}
 
-            resp = sc._send_request({
-                'command': 'get_temp_image',
-                'screenshot_id': screenshot_id,
-            })
+            resp = sc.get_temp_image_bytes(screenshot_id)
 
             if resp.get('status') != 'success':
                 logger.error(
@@ -479,8 +516,8 @@ def _handle_command_impl(req: dict):
                 )
                 return {'error': f"Failed to fetch image: {resp.get('error', 'unknown')}"}
 
-            image_data_b64 = resp.get('data', {}).get('image_data')
-            if not image_data_b64:
+            image_bytes = resp.get('data', {}).get('image_bytes')
+            if not image_bytes:
                 logger.error(
                     '[DIAG:process_ocr] screenshot_id=%s get_temp_image returned empty payload in %.3fs',
                     screenshot_id,
@@ -490,10 +527,10 @@ def _handle_command_impl(req: dict):
 
             fetch_elapsed = time.perf_counter() - t_fetch
             logger.debug(
-                '[DIAG:process_ocr] screenshot_id=%s temp image fetched in %.3fs payload_b64_len=%s',
+                '[DIAG:process_ocr] screenshot_id=%s temp image fetched in %.3fs payload_bytes=%s',
                 screenshot_id,
                 fetch_elapsed,
-                len(image_data_b64),
+                len(image_bytes),
             )
             if fetch_elapsed >= PROCESS_OCR_SLOW_STAGE_SECS:
                 logger.warning(
@@ -503,7 +540,6 @@ def _handle_command_impl(req: dict):
                 )
 
             t_decode = time.perf_counter()
-            image_bytes = base64.b64decode(image_data_b64)
             image_pil = Image.open(_io.BytesIO(image_bytes))
             decode_elapsed = time.perf_counter() - t_decode
             logger.debug(
@@ -684,14 +720,17 @@ def _handle_command_impl(req: dict):
         title = req.get('title', '')
         ocr_text = req.get('ocr_text', '')
         process_name = req.get('process_name', '')
-        if not _classifier:
+        if not _classifier and not hasattr(_ocr_worker, 'classify'):
             return {'error': 'Classification service not initialised'}
         try:
-            category, confidence = _classifier.classify(
-                title=title,
-                ocr_text=ocr_text,
-                process_name=process_name,
-            )
+            if hasattr(_ocr_worker, 'classify'):
+                category, confidence = _ocr_worker.classify(title, ocr_text, process_name)
+            else:
+                category, confidence = _classifier.classify(
+                    title=title,
+                    ocr_text=ocr_text,
+                    process_name=process_name,
+                )
             return {
                 'status': 'success',
                 'category': category,
@@ -1069,27 +1108,21 @@ def start(_debug, pipe_name: str = None, auth_token: str = None, storage_pipe: s
         logger.error("Failed to initialize shared ChromaDB client: %s", e)
         shared_chroma_client = None
 
-    # Lazy import to avoid triggering heavy model loading before IPC is ready
-    from ocr_service import OCRService
+    from .worker_process import RestartableModelWorker
 
-    logger.info("Initialising OCR service...")
-    _ocr_worker = OCRService(
-        vector_db_path=os.path.join(get_data_dir(), 'chroma_db'),
+    worker_env = {
+        'CARBONPAPER_CLUSTERING_ENABLED': str(config.CLUSTERING_ENABLED),
+        'CARBONPAPER_CLASSIFICATION_ENABLED': str(config.CLASSIFICATION_ENABLED),
+        'CARBONPAPER_USE_ONNX': os.environ.get('CARBONPAPER_USE_ONNX', 'true'),
+        'CARBONPAPER_OCR_TIMEOUT_SECS': str(getattr(config, '_ocr_timeout_secs', 120)),
+    }
+    _ocr_worker = RestartableModelWorker(
         storage_pipe=storage_pipe,
-        chroma_client=shared_chroma_client,
+        data_dir=get_data_dir(),
+        env=worker_env,
     )
-    _ocr_worker.start()
-
-    # Initialise classification service (BGE-small-zh-v1.5)
-    try:
-        from classifier import ClassificationService
-        _classifier = ClassificationService(
-            anchors_path=os.path.join(get_data_dir(), 'anchors.json'),
-        )
-        logger.info('Classification service initialised')
-    except Exception as e:
-        logger.warning('Classification service failed to initialise (non-fatal): %s', e)
-        _classifier = None
+    _classifier = _ocr_worker
+    logger.info('Restartable model worker proxy initialised')
 
     # Initialise task clustering service (MiniLM + HDBSCAN)
     try:

--- a/monitor/monitor/config.py
+++ b/monitor/monitor/config.py
@@ -81,6 +81,7 @@ IGNORE_PROTECTED_WINDOWS: bool = True
 # Advanced capture config (synced from Rust CaptureState)
 _capture_on_ocr_busy: bool = False
 _ocr_queue_max_size: int = 1
+_ocr_timeout_secs: int = int(os.environ.get("CARBONPAPER_OCR_TIMEOUT_SECS", "120") or "120")
 
 FILTER_SETTINGS_PATH = os.path.join(get_data_dir(), "monitor_filters.json")
 
@@ -190,11 +191,13 @@ def get_exclusion_settings():
     }
 
 
-def update_advanced_capture_config(capture_on_ocr_busy: bool, ocr_queue_max_size: int):
+def update_advanced_capture_config(capture_on_ocr_busy: bool, ocr_queue_max_size: int, ocr_timeout_secs: int = None):
     """Update advanced capture configuration (called via IPC, takes effect immediately)."""
-    global _capture_on_ocr_busy, _ocr_queue_max_size
+    global _capture_on_ocr_busy, _ocr_queue_max_size, _ocr_timeout_secs
     _capture_on_ocr_busy = capture_on_ocr_busy
     _ocr_queue_max_size = max(1, ocr_queue_max_size)
+    if ocr_timeout_secs is not None:
+        _ocr_timeout_secs = max(30, min(600, int(ocr_timeout_secs)))
 
 
 # Load persisted settings on module import

--- a/monitor/monitor/ipc_pipe.py
+++ b/monitor/monitor/ipc_pipe.py
@@ -5,6 +5,7 @@ import logging
 import pywintypes
 import os
 import time as _time
+import struct
 
 logger = logging.getLogger(__name__)
 import win32pipe
@@ -18,6 +19,7 @@ from typing import Callable
 
 
 MAX_PIPE_MESSAGE_BYTES = 16 * 1024 * 1024
+IPC_PROTOCOL_VERSION = 2
 
 
 def _is_authorized_client_pid(client_pid: int, expected_pid: int | None, curr_ppid: int) -> bool:
@@ -29,44 +31,50 @@ def _is_authorized_client_pid(client_pid: int, expected_pid: int | None, curr_pp
     return False
 
 
-def _read_complete_json_message(handle, chunk_size=1024 * 1024, max_bytes=MAX_PIPE_MESSAGE_BYTES):
-    """Read a complete JSON message from a named pipe handle.
+def _read_framed_json_message(handle, chunk_size=1024 * 1024, max_bytes=MAX_PIPE_MESSAGE_BYTES):
+    """Read a v2 length-prefixed JSON message."""
+    try:
+        resp_code, first = win32file.ReadFile(handle, 4)
+    except pywintypes.error as e:
+        if getattr(e, 'winerror', None) == 109:
+            return None
+        raise
 
-    Supports PIPE_TYPE_MESSAGE fragmentation via ERROR_MORE_DATA (234).
-    Returns decoded payload string, or None if no data was read.
-    """
-    chunks = []
-    total = 0
-
-    while True:
-        try:
-            resp_code, data = win32file.ReadFile(handle, chunk_size)
-        except pywintypes.error as e:
-            if getattr(e, 'winerror', None) == 109:  # ERROR_BROKEN_PIPE
-                break
-            raise
-
-        if data:
-            chunks.append(data)
-            total += len(data)
-            if total > max_bytes:
-                raise ValueError(f"Request too large (max {max_bytes} bytes)")
-
-        # 234 means there is still unread remainder for this message.
-        if resp_code == 234:
-            continue
-        if resp_code == 0:
-            break
-
-        raise RuntimeError(f"ReadFile returned unexpected status code: {resp_code}")
-
-    if not chunks:
+    if not first:
         return None
 
-    payload = b"".join(chunks).decode('utf-8').strip()
-    if not payload:
-        return None
-    return payload
+    if len(first) == 4:
+        frame_len = struct.unpack('<I', first)[0]
+        if 0 < frame_len <= max_bytes:
+            body = bytearray()
+            remaining = frame_len
+            while remaining:
+                resp_code, chunk = win32file.ReadFile(handle, min(chunk_size, remaining))
+                if chunk:
+                    body.extend(chunk)
+                    remaining -= len(chunk)
+                if resp_code not in (0, 234):
+                    raise RuntimeError(f"ReadFile returned unexpected status code: {resp_code}")
+                if not chunk:
+                    break
+            if len(body) != frame_len:
+                raise RuntimeError(f"Incomplete IPC frame: expected {frame_len}, got {len(body)}")
+            return bytes(body).decode('utf-8').strip()
+    padded = first.ljust(4, b'\0')
+    frame_len = struct.unpack('<I', padded)[0]
+    raise ValueError(f"Invalid IPC v{IPC_PROTOCOL_VERSION} frame length: {frame_len}")
+
+
+def _write_framed_json(handle, payload: bytes):
+    if len(payload) > MAX_PIPE_MESSAGE_BYTES:
+        raise ValueError(f"Response too large (max {MAX_PIPE_MESSAGE_BYTES} bytes)")
+    win32file.WriteFile(handle, struct.pack('<I', len(payload)))
+    offset = 0
+    while offset < len(payload):
+        _, written = win32file.WriteFile(handle, payload[offset:offset + 64 * 1024])
+        if not isinstance(written, int) or written <= 0:
+            raise RuntimeError("Named pipe write returned no progress")
+        offset += written
 
 
 def _make_security_attributes_for_current_user():
@@ -173,18 +181,18 @@ class _NamedPipeServer(threading.Thread):
             if not is_valid:
                 logger.warning(f"[SECURITY] Rejecting PID {client_pid}. (Expected: {expected_pid}, PPID: {curr_ppid})")
                 error_resp = json.dumps({"error": f"Access denied: PID {client_pid} is not authorized"}).encode('utf-8')
-                win32file.WriteFile(handle, error_resp)
+                _write_framed_json(handle, error_resp)
                 win32file.FlushFileBuffers(handle)
                 return
 
             logger.debug(f"IPC client verified: PID {client_pid}")
             # 2. Read Request
             try:
-                payload = _read_complete_json_message(handle)
+                payload = _read_framed_json_message(handle)
             except ValueError as e:
                 logger.error(str(e))
                 error_resp = json.dumps({"error": str(e)}).encode('utf-8')
-                win32file.WriteFile(handle, error_resp)
+                _write_framed_json(handle, error_resp)
                 win32file.FlushFileBuffers(handle)
                 return
             except pywintypes.error as e:
@@ -200,7 +208,7 @@ class _NamedPipeServer(threading.Thread):
             except json.JSONDecodeError:
                 logger.error(f"Invalid JSON: {payload[:100]}")
                 error_resp = json.dumps({"error": "Invalid JSON in request"}).encode('utf-8')
-                win32file.WriteFile(handle, error_resp)
+                _write_framed_json(handle, error_resp)
                 win32file.FlushFileBuffers(handle)
                 return
 
@@ -239,8 +247,18 @@ class _NamedPipeServer(threading.Thread):
 
             write_started = _time.perf_counter()
             resp_str = json.dumps(result, default=json_serial)
-            win32file.WriteFile(handle, resp_str.encode('utf-8'))
-            win32file.FlushFileBuffers(handle)
+            try:
+                _write_framed_json(handle, resp_str.encode('utf-8'))
+                win32file.FlushFileBuffers(handle)
+            except pywintypes.error as e:
+                if getattr(e, 'winerror', None) in (109, 232):
+                    logger.debug(
+                        "[DIAG:PIPE] client closed before response command=%s winerror=%s",
+                        command,
+                        e.winerror,
+                    )
+                    return
+                raise
             if is_process_ocr:
                 logger.debug(
                     '[DIAG:PIPE] response sent command=%s write=%.3fs total=%.3fs resp_bytes=%s',
@@ -280,8 +298,10 @@ def send_ipc_request(pipe_name, req):
             0, None
         )
         win32pipe.SetNamedPipeHandleState(handle, win32pipe.PIPE_READMODE_MESSAGE, None, None)
-        win32file.WriteFile(handle, json.dumps(req).encode('utf-8'))
-        payload = _read_complete_json_message(handle)
+        framed_req = dict(req)
+        framed_req['ipc_protocol_version'] = IPC_PROTOCOL_VERSION
+        _write_framed_json(handle, json.dumps(framed_req).encode('utf-8'))
+        payload = _read_framed_json_message(handle)
         return json.loads(payload) if payload else {}
     finally:
         try:

--- a/monitor/monitor/worker_process.py
+++ b/monitor/monitor/worker_process.py
@@ -1,0 +1,406 @@
+"""Restartable worker process for OCR, embedding, and classification.
+
+The parent monitor process keeps the named-pipe server responsive. Expensive
+model calls run here so a stuck OCR/embedding/classifier call can be terminated
+by killing this process and starting a fresh one for the next request.
+"""
+
+from __future__ import annotations
+
+import datetime
+import io
+import logging
+import multiprocessing
+import os
+import time
+import traceback
+from typing import Any, Dict, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+def _json_safe(obj):
+    if isinstance(obj, (datetime.datetime, datetime.date)):
+        return obj.isoformat()
+    return obj
+
+
+def _process_ocr(req: Dict[str, Any], ocr_worker, classifier) -> Dict[str, Any]:
+    from PIL import Image
+    from storage_client import get_storage_client
+    from . import config
+
+    screenshot_id = req.get("screenshot_id")
+    if screenshot_id is None:
+        return {"error": "screenshot_id is required"}
+
+    cmd_started = time.perf_counter()
+    sc = get_storage_client()
+    if not sc:
+        return {"error": "Storage client not available"}
+
+    resp = sc.get_temp_image_bytes(screenshot_id)
+    if resp.get("status") != "success":
+        return {"error": f"Failed to fetch image: {resp.get('error', 'unknown')}"}
+
+    image_bytes = resp.get("data", {}).get("image_bytes")
+    if not image_bytes:
+        return {"error": "No image data returned from storage"}
+
+    image_pil = Image.open(io.BytesIO(image_bytes))
+    image_pil.load()
+
+    ocr_results = ocr_worker.ocr_engine.recognize(image_pil)
+    filtered = [r for r in ocr_results if r.get("confidence", 0) >= 0.5]
+    ocr_worker.stats["processed_count"] += 1
+    ocr_worker.stats["total_texts_found"] += len(filtered)
+
+    image_hash = req.get("image_hash", "")
+    ocr_text = " ".join([r.get("text", "") for r in filtered])
+    if ocr_worker.enable_vector_store and ocr_worker.vector_store and ocr_text.strip():
+        try:
+            ocr_worker.vector_store.add_image(
+                image_path=f"memory://{image_hash}",
+                image=image_pil,
+                metadata={
+                    "window_title": req.get("window_title", ""),
+                    "process_name": req.get("process_name", ""),
+                    "timestamp": req.get("timestamp", 0),
+                },
+                ocr_text=ocr_text,
+            )
+        except Exception as exc:
+            logger.warning("Vector store add failed: %s", exc)
+
+    category = None
+    category_confidence = None
+    if classifier and config.CLASSIFICATION_ENABLED:
+        try:
+            category, category_confidence = classifier.classify(
+                title=req.get("window_title", ""),
+                ocr_text=ocr_text,
+                process_name=req.get("process_name", ""),
+            )
+            category_confidence = round(category_confidence, 4)
+        except Exception as exc:
+            logger.warning("Classification failed: %s", exc)
+
+    result = {
+        "status": "success",
+        "ocr_results": filtered,
+        "ocr_text": ocr_text,
+        "elapsed": time.perf_counter() - cmd_started,
+    }
+    if category:
+        result["category"] = category
+        result["category_confidence"] = category_confidence
+    return result
+
+
+def _worker_main(conn, storage_pipe: Optional[str], data_dir: str, env: Dict[str, str]):
+    os.environ.update(env or {})
+    if data_dir:
+        os.environ["CARBONPAPER_DATA_DIR"] = data_dir
+
+    try:
+        from logging_config import setup_logging
+        setup_logging()
+    except Exception:
+        pass
+
+    try:
+        from storage_client import init_storage_client
+        from ocr_service import OCRService
+        from classifier import ClassificationService
+        from .config import update_feature_config
+
+        update_feature_config(
+            os.environ.get("CARBONPAPER_CLUSTERING_ENABLED", "true").lower() in ("1", "true", "yes", "on"),
+            os.environ.get("CARBONPAPER_CLASSIFICATION_ENABLED", "true").lower() in ("1", "true", "yes", "on"),
+        )
+
+        if storage_pipe:
+            init_storage_client(storage_pipe)
+
+        try:
+            import chromadb
+            from chromadb.config import Settings as ChromaSettings
+            shared_chroma_client = chromadb.PersistentClient(
+                path=os.path.join(data_dir, "chroma_db"),
+                settings=ChromaSettings(anonymized_telemetry=False),
+            )
+        except Exception as exc:
+            logger.error("Worker ChromaDB init failed: %s", exc)
+            shared_chroma_client = None
+
+        ocr_worker = OCRService(
+            vector_db_path=os.path.join(data_dir, "chroma_db"),
+            storage_pipe=storage_pipe,
+            chroma_client=shared_chroma_client,
+        )
+        ocr_worker.start()
+
+        try:
+            classifier = ClassificationService(anchors_path=os.path.join(data_dir, "anchors.json"))
+        except Exception as exc:
+            logger.warning("Worker classifier init failed: %s", exc)
+            classifier = None
+
+        conn.send({"status": "ready"})
+    except Exception as exc:
+        conn.send({"status": "error", "error": str(exc), "traceback": traceback.format_exc()})
+        return
+
+    while True:
+        try:
+            msg = conn.recv()
+        except EOFError:
+            return
+        command = msg.get("command")
+        try:
+            if command == "stop":
+                conn.send({"status": "success"})
+                return
+            if command == "process_ocr":
+                conn.send(_process_ocr(msg.get("request", {}), ocr_worker, classifier))
+            elif command == "get_stats":
+                conn.send({"status": "success", "stats": ocr_worker.get_stats()})
+            elif command == "search_by_natural_language":
+                args = msg.get("args", {})
+                conn.send({
+                    "status": "success",
+                    "results": ocr_worker.search_by_natural_language(**args),
+                })
+            elif command == "delete_vector_image":
+                image_hash = msg.get("image_hash", "")
+                ok = False
+                if ocr_worker.vector_store:
+                    ok = bool(ocr_worker.vector_store.delete_image(f"memory://{image_hash}"))
+                conn.send({"status": "success", "ok": ok})
+            elif command == "classify":
+                if not classifier:
+                    conn.send({"error": "Classification service not initialised"})
+                else:
+                    args = msg.get("args", {})
+                    category, confidence = classifier.classify(**args)
+                    conn.send({"status": "success", "category": category, "confidence": confidence})
+            elif command == "classify_debug":
+                if not classifier:
+                    conn.send({"error": "Classification service not initialised"})
+                else:
+                    conn.send({"status": "success", "data": classifier.classify_debug(**msg.get("args", {}))})
+            elif command == "add_anchor":
+                if not classifier:
+                    conn.send({"error": "Classification service not initialised"})
+                else:
+                    conn.send({"status": "success", "data": classifier.add_anchor(**msg.get("args", {}))})
+            elif command == "remove_anchor":
+                if not classifier:
+                    conn.send({"error": "Classification service not initialised"})
+                else:
+                    removed = classifier.remove_anchor(msg.get("category", ""), msg.get("title", ""))
+                    conn.send({"status": "success", "removed": removed})
+            elif command == "remove_local_anchors_by_process":
+                if not classifier:
+                    conn.send({"error": "Classification service not initialised"})
+                else:
+                    removed_count = classifier.remove_local_anchors_by_process(
+                        msg.get("category", ""),
+                        msg.get("process_name", ""),
+                    )
+                    conn.send({"status": "success", "removed_count": removed_count})
+            elif command == "get_categories":
+                if not classifier:
+                    conn.send({"error": "Classification service not initialised"})
+                else:
+                    conn.send({"status": "success", "categories": classifier.get_categories()})
+            elif command == "get_anchors":
+                if not classifier:
+                    conn.send({"error": "Classification service not initialised"})
+                else:
+                    conn.send({"status": "success", "anchors": classifier.get_anchors()})
+            else:
+                conn.send({"error": f"Unknown worker command: {command}"})
+        except Exception as exc:
+            conn.send({"error": str(exc), "traceback": traceback.format_exc()})
+
+
+class RestartableModelWorker:
+    def __init__(self, storage_pipe: Optional[str], data_dir: str, env: Optional[Dict[str, str]] = None):
+        self.storage_pipe = storage_pipe
+        self.data_dir = data_dir
+        self.env = env or {}
+        self._ctx = multiprocessing.get_context("spawn")
+        self._conn = None
+        self._proc = None
+        self._lock = multiprocessing.RLock()
+        self._stats = {"processed_count": 0, "failed_count": 0, "total_texts_found": 0, "start_time": None}
+        self.stats = self._stats
+        self.enable_vector_store = True
+        self.vector_store = None
+
+    def start(self, timeout: float = 180.0):
+        with self._lock:
+            if self._proc is not None and self._proc.is_alive():
+                return
+            parent_conn, child_conn = self._ctx.Pipe()
+            proc = self._ctx.Process(
+                target=_worker_main,
+                args=(child_conn, self.storage_pipe, self.data_dir, self.env),
+                name="CarbonModelWorker",
+                daemon=True,
+            )
+            proc.start()
+            self._conn = parent_conn
+            self._proc = proc
+            if not parent_conn.poll(timeout):
+                self.restart()
+                raise TimeoutError(f"Model worker cold start timed out after {timeout}s")
+            ready = parent_conn.recv()
+            if ready.get("status") != "ready":
+                self.restart()
+                raise RuntimeError(ready.get("error", "Model worker failed to start"))
+
+    def request(self, command: str, payload: Optional[Dict[str, Any]] = None, timeout: float = 120.0):
+        with self._lock:
+            self.start(timeout=max(30.0, min(180.0, timeout)))
+            assert self._conn is not None
+            self._conn.send({"command": command, **(payload or {})})
+            if not self._conn.poll(timeout):
+                self.restart()
+                self._stats["failed_count"] += 1
+                raise TimeoutError(f"Model worker command {command} timed out after {timeout}s")
+            result = self._conn.recv()
+            if command == "process_ocr" and result.get("status") == "success":
+                self._stats["processed_count"] += 1
+                self._stats["total_texts_found"] += len(result.get("ocr_results") or [])
+            elif result.get("error"):
+                self._stats["failed_count"] += 1
+            return result
+
+    def restart(self):
+        with self._lock:
+            if self._proc is not None and self._proc.is_alive():
+                self._proc.terminate()
+                self._proc.join(timeout=5)
+                if self._proc.is_alive():
+                    self._proc.kill()
+            self._proc = None
+            self._conn = None
+
+    def stop(self):
+        with self._lock:
+            try:
+                if self._conn and self._proc and self._proc.is_alive():
+                    self._conn.send({"command": "stop"})
+                    self._conn.poll(2)
+            except Exception:
+                pass
+            self.restart()
+
+    def get_stats(self):
+        # Status polling must never start the model worker. Cold-starting OCR,
+        # vector, or classifier models from a cheap health check blocks the
+        # monitor pipe long enough for Rust-side status callers to time out.
+        if self._proc is None or not self._proc.is_alive() or self._conn is None:
+            return dict(self._stats)
+        if not self._lock.acquire(block=False):
+            return dict(self._stats)
+        try:
+            self._conn.send({"command": "get_stats"})
+            if self._conn.poll(0.05):
+                result = self._conn.recv()
+                if result.get("status") == "success":
+                    return result.get("stats", self._stats)
+        except Exception:
+            return dict(self._stats)
+        finally:
+            self._lock.release()
+        return dict(self._stats)
+
+    def pause(self):
+        logger.info("Model worker proxy paused")
+
+    def resume(self):
+        logger.info("Model worker proxy resumed")
+
+    def search_by_natural_language(self, **kwargs):
+        result = self.request(
+            "search_by_natural_language",
+            {"args": kwargs},
+            timeout=max(30.0, float(os.environ.get("CARBONPAPER_OCR_TIMEOUT_SECS", "120") or "120")),
+        )
+        if result.get("status") == "success":
+            return result.get("results", [])
+        raise RuntimeError(result.get("error", "Model worker search failed"))
+
+    def delete_vector_image(self, image_hash: str) -> bool:
+        result = self.request("delete_vector_image", {"image_hash": image_hash}, timeout=30)
+        return bool(result.get("ok"))
+
+    def classify(self, title: str, ocr_text: str, process_name: str = ""):
+        result = self.request(
+            "classify",
+            {"args": {"title": title, "ocr_text": ocr_text, "process_name": process_name}},
+            timeout=30,
+        )
+        if result.get("status") == "success":
+            return result.get("category"), result.get("confidence")
+        raise RuntimeError(result.get("error", "Model worker classify failed"))
+
+    def classify_debug(self, title: str, ocr_text: str, process_name: str = ""):
+        result = self.request(
+            "classify_debug",
+            {"args": {"title": title, "ocr_text": ocr_text, "process_name": process_name}},
+            timeout=30,
+        )
+        if result.get("status") == "success":
+            return result.get("data", {})
+        raise RuntimeError(result.get("error", "Model worker classify_debug failed"))
+
+    def add_anchor(self, category: str, title: str, ocr_text: str = "", old_category=None, process_name: str = ""):
+        result = self.request(
+            "add_anchor",
+            {
+                "args": {
+                    "category": category,
+                    "title": title,
+                    "ocr_text": ocr_text,
+                    "old_category": old_category,
+                    "process_name": process_name,
+                }
+            },
+            timeout=30,
+        )
+        if result.get("status") == "success":
+            return result.get("data", {})
+        raise RuntimeError(result.get("error", "Model worker add_anchor failed"))
+
+    def remove_anchor(self, category: str, title: str):
+        result = self.request("remove_anchor", {"category": category, "title": title}, timeout=30)
+        if result.get("status") == "success":
+            return result.get("removed", False)
+        raise RuntimeError(result.get("error", "Model worker remove_anchor failed"))
+
+    def remove_local_anchors_by_process(self, category: str, process_name: str):
+        result = self.request(
+            "remove_local_anchors_by_process",
+            {"category": category, "process_name": process_name},
+            timeout=30,
+        )
+        if result.get("status") == "success":
+            return result.get("removed_count", 0)
+        raise RuntimeError(result.get("error", "Model worker remove_local_anchors_by_process failed"))
+
+    def get_categories(self):
+        result = self.request("get_categories", timeout=30)
+        if result.get("status") == "success":
+            return result.get("categories", [])
+        raise RuntimeError(result.get("error", "Model worker get_categories failed"))
+
+    def get_anchors(self):
+        result = self.request("get_anchors", timeout=30)
+        if result.get("status") == "success":
+            return result.get("anchors", {})
+        raise RuntimeError(result.get("error", "Model worker get_anchors failed"))

--- a/monitor/storage_client.py
+++ b/monitor/storage_client.py
@@ -5,6 +5,7 @@ import json
 import time
 import logging
 import threading
+import struct
 from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
@@ -12,6 +13,84 @@ import win32file
 import win32pipe
 import pywintypes
 from typing import Optional, Dict, Any, List
+
+
+IPC_PROTOCOL_VERSION = 2
+MAX_PIPE_MESSAGE_BYTES = 16 * 1024 * 1024
+MAX_PIPE_BINARY_BYTES = 64 * 1024 * 1024
+
+
+def _write_framed_json(handle, payload: bytes) -> None:
+    if len(payload) > MAX_PIPE_MESSAGE_BYTES:
+        raise ValueError(f"Request too large (max {MAX_PIPE_MESSAGE_BYTES} bytes)")
+    win32file.WriteFile(handle, struct.pack('<I', len(payload)))
+    offset = 0
+    chunk_size = 64 * 1024
+    while offset < len(payload):
+        chunk = payload[offset:offset + chunk_size]
+        _, written = win32file.WriteFile(handle, chunk)
+        if not isinstance(written, int) or written <= 0:
+            raise RuntimeError("Named pipe write returned no progress")
+        offset += written
+
+
+def _read_exact_frame(handle, max_bytes: int) -> bytes:
+    _, prefix = win32file.ReadFile(handle, 4)
+    if len(prefix) != 4:
+        raise RuntimeError(f"Incomplete frame prefix: {len(prefix)} bytes")
+    frame_len = struct.unpack('<I', prefix)[0]
+    if frame_len > max_bytes:
+        raise RuntimeError(f"Frame too large: {frame_len} bytes (max {max_bytes})")
+    chunks = []
+    remaining = frame_len
+    while remaining:
+        _, chunk = win32file.ReadFile(handle, min(64 * 1024, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    body = b''.join(chunks)
+    if len(body) != frame_len:
+        raise RuntimeError(f"Incomplete frame: expected {frame_len}, got {len(body)}")
+    return body
+
+
+def _read_framed_json(handle) -> Dict[str, Any]:
+    try:
+        _, first = win32file.ReadFile(handle, 4)
+    except pywintypes.error as e:
+        if e.winerror == 109:
+            return {'status': 'error', 'error': 'Empty response'}
+        raise
+    if not first:
+        return {'status': 'error', 'error': 'Empty response'}
+
+    if len(first) == 4:
+        frame_len = struct.unpack('<I', first)[0]
+        if 0 < frame_len <= MAX_PIPE_MESSAGE_BYTES:
+            chunks = []
+            remaining = frame_len
+            while remaining:
+                _, chunk = win32file.ReadFile(handle, min(64 * 1024, remaining))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            response_bytes = b''.join(chunks)
+            if len(response_bytes) != frame_len:
+                return {'status': 'error', 'error': f'Incomplete response frame: expected {frame_len}, got {len(response_bytes)}'}
+            response = json.loads(response_bytes.decode('utf-8'))
+            if response.get('status') == 'success' and response.get('data', {}).get('binary_frame'):
+                try:
+                    response['_binary_body'] = _read_exact_frame(handle, MAX_PIPE_BINARY_BYTES)
+                except Exception as e:
+                    return {'status': 'error', 'error': f'Binary response read failed: {e}'}
+            return response
+
+    return {
+        'status': 'error',
+        'error': f'Invalid IPC v{IPC_PROTOCOL_VERSION} frame length: {struct.unpack("<I", first)[0]}',
+    }
 
 
 class StorageClient:
@@ -94,23 +173,9 @@ class StorageClient:
                     None
                 )
                 
-                # Send request (write large data in chunks).
-                # Named pipes can report partial writes; always advance by actual bytes written.
+                # Send request using v2 length-prefixed framing.
                 request_bytes = json.dumps(request).encode('utf-8')
-                chunk_size = 64 * 1024  # 64KB chunks
-                offset = 0
-
-                while offset < len(request_bytes):
-                    chunk = request_bytes[offset:offset + chunk_size]
-                    chunk_offset = 0
-
-                    while chunk_offset < len(chunk):
-                        _, written = win32file.WriteFile(handle, chunk[chunk_offset:])
-                        if not isinstance(written, int) or written <= 0:
-                            raise RuntimeError("Named pipe write returned no progress")
-                        chunk_offset += written
-
-                    offset += chunk_offset
+                _write_framed_json(handle, request_bytes)
                 
                 # Flush pipe to ensure all data has been sent.
                 # In request/response mode the server may close quickly after handling
@@ -125,32 +190,7 @@ class StorageClient:
                         e.winerror,
                     )
                 
-                # Read response (supports chunked reads for large responses)
-                response_bytes = b''
-                while True:
-                    try:
-                        _, chunk = win32file.ReadFile(handle, 64 * 1024)
-                        if not chunk:
-                            break
-                        response_bytes += chunk
-                        # Try to parse; if successful, the response is complete
-                        try:
-                            response = json.loads(response_bytes.decode('utf-8'))
-                            return response
-                        except (json.JSONDecodeError, UnicodeDecodeError):
-                            # Incomplete response or mid-character split — continue reading
-                            continue
-                    except pywintypes.error as e:
-                        # Pipe ended (109) or other error
-                        if e.winerror == 109:
-                            break
-                        raise
-                
-                if response_bytes:
-                    response = json.loads(response_bytes.decode('utf-8'))
-                    return response
-                else:
-                    return {'status': 'error', 'error': 'Empty response'}
+                return _read_framed_json(handle)
                     
             finally:
                 win32file.CloseHandle(handle)
@@ -418,6 +458,28 @@ class StorageClient:
             data = response.get('data', {})
             return bool(data.get('session_valid', False))
         return False
+
+    def get_temp_image_bytes(self, screenshot_id: int) -> Dict[str, Any]:
+        """Fetch temporary OCR image bytes using v2 binary response framing."""
+        response = self._send_request({
+            'command': 'get_temp_image',
+            'screenshot_id': int(screenshot_id),
+        })
+        if response.get('status') != 'success':
+            return response
+
+        data = response.get('data', {})
+        image_bytes = response.get('_binary_body')
+        if image_bytes is None:
+            return {'status': 'error', 'error': 'Binary image response missing body frame'}
+
+        return {
+            'status': 'success',
+            'data': {
+                'image_bytes': image_bytes,
+                'mime_type': data.get('mime_type', 'image/jpeg'),
+            },
+        }
 
     def screenshot_exists(self, image_hash: str) -> bool:
         """

--- a/monitor/tests/test_ipc_pipe_auth_guard.py
+++ b/monitor/tests/test_ipc_pipe_auth_guard.py
@@ -1,4 +1,5 @@
 import monitor.ipc_pipe as ipc_pipe
+import struct
 
 
 def test_authorized_when_matches_expected_pid():
@@ -33,12 +34,13 @@ def test_client_handler_allows_authorized_pid_and_executes_handler(monkeypatch):
     monkeypatch.setattr(ipc_pipe.os, "getppid", lambda: 1111)
     monkeypatch.setattr(
         ipc_pipe,
-        "_read_complete_json_message",
+        "_read_framed_json_message",
         lambda _h: '{"command":"status","_auth_token":"t","_seq_no":1}',
     )
 
     def fake_write(_h, data):
         state["writes"].append(data)
+        return 0, len(data)
 
     monkeypatch.setattr(ipc_pipe.win32file, "WriteFile", fake_write)
     monkeypatch.setattr(ipc_pipe.win32file, "FlushFileBuffers", lambda _h: None)
@@ -54,9 +56,8 @@ def test_client_handler_allows_authorized_pid_and_executes_handler(monkeypatch):
     assert state["request"] == {"command": "status", "_auth_token": "t", "_seq_no": 1}
     assert state["closed"] is True
 
-    decoded_writes = [
-        chunk.decode("utf-8") if isinstance(chunk, (bytes, bytearray)) else str(chunk)
-        for chunk in state["writes"]
-    ]
-    assert any('"ok": true' in item for item in decoded_writes)
-    assert all("Access denied" not in item for item in decoded_writes)
+    wire = b"".join(state["writes"])
+    frame_len = struct.unpack("<I", wire[:4])[0]
+    decoded = wire[4:4 + frame_len].decode("utf-8")
+    assert '"ok": true' in decoded
+    assert "Access denied" not in decoded

--- a/monitor/tests/test_ipc_pipe_request_integrity.py
+++ b/monitor/tests/test_ipc_pipe_request_integrity.py
@@ -1,5 +1,7 @@
-import pytest
 import json
+import struct
+
+import pytest
 
 import monitor.ipc_pipe as ipc_pipe
 
@@ -10,12 +12,9 @@ class FakePyWinError(Exception):
         self.winerror = winerror
 
 
-def test_read_complete_json_message_handles_more_data(monkeypatch):
-    utf8_tail = bytes([0xE4, 0xB8, 0xAD, 0xE6, 0x96, 0x87, 0x22, 0x7D])
-    chunks = [
-        (234, b'{"command":"search_nl","query":"'),
-        (0, utf8_tail),
-    ]
+def test_read_framed_json_message_handles_chunked_body(monkeypatch):
+    body = json.dumps({"command": "search_nl", "query": "中文"}, ensure_ascii=False).encode("utf-8")
+    chunks = [(0, struct.pack("<I", len(body))), (234, body[:3]), (0, body[3:])]
 
     def fake_read(_handle, _size):
         if not chunks:
@@ -25,47 +24,47 @@ def test_read_complete_json_message_handles_more_data(monkeypatch):
     monkeypatch.setattr(ipc_pipe.pywintypes, "error", FakePyWinError)
     monkeypatch.setattr(ipc_pipe.win32file, "ReadFile", fake_read)
 
-    payload = ipc_pipe._read_complete_json_message(object(), chunk_size=16)
+    payload = ipc_pipe._read_framed_json_message(object(), chunk_size=3)
 
     parsed = json.loads(payload)
     assert parsed["command"] == "search_nl"
     assert parsed["query"] == "\u4e2d\u6587"
 
 
-def test_read_complete_json_message_rejects_oversize(monkeypatch):
+def test_read_framed_json_message_rejects_oversize(monkeypatch):
     def fake_read(_handle, _size):
-        return 0, b"123456"
+        return 0, struct.pack("<I", 6)
 
     monkeypatch.setattr(ipc_pipe.pywintypes, "error", FakePyWinError)
     monkeypatch.setattr(ipc_pipe.win32file, "ReadFile", fake_read)
 
-    with pytest.raises(ValueError, match="Request too large"):
-        ipc_pipe._read_complete_json_message(object(), max_bytes=5)
+    with pytest.raises(ValueError, match="Invalid IPC v2 frame length"):
+        ipc_pipe._read_framed_json_message(object(), max_bytes=5)
 
 
-def test_read_complete_json_message_handles_broken_pipe_after_data(monkeypatch):
-    state = {"called": 0}
+def test_read_framed_json_message_rejects_incomplete_body(monkeypatch):
+    chunks = [(0, struct.pack("<I", 10)), (0, b"abc")]
 
     def fake_read(_handle, _size):
-        state["called"] += 1
-        if state["called"] == 1:
-            return 234, b'{"command":"status"'
-        raise FakePyWinError(109, "broken pipe")
+        if not chunks:
+            return 0, b""
+        return chunks.pop(0)
 
     monkeypatch.setattr(ipc_pipe.pywintypes, "error", FakePyWinError)
     monkeypatch.setattr(ipc_pipe.win32file, "ReadFile", fake_read)
 
-    payload = ipc_pipe._read_complete_json_message(object())
+    with pytest.raises(RuntimeError, match="Incomplete IPC frame"):
+        ipc_pipe._read_framed_json_message(object())
 
-    assert payload == '{"command":"status"'
 
+def test_read_framed_json_message_unexpected_status_code(monkeypatch):
+    chunks = [(0, struct.pack("<I", 4)), (5, b"data")]
 
-def test_read_complete_json_message_unexpected_status_code(monkeypatch):
     def fake_read(_handle, _size):
-        return 5, b"data"
+        return chunks.pop(0)
 
     monkeypatch.setattr(ipc_pipe.pywintypes, "error", FakePyWinError)
     monkeypatch.setattr(ipc_pipe.win32file, "ReadFile", fake_read)
 
     with pytest.raises(RuntimeError, match="unexpected status code"):
-        ipc_pipe._read_complete_json_message(object())
+        ipc_pipe._read_framed_json_message(object())

--- a/monitor/tests/test_storage_client_error_paths.py
+++ b/monitor/tests/test_storage_client_error_paths.py
@@ -1,4 +1,5 @@
 import storage_client as sc
+import struct
 
 
 class FakePyWinError(Exception):
@@ -17,6 +18,20 @@ def _install_win32(monkeypatch, *, create_file, write_file, read_file, flush_fil
     monkeypatch.setattr(sc.win32pipe, "SetNamedPipeHandleState", lambda *_a, **_k: None)
     if sleep_hook is not None:
         monkeypatch.setattr(sc.time, "sleep", sleep_hook)
+
+
+def _framed_reader(payload: bytes):
+    stream = bytearray(struct.pack("<I", len(payload)) + payload)
+
+    def read_file(_h, size):
+        if not stream:
+            return 0, b""
+        n = min(size, len(stream))
+        chunk = bytes(stream[:n])
+        del stream[:n]
+        return 0, chunk
+
+    return read_file
 
 
 def test_send_request_returns_ipc_error_when_connect_fails(monkeypatch):
@@ -54,7 +69,7 @@ def test_send_request_retries_on_pipe_busy(monkeypatch):
         monkeypatch,
         create_file=create_file,
         write_file=lambda _h, payload: (0, len(payload)),
-        read_file=lambda _h, _s: (0, response),
+        read_file=_framed_reader(response),
         flush_file=lambda _h: None,
         sleep_hook=lambda sec: sleeps.append(sec),
     )

--- a/monitor/tests/test_storage_client_ipc.py
+++ b/monitor/tests/test_storage_client_ipc.py
@@ -1,4 +1,5 @@
 import json
+import struct
 
 import storage_client as sc
 
@@ -9,6 +10,10 @@ class FakePyWinError(Exception):
         self.winerror = winerror
 
 
+def frame(payload: bytes) -> bytes:
+    return struct.pack("<I", len(payload)) + payload
+
+
 def install_pipe_mocks(monkeypatch, read_chunks, flush_error=None):
     state = {
         "write_calls": 0,
@@ -17,7 +22,7 @@ def install_pipe_mocks(monkeypatch, read_chunks, flush_error=None):
         "read_calls": 0,
         "set_mode_calls": 0,
     }
-    chunk_iter = iter(read_chunks)
+    stream = bytearray(b"".join(read_chunks))
 
     def fake_create_file(*_args, **_kwargs):
         return object()
@@ -37,12 +42,11 @@ def install_pipe_mocks(monkeypatch, read_chunks, flush_error=None):
 
     def fake_read_file(_handle, _size):
         state["read_calls"] += 1
-        try:
-            chunk = next(chunk_iter)
-        except StopIteration:
+        if not stream:
             return 0, b""
-        if isinstance(chunk, Exception):
-            raise chunk
+        n = min(_size, len(stream))
+        chunk = bytes(stream[:n])
+        del stream[:n]
         return 0, chunk
 
     def fake_close_handle(_handle):
@@ -61,7 +65,7 @@ def install_pipe_mocks(monkeypatch, read_chunks, flush_error=None):
 
 def test_send_request_handles_utf8_split_and_partial_write(monkeypatch):
     response_obj = {"status": "success", "data": {"value": "中文"}}
-    response_bytes = json.dumps(response_obj, ensure_ascii=False).encode("utf-8")
+    response_bytes = frame(json.dumps(response_obj, ensure_ascii=False).encode("utf-8"))
     split_at = response_bytes.index("中文".encode("utf-8")) + 1
 
     benign_flush_error = FakePyWinError(109, "broken pipe after response")
@@ -73,7 +77,7 @@ def test_send_request_handles_utf8_split_and_partial_write(monkeypatch):
 
     client = sc.StorageClient("test-pipe")
     request = {"command": "probe", "payload": "x" * (70 * 1024)}
-    expected_request_len = len(json.dumps(request).encode("utf-8"))
+    expected_request_len = 4 + len(json.dumps(request).encode("utf-8"))
 
     result = client._send_request(request)
 
@@ -162,3 +166,49 @@ def test_list_screenshots_for_clustering_uses_expected_payload(monkeypatch):
         "limit": 9,
     }
     assert result["status"] == "success"
+
+
+def test_get_temp_image_bytes_reads_binary_frame(monkeypatch):
+    metadata = {
+        "status": "success",
+        "data": {
+            "mime_type": "image/jpeg",
+            "binary_frame": True,
+            "binary_body_len": 4,
+        },
+    }
+    metadata_bytes = json.dumps(metadata).encode("utf-8")
+    image_bytes = b"\xff\xd8\xff\xd9"
+    stream = bytearray(
+        struct.pack("<I", len(metadata_bytes))
+        + metadata_bytes
+        + struct.pack("<I", len(image_bytes))
+        + image_bytes
+    )
+
+    monkeypatch.setattr(sc.pywintypes, "error", FakePyWinError)
+    monkeypatch.setattr(sc.win32file, "CreateFile", lambda *_a, **_k: object())
+    monkeypatch.setattr(sc.win32pipe, "SetNamedPipeHandleState", lambda *_a, **_k: None)
+    monkeypatch.setattr(sc.win32file, "WriteFile", lambda _h, payload: (0, len(payload)))
+    monkeypatch.setattr(sc.win32file, "FlushFileBuffers", lambda _h: None)
+    monkeypatch.setattr(sc.win32file, "CloseHandle", lambda _h: None)
+
+    def fake_read_file(_handle, size):
+        if not stream:
+            return 0, b""
+        n = min(size, len(stream))
+        chunk = bytes(stream[:n])
+        del stream[:n]
+        return 0, chunk
+
+    monkeypatch.setattr(sc.win32file, "ReadFile", fake_read_file)
+
+    result = sc.StorageClient("test-pipe").get_temp_image_bytes(123)
+
+    assert result == {
+        "status": "success",
+        "data": {
+            "image_bytes": image_bytes,
+            "mime_type": "image/jpeg",
+        },
+    }

--- a/src-tauri/src/bin/nmh.rs
+++ b/src-tauri/src/bin/nmh.rs
@@ -9,13 +9,16 @@
 //!
 //! Protocol:
 //!   - stdin/stdout: Chrome NM protocol (4-byte LE length prefix + JSON)
-//!   - Named Pipe (data): connects to CarbonPaper's NMH pipe (deterministic name from user SID)
+//!   - Named Pipe (data): v2 frame (4-byte LE length prefix + JSON)
 //!   - Named Pipe (cmd):  CarbonPaper connects here to request captures
 
 use sha2::{Digest, Sha256};
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+
+const IPC_PROTOCOL_VERSION: u32 = 2;
+const IPC_MAX_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
 
 fn main() {
     // Compute deterministic pipe name
@@ -174,6 +177,7 @@ fn handle_message(msg: serde_json::Value, pipe_name: &str, auth_token: &str) -> 
 
             let pipe_request = serde_json::json!({
                 "command": "save_extension_screenshot",
+                "ipc_protocol_version": IPC_PROTOCOL_VERSION,
                 "auth_token": auth_token,
                 "image_data": image_data,
                 "image_hash": image_hash,
@@ -195,6 +199,42 @@ fn handle_message(msg: serde_json::Value, pipe_name: &str, auth_token: &str) -> 
             serde_json::json!({"status": "error", "error": format!("Unknown message type: {}", msg_type)})
         }
     }
+}
+
+fn write_pipe_frame<W: Write>(writer: &mut W, body: &[u8]) -> io::Result<()> {
+    if body.len() > IPC_MAX_MESSAGE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "IPC request too large: {} bytes (max {})",
+                body.len(),
+                IPC_MAX_MESSAGE_BYTES
+            ),
+        ));
+    }
+
+    writer.write_all(&(body.len() as u32).to_le_bytes())?;
+    writer.write_all(body)
+}
+
+fn read_pipe_frame<R: Read>(reader: &mut R) -> io::Result<Vec<u8>> {
+    let mut len_buf = [0u8; 4];
+    reader.read_exact(&mut len_buf)?;
+
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len == 0 || len > IPC_MAX_MESSAGE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Invalid IPC v{} frame length: {} (max {})",
+                IPC_PROTOCOL_VERSION, len, IPC_MAX_MESSAGE_BYTES
+            ),
+        ));
+    }
+
+    let mut body = vec![0u8; len];
+    reader.read_exact(&mut body)?;
+    Ok(body)
 }
 
 /// Send a JSON request to the Named Pipe and read the response
@@ -219,32 +259,21 @@ fn send_to_pipe(pipe_name: &str, request: &serde_json::Value) -> serde_json::Val
         }
     };
 
-    // Write request
-    if let Err(e) = pipe.write_all(&data) {
+    // Write v2 framed request.
+    if let Err(e) = write_pipe_frame(&mut pipe, &data) {
         return serde_json::json!({"status": "error", "error": format!("Pipe write failed: {}", e)});
     }
 
-    // Shutdown write side so server knows we're done sending
-    // On Windows named pipes, we need to flush and then read
     if let Err(e) = pipe.flush() {
         return serde_json::json!({"status": "error", "error": format!("Pipe flush failed: {}", e)});
     }
 
-    // Read response with timeout
-    let mut response_buf = Vec::new();
-    match pipe.read_to_end(&mut response_buf) {
-        Ok(_) => {}
+    let response_buf = match read_pipe_frame(&mut pipe) {
+        Ok(buf) => buf,
         Err(e) => {
-            // Broken pipe is OK if we already got data
-            if response_buf.is_empty() {
-                return serde_json::json!({"status": "error", "error": format!("Pipe read failed: {}", e)});
-            }
+            return serde_json::json!({"status": "error", "error": format!("Pipe read failed: {}", e)})
         }
-    }
-
-    if response_buf.is_empty() {
-        return serde_json::json!({"status": "error", "error": "Empty response from CarbonPaper"});
-    }
+    };
 
     match serde_json::from_slice(&response_buf) {
         Ok(v) => v,

--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -166,6 +166,9 @@ pub struct CaptureState {
     pub in_flight_ocr_count: AtomicU32,
     pub capture_on_ocr_busy: AtomicBool,
     pub ocr_queue_max_size: AtomicU32,
+    pub ocr_timeout_secs: AtomicU32,
+    pub ocr_cold_start_pending: AtomicBool,
+    pub startup_pending_cleanup_cancelled: AtomicBool,
     pub capture_task: Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
     pub ocr_image_cache: OcrImageCache,
     pub wgc_state: Mutex<Option<WgcCaptureSession>>,
@@ -190,6 +193,9 @@ impl CaptureState {
             in_flight_ocr_count: AtomicU32::new(0),
             capture_on_ocr_busy: AtomicBool::new(false),
             ocr_queue_max_size: AtomicU32::new(1),
+            ocr_timeout_secs: AtomicU32::new(120),
+            ocr_cold_start_pending: AtomicBool::new(true),
+            startup_pending_cleanup_cancelled: AtomicBool::new(false),
             capture_task: Mutex::new(None),
             ocr_image_cache: Arc::new(Mutex::new(HashMap::new())),
             wgc_state: Mutex::new(None),
@@ -1493,6 +1499,9 @@ pub async fn run_capture_loop(
                 continue;
             }
         };
+        capture_state
+            .startup_pending_cleanup_cancelled
+            .store(true, Ordering::SeqCst);
 
         // Spawn async OCR task
         let storage_clone = storage.clone();
@@ -1563,17 +1572,34 @@ async fn process_ocr_async(
         cache.insert(screenshot_id, jpeg_bytes.clone());
     }
 
-    let result = process_ocr_inner(
-        monitor_state,
-        &storage,
-        screenshot_id,
-        &jpeg_bytes,
-        &image_hash,
-        &window_title,
-        &process_name,
-        timestamp_ms,
+    let timeout_secs = if capture_state
+        .ocr_cold_start_pending
+        .swap(false, Ordering::SeqCst)
+    {
+        180
+    } else {
+        capture_state.ocr_timeout_secs.load(Ordering::SeqCst).max(1)
+    };
+
+    let result = match tokio::time::timeout(
+        tokio::time::Duration::from_secs(timeout_secs as u64),
+        process_ocr_inner(
+            monitor_state,
+            &storage,
+            screenshot_id,
+            &jpeg_bytes,
+            &image_hash,
+            &window_title,
+            &process_name,
+            timestamp_ms,
+            timeout_secs,
+        ),
     )
-    .await;
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(format!("OCR timed out after {}s", timeout_secs)),
+    };
 
     // Always remove from cache regardless of success/failure
     {
@@ -1628,6 +1654,7 @@ async fn process_ocr_inner(
     window_title: &str,
     process_name: &str,
     timestamp_ms: i64,
+    timeout_secs: u32,
 ) -> Result<(), String> {
     const OCR_IPC_ROUNDTRIP_WARN_MS: u128 = 60_000;
     const COMMIT_SLOW_WARN_MS: u128 = 2_000;
@@ -1654,6 +1681,7 @@ async fn process_ocr_inner(
         "window_title": window_title,
         "process_name": process_name,
         "timestamp": timestamp_ms,
+        "timeout_secs": timeout_secs,
     });
 
     let (auth_token, seq_no) = {

--- a/src-tauri/src/commands/utility.rs
+++ b/src-tauri/src/commands/utility.rs
@@ -89,6 +89,7 @@ pub fn get_advanced_config() -> Result<serde_json::Value, String> {
     let ocr_queue_limit_enabled =
         registry_config::get_bool("ocr_queue_limit_enabled").unwrap_or(true);
     let ocr_queue_max_size = registry_config::get_u32("ocr_queue_max_size").unwrap_or(1);
+    let ocr_timeout_secs = registry_config::get_u32("ocr_timeout_secs").unwrap_or(120);
     let use_dml = registry_config::get_bool("use_dml").unwrap_or(false);
     let dml_device_id = registry_config::get_u32("dml_device_id").unwrap_or(0);
     let game_mode_enabled = registry_config::get_bool("game_mode_enabled").unwrap_or(true);
@@ -107,6 +108,7 @@ pub fn get_advanced_config() -> Result<serde_json::Value, String> {
         "capture_on_ocr_busy": capture_on_ocr_busy,
         "ocr_queue_limit_enabled": ocr_queue_limit_enabled,
         "ocr_queue_max_size": ocr_queue_max_size,
+        "ocr_timeout_secs": ocr_timeout_secs,
         "use_dml": use_dml,
         "dml_device_id": dml_device_id,
         "game_mode_enabled": game_mode_enabled,
@@ -138,6 +140,10 @@ pub fn set_advanced_config(config: serde_json::Value) -> Result<(), String> {
     }
     if let Some(v) = config.get("ocr_queue_max_size").and_then(|v| v.as_u64()) {
         registry_config::set_u32("ocr_queue_max_size", v as u32)?;
+    }
+    if let Some(v) = config.get("ocr_timeout_secs").and_then(|v| v.as_u64()) {
+        let clamped = (v as u32).clamp(30, 600);
+        registry_config::set_u32("ocr_timeout_secs", clamped)?;
     }
     if let Some(v) = config.get("use_dml").and_then(|v| v.as_bool()) {
         registry_config::set_bool("use_dml", v)?;

--- a/src-tauri/src/credential_manager.rs
+++ b/src-tauri/src/credential_manager.rs
@@ -444,6 +444,87 @@ mod windows_impl {
         Ok(output)
     }
 
+    /// Encrypt with an exported RSAPUBLICBLOB only.
+    ///
+    /// This keeps background writes off the protected persisted key handle. The
+    /// persisted key has a high-protection UI policy, so even public operations
+    /// through that handle can surface Windows security UI on some systems.
+    pub fn encrypt_with_exported_public_key(
+        public_key: &[u8],
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, CredentialError> {
+        use windows::core::{HSTRING, PCWSTR};
+        use windows::Win32::Security::Cryptography::{
+            NCryptEncrypt, NCryptFreeObject, NCryptImportKey, NCryptOpenStorageProvider,
+            NCRYPT_FLAGS, NCRYPT_HANDLE, NCRYPT_KEY_HANDLE, NCRYPT_PAD_PKCS1_FLAG,
+            NCRYPT_PROV_HANDLE,
+        };
+
+        let mut provider = NCRYPT_PROV_HANDLE::default();
+        let provider_name = HSTRING::from(CNG_PROVIDER_NAME);
+        unsafe {
+            NCryptOpenStorageProvider(&mut provider, PCWSTR::from_raw(provider_name.as_ptr()), 0)
+        }
+        .map_err(|e| CredentialError::SystemError(format!("Failed to open CNG provider: {}", e)))?;
+
+        let blob_type = HSTRING::from("RSAPUBLICBLOB");
+        let mut key = NCRYPT_KEY_HANDLE::default();
+        unsafe {
+            NCryptImportKey(
+                provider,
+                NCRYPT_KEY_HANDLE::default(),
+                PCWSTR::from_raw(blob_type.as_ptr()),
+                None,
+                &mut key,
+                public_key,
+                NCRYPT_FLAGS(0),
+            )
+        }
+        .map_err(|e| {
+            let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(provider.0)) };
+            CredentialError::SystemError(format!("NCryptImportKey public key failed: {}", e))
+        })?;
+
+        let mut out_len: u32 = 0;
+        unsafe {
+            NCryptEncrypt(
+                key,
+                Some(plaintext),
+                None,
+                None,
+                &mut out_len,
+                NCRYPT_PAD_PKCS1_FLAG,
+            )
+        }
+        .map_err(|e| {
+            let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(key.0)) };
+            let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(provider.0)) };
+            CredentialError::SystemError(format!("NCryptEncrypt public size failed: {}", e))
+        })?;
+
+        let mut output = vec![0u8; out_len as usize];
+        unsafe {
+            NCryptEncrypt(
+                key,
+                Some(plaintext),
+                None,
+                Some(output.as_mut_slice()),
+                &mut out_len,
+                NCRYPT_PAD_PKCS1_FLAG,
+            )
+        }
+        .map_err(|e| {
+            let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(key.0)) };
+            let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(provider.0)) };
+            CredentialError::SystemError(format!("NCryptEncrypt public failed: {}", e))
+        })?;
+
+        let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(key.0)) };
+        let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(provider.0)) };
+        output.truncate(out_len as usize);
+        Ok(output)
+    }
+
     /// 导出或获取缓存的公钥（同步，不触发任何 UI 弹窗）
     pub fn export_or_get_public_key(
         state: &CredentialManagerState,
@@ -604,6 +685,16 @@ pub use windows_impl::*;
 #[cfg(not(windows))]
 pub fn export_or_get_public_key(
     _state: &CredentialManagerState,
+) -> Result<Vec<u8>, CredentialError> {
+    Err(CredentialError::SystemError(
+        "CNG is only available on Windows".to_string(),
+    ))
+}
+
+#[cfg(not(windows))]
+pub fn encrypt_with_exported_public_key(
+    _public_key: &[u8],
+    _plaintext: &[u8],
 ) -> Result<Vec<u8>, CredentialError> {
     Err(CredentialError::SystemError(
         "CNG is only available on Windows".to_string(),
@@ -935,11 +1026,6 @@ fn encrypt_master_key_with_cng(master_key: &[u8]) -> Result<Vec<u8>, CredentialE
     Ok(output)
 }
 
-/// 使用 CNG 公钥封装任意行密钥（无 UI）
-pub fn encrypt_row_key_with_cng(row_key: &[u8]) -> Result<Vec<u8>, CredentialError> {
-    encrypt_master_key_with_cng(row_key)
-}
-
 #[cfg(windows)]
 pub fn decrypt_master_key_with_cng(ciphertext: &[u8]) -> Result<Vec<u8>, CredentialError> {
     use windows::Win32::Security::Cryptography::{
@@ -1059,13 +1145,6 @@ pub fn save_public_key_to_file(
         .map_err(|e| CredentialError::SystemError(format!("Failed to save public key: {}", e)))?;
 
     Ok(())
-}
-
-#[cfg(not(windows))]
-pub fn encrypt_row_key_with_cng(_row_key: &[u8]) -> Result<Vec<u8>, CredentialError> {
-    Err(CredentialError::SystemError(
-        "CNG is only available on Windows".to_string(),
-    ))
 }
 
 #[cfg(not(windows))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -248,7 +248,7 @@ async fn run_delete_queue_maintenance_loop(app_handle: tauri::AppHandle) {
         {
             Ok(Ok(count)) => count,
             Ok(Err(e)) => {
-                tracing::warn!("[DELETE_QUEUE] OCR batch cleanup failed: {}", e);
+                tracing::debug!("[DELETE_QUEUE] OCR batch cleanup failed: {}", e);
                 0
             }
             Err(e) => {

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::Emitter;
 use tauri::{AppHandle, Manager, State};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::windows::named_pipe::ClientOptions;
 
 use std::os::windows::io::AsRawHandle;
@@ -129,6 +129,10 @@ fn inject_ipc_auth(mut req: Value, auth_token: &str, seq_no: u64) -> Value {
             Value::String(auth_token.to_string()),
         );
         obj.insert("_seq_no".to_string(), Value::Number(seq_no.into()));
+        obj.insert(
+            "ipc_protocol_version".to_string(),
+            Value::Number(IPC_PROTOCOL_VERSION.into()),
+        );
     }
     req
 }
@@ -137,6 +141,56 @@ fn parse_ipc_response(bytes: &[u8]) -> Result<Value, String> {
     let resp_str = String::from_utf8_lossy(bytes);
     serde_json::from_str::<Value>(&resp_str)
         .map_err(|e| format!("Invalid JSON response: {}. Data: {}", e, resp_str))
+}
+
+const IPC_PROTOCOL_VERSION: u32 = 2;
+const IPC_MAX_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
+
+async fn write_ipc_frame<W>(writer: &mut W, body: &[u8]) -> Result<(), String>
+where
+    W: AsyncWrite + Unpin,
+{
+    if body.len() > IPC_MAX_MESSAGE_BYTES {
+        return Err(format!(
+            "IPC request too large: {} bytes (max {})",
+            body.len(),
+            IPC_MAX_MESSAGE_BYTES
+        ));
+    }
+    let len = body.len() as u32;
+    writer
+        .write_all(&len.to_le_bytes())
+        .await
+        .map_err(|e| format!("Write frame length error: {}", e))?;
+    writer
+        .write_all(body)
+        .await
+        .map_err(|e| format!("Write frame body error: {}", e))
+}
+
+async fn read_ipc_frame<R>(reader: &mut R) -> Result<Vec<u8>, String>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut first = [0u8; 4];
+    reader
+        .read_exact(&mut first)
+        .await
+        .map_err(|e| format!("Read frame length error: {}", e))?;
+
+    let len = u32::from_le_bytes(first) as usize;
+    if len > 0 && len <= IPC_MAX_MESSAGE_BYTES {
+        let mut body = vec![0u8; len];
+        reader
+            .read_exact(&mut body)
+            .await
+            .map_err(|e| format!("Read frame body error: {}", e))?;
+        return Ok(body);
+    }
+    Err(format!(
+        "Invalid IPC v{} frame length: {} (max {})",
+        IPC_PROTOCOL_VERSION, len, IPC_MAX_MESSAGE_BYTES
+    ))
 }
 
 // 内部函数：尝试连接到管道，支持重试
@@ -207,6 +261,19 @@ pub async fn send_ipc_request(
         .unwrap_or("<unknown>")
         .to_string();
     let is_process_ocr = command_name == "process_ocr";
+    let requested_timeout_secs = req
+        .get("timeout_secs")
+        .and_then(|v| v.as_u64())
+        .map(|v| v.saturating_add(1));
+    let default_timeout_secs = match command_name.as_str() {
+        "stop" => 2,
+        "status" | "pause" | "resume" | "continue" => 5,
+        _ => 30,
+    };
+    let min_timeout_secs = if is_process_ocr { 30 } else { 1 };
+    let ipc_timeout_secs = requested_timeout_secs
+        .unwrap_or(default_timeout_secs)
+        .clamp(min_timeout_secs, 605);
     let ipc_started = std::time::Instant::now();
 
     if is_process_ocr {
@@ -244,8 +311,8 @@ pub async fn send_ipc_request(
         }
     };
 
-    let req_bytes = req.to_string().into_bytes();
-    if let Err(e) = client.write_all(&req_bytes).await {
+    let req_bytes = serde_json::to_vec(&req).map_err(|e| format!("Serialize error: {}", e))?;
+    if let Err(e) = write_ipc_frame(&mut client, &req_bytes).await {
         if is_process_ocr {
             tracing::error!(
                 "[DIAG:IPC] write failed command={} seq_no={} elapsed={}ms error={}",
@@ -255,7 +322,7 @@ pub async fn send_ipc_request(
                 e
             );
         }
-        return Err(format!("Write error: {}", e));
+        return Err(e);
     }
 
     if is_process_ocr {
@@ -268,9 +335,13 @@ pub async fn send_ipc_request(
         );
     }
 
-    let mut buf = Vec::new();
-    match client.read_to_end(&mut buf).await {
-        Ok(_) => {
+    match tokio::time::timeout(
+        tokio::time::Duration::from_secs(ipc_timeout_secs),
+        read_ipc_frame(&mut client),
+    )
+    .await
+    {
+        Ok(Ok(buf)) => {
             if is_process_ocr {
                 let elapsed_ms = ipc_started.elapsed().as_millis();
                 tracing::debug!(
@@ -297,7 +368,7 @@ pub async fn send_ipc_request(
                 }
             }
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             if is_process_ocr {
                 tracing::error!(
                     "[DIAG:IPC] read failed command={} seq_no={} elapsed={}ms error={}",
@@ -307,7 +378,20 @@ pub async fn send_ipc_request(
                     e
                 );
             }
-            Err(format!("Read error: {}", e))
+            Err(e)
+        }
+        Err(_) => {
+            let e = format!("IPC response timed out after {}s", ipc_timeout_secs);
+            if is_process_ocr {
+                tracing::error!(
+                    "[DIAG:IPC] read timeout command={} seq_no={} elapsed={}ms error={}",
+                    command_name,
+                    seq_no,
+                    ipc_started.elapsed().as_millis(),
+                    e
+                );
+            }
+            Err(e)
         }
     }
 }
@@ -414,6 +498,13 @@ pub async fn execute_monitor_command(
                 .get("ocr_queue_max_size")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(1) as u32;
+            let ocr_timeout_secs = payload
+                .get("ocr_timeout_secs")
+                .and_then(|v| v.as_u64())
+                .unwrap_or_else(|| {
+                    crate::registry_config::get_u32("ocr_timeout_secs").unwrap_or(120) as u64
+                })
+                .clamp(30, 600) as u32;
 
             capture_state
                 .capture_on_ocr_busy
@@ -421,6 +512,9 @@ pub async fn execute_monitor_command(
             capture_state
                 .ocr_queue_max_size
                 .store(ocr_queue_max_size, Ordering::SeqCst);
+            capture_state
+                .ocr_timeout_secs
+                .store(ocr_timeout_secs, Ordering::SeqCst);
             // Still forward to Python
         }
         _ => {}
@@ -836,7 +930,14 @@ pub async fn start_monitor(
                     .unwrap_or(true)
                     .to_string(),
             )
-            .env("CARBONPAPER_USE_ONNX", use_onnx.to_string());
+            .env("CARBONPAPER_USE_ONNX", use_onnx.to_string())
+            .env(
+                "CARBONPAPER_OCR_TIMEOUT_SECS",
+                crate::registry_config::get_u32("ocr_timeout_secs")
+                    .unwrap_or(120)
+                    .clamp(30, 600)
+                    .to_string(),
+            );
 
         if let Some(resolved) = &resolved_model_runtime {
             let paths = &resolved.paths;
@@ -1129,6 +1230,9 @@ fn spawn_capture_loop(app: &AppHandle) {
     capture_state.paused.store(false, Ordering::SeqCst);
     capture_state.in_flight_ocr_count.store(0, Ordering::SeqCst);
     capture_state.clear_wgc_session("spawn_capture_loop_reset");
+    capture_state
+        .startup_pending_cleanup_cancelled
+        .store(false, Ordering::SeqCst);
 
     // Load exclusion settings from disk
     {
@@ -1145,16 +1249,50 @@ fn spawn_capture_loop(app: &AppHandle) {
         let capture_on_ocr_busy =
             crate::registry_config::get_bool("capture_on_ocr_busy").unwrap_or(false);
         let ocr_queue_max_size = crate::registry_config::get_u32("ocr_queue_max_size").unwrap_or(1);
+        let ocr_timeout_secs = crate::registry_config::get_u32("ocr_timeout_secs")
+            .unwrap_or(120)
+            .clamp(30, 600);
         capture_state
             .capture_on_ocr_busy
             .store(capture_on_ocr_busy, Ordering::SeqCst);
         capture_state
             .ocr_queue_max_size
             .store(ocr_queue_max_size, Ordering::SeqCst);
+        capture_state
+            .ocr_timeout_secs
+            .store(ocr_timeout_secs, Ordering::SeqCst);
+        capture_state
+            .ocr_cold_start_pending
+            .store(true, Ordering::SeqCst);
     }
 
     let cs = capture_state.inner().clone();
     let st = storage.inner().clone();
+    {
+        let cleanup_storage = st.clone();
+        let cleanup_capture_state = cs.clone();
+        tauri::async_runtime::spawn(async move {
+            let result = tokio::task::spawn_blocking(move || {
+                cleanup_storage.abort_startup_pending_screenshots(|| {
+                    cleanup_capture_state
+                        .startup_pending_cleanup_cancelled
+                        .load(Ordering::SeqCst)
+                })
+            })
+            .await;
+            match result {
+                Ok(Ok(aborted)) if aborted > 0 => {
+                    tracing::info!(
+                        "[DIAG:STARTUP] aborted {} stale pending screenshots",
+                        aborted
+                    );
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => tracing::warn!("[DIAG:STARTUP] pending cleanup failed: {}", e),
+                Err(e) => tracing::warn!("[DIAG:STARTUP] pending cleanup task failed: {}", e),
+            }
+        });
+    }
     // MonitorState is not Arc-wrapped in Tauri managed state, but we access it via AppHandle
     // We need to pass the AppHandle so the capture loop can access MonitorState
     let app_handle = app.clone();
@@ -1229,17 +1367,39 @@ pub async fn stop_monitor(
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     }
 
-    // 2. 尝试通过 IPC 发送结束信号 to Python
-    let _ = send_ipc_command_internal(&state, "stop").await;
+    // 2. Best-effort stop signal to Python. Do not let a broken worker or pipe
+    // handler hold the UI in LOADING during an intentional terminate/restart.
+    let _ = tokio::time::timeout(
+        tokio::time::Duration::from_secs(2),
+        send_ipc_command_internal(&state, "stop"),
+    )
+    .await;
 
-    // 等待进程退出
-    let mut process_guard = state.process.lock().unwrap_or_else(|e| e.into_inner());
-    if let Some(mut child) = process_guard.take() {
-        // 给一点时间让它自己退出
-        // 这里是同步阻塞，稍微不太好，但在 destroy 阶段通常可以接受
-        // 或者直接 kill
+    // Terminate the monitor process without blocking indefinitely. Child
+    // processes are also covered by the Job Object when its handle is dropped.
+    let child_to_stop = {
+        let mut process_guard = state.process.lock().unwrap_or_else(|e| e.into_inner());
+        process_guard.take()
+    };
+    if let Some(mut child) = child_to_stop {
         let _ = child.kill();
-        let _ = child.wait();
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(3);
+        loop {
+            match child.try_wait() {
+                Ok(Some(_status)) => break,
+                Ok(None) if tokio::time::Instant::now() < deadline => {
+                    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+                }
+                Ok(None) => {
+                    tracing::warn!("Timed out waiting for monitor process to exit after kill");
+                    break;
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to wait for monitor process after kill: {}", e);
+                    break;
+                }
+            }
+        }
     }
 
     // 停止反向 IPC 服务器
@@ -1284,6 +1444,7 @@ pub async fn stop_monitor(
     }
 
     crate::refresh_tray_menu(&app);
+    let _ = app.emit("monitor-stopped", serde_json::json!({"intentional": true}));
 
     Ok("Monitor stopped".into())
 }
@@ -1320,6 +1481,15 @@ pub async fn resume_monitor(
 
 #[tauri::command]
 pub async fn get_monitor_status(state: State<'_, MonitorState>) -> Result<String, String> {
+    if state.stopping.load(Ordering::SeqCst) {
+        let stopped = serde_json::json!({
+            "paused": false,
+            "stopped": true,
+            "interval": 0
+        });
+        return Ok(stopped.to_string());
+    }
+
     match send_ipc_command_internal(&state, "status").await {
         Ok(status) => Ok(status),
         Err(e) => {

--- a/src-tauri/src/reverse_ipc.rs
+++ b/src-tauri/src/reverse_ipc.rs
@@ -21,6 +21,81 @@ use tokio::sync::mpsc;
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::System::Pipes::GetNamedPipeClientProcessId;
 
+const IPC_PROTOCOL_VERSION: u32 = 2;
+const IPC_MAX_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
+const IPC_MAX_BINARY_BYTES: usize = 64 * 1024 * 1024;
+
+async fn read_ipc_frame(server: &mut NamedPipeServer) -> Result<Vec<u8>, String> {
+    let mut first = [0u8; 4];
+    match tokio::time::timeout(
+        tokio::time::Duration::from_secs(30),
+        server.read_exact(&mut first),
+    )
+    .await
+    {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) if e.raw_os_error() == Some(109) => return Ok(Vec::new()),
+        Ok(Err(e)) => return Err(format!("read_prefix_error:{}", e)),
+        Err(_) => return Err("overall_timeout".to_string()),
+    }
+
+    let len = u32::from_le_bytes(first) as usize;
+    if len > 0 && len <= IPC_MAX_MESSAGE_BYTES {
+        let mut body = vec![0u8; len];
+        tokio::time::timeout(
+            tokio::time::Duration::from_secs(30),
+            server.read_exact(&mut body),
+        )
+        .await
+        .map_err(|_| "overall_timeout".to_string())?
+        .map_err(|e| format!("read_body_error:{}", e))?;
+        return Ok(body);
+    }
+
+    Err(format!(
+        "Invalid IPC v{} frame length: {} (max {})",
+        IPC_PROTOCOL_VERSION, len, IPC_MAX_MESSAGE_BYTES
+    ))
+}
+
+async fn write_ipc_frame(server: &mut NamedPipeServer, body: &[u8]) -> Result<(), String> {
+    if body.len() > IPC_MAX_MESSAGE_BYTES {
+        return Err(format!(
+            "Response too large: {} bytes (max {})",
+            body.len(),
+            IPC_MAX_MESSAGE_BYTES
+        ));
+    }
+    let len = body.len() as u32;
+    server
+        .write_all(&len.to_le_bytes())
+        .await
+        .map_err(|e| format!("write_prefix_error:{}", e))?;
+    server
+        .write_all(body)
+        .await
+        .map_err(|e| format!("write_body_error:{}", e))
+}
+
+async fn write_ipc_binary_frame(server: &mut NamedPipeServer, body: &[u8]) -> Result<(), String> {
+    if body.len() > IPC_MAX_BINARY_BYTES {
+        return Err(format!(
+            "Binary response too large: {} bytes (max {})",
+            body.len(),
+            IPC_MAX_BINARY_BYTES
+        ));
+    }
+    let len = body.len() as u32;
+    server
+        .write_all(&len.to_le_bytes())
+        .await
+        .map_err(|e| format!("write_binary_prefix_error:{}", e))?;
+    server
+        .write_all(body)
+        .await
+        .map_err(|e| format!("write_binary_body_error:{}", e))
+}
+
 /// Commands that Python can send to Rust via the reverse IPC named pipe.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "command")]
@@ -208,31 +283,50 @@ fn get_security_context_inner(token_handle: HANDLE) -> Result<PipeSecurityContex
     }
 }
 
-/// Lightweight parent-PID lookup via CreateToolhelp32Snapshot (single process query).
-fn get_parent_pid(pid: u32) -> Option<u32> {
+/// Return whether `pid` is `expected_ancestor_pid` or a bounded-depth descendant.
+fn is_pid_descendant_of(pid: u32, expected_ancestor_pid: u32) -> bool {
     use windows::Win32::System::Diagnostics::ToolHelp::{
         CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32, TH32CS_SNAPPROCESS,
     };
+    if pid == expected_ancestor_pid {
+        return true;
+    }
+
+    let mut parent_by_pid = std::collections::HashMap::<u32, u32>::new();
     unsafe {
-        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0).ok()?;
+        let snapshot = match CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) {
+            Ok(snapshot) => snapshot,
+            Err(_) => return false,
+        };
         let mut entry = PROCESSENTRY32 {
             dwSize: std::mem::size_of::<PROCESSENTRY32>() as u32,
             ..std::mem::zeroed()
         };
         if Process32First(snapshot, &mut entry).is_ok() {
             loop {
-                if entry.th32ProcessID == pid {
-                    let _ = windows::Win32::Foundation::CloseHandle(snapshot);
-                    return Some(entry.th32ParentProcessID);
-                }
+                parent_by_pid.insert(entry.th32ProcessID, entry.th32ParentProcessID);
                 if Process32Next(snapshot, &mut entry).is_err() {
                     break;
                 }
             }
         }
         let _ = windows::Win32::Foundation::CloseHandle(snapshot);
-        None
     }
+
+    let mut current = pid;
+    for _ in 0..8 {
+        let Some(parent) = parent_by_pid.get(&current).copied() else {
+            return false;
+        };
+        if parent == expected_ancestor_pid {
+            return true;
+        }
+        if parent == 0 || parent == current {
+            return false;
+        }
+        current = parent;
+    }
+    false
 }
 
 /// Named pipe server for Python-to-Rust reverse IPC (storage requests).
@@ -389,26 +483,16 @@ async fn handle_client(
             };
 
             if let Some(expected_pid) = expected_pid_raw {
-                let mut is_valid = false;
-                // 1. 直接匹配 (Monitor 进程)
-                if client_pid == expected_pid {
-                    is_valid = true;
-                } else {
-                    // 2. 检查是否为直接后代进程 (Python multiprocessing 第一层)
-                    if let Some(ppid) = get_parent_pid(client_pid) {
-                        if ppid == expected_pid {
-                            is_valid = true;
-                        }
-                    }
-                }
+                let is_valid = is_pid_descendant_of(client_pid, expected_pid);
 
                 if !is_valid {
                     tracing::warn!(
-                        "Illegal access attempt to Reverse IPC from PID {} (not authorized)",
-                        client_pid
+                        "Illegal access attempt to Reverse IPC from PID {} (monitor root PID {} not in parent chain)",
+                        client_pid,
+                        expected_pid
                     );
                     let err_resp = serde_json::json!({"error": format!("Access denied: PID {} is not authorized", client_pid)});
-                    let _ = server.write_all(err_resp.to_string().as_bytes()).await;
+                    let _ = write_ipc_frame(&mut server, err_resp.to_string().as_bytes()).await;
                     return;
                 }
             } else {
@@ -424,66 +508,14 @@ async fn handle_client(
         }
     }
 
-    // 读取请求 - 使用循环读取直到 JSON 完整或超时
-    // 因为图片 Base64 数据可能很大（数 MB），且数据可能分片到达
-    let mut buf = Vec::with_capacity(4 * 1024 * 1024); // 预分配 4MB
-    let mut temp_buf = vec![0u8; 64 * 1024]; // 64KB 临时缓冲区
-    let read_end_reason = {
-        // 设置读取超时
-        let read_timeout = tokio::time::Duration::from_secs(30);
-        let start_time = tokio::time::Instant::now();
-
-        loop {
-            if start_time.elapsed() > read_timeout {
-                tracing::warn!("Read timeout after {} bytes", buf.len());
-                break String::from("overall_timeout");
-            }
-
-            match tokio::time::timeout(
-                tokio::time::Duration::from_millis(500),
-                server.read(&mut temp_buf),
-            )
-            .await
-            {
-                Ok(Ok(0)) => {
-                    // 连接已关闭，数据读取完成
-                    break String::from("peer_closed");
-                }
-                Ok(Ok(n)) => {
-                    buf.extend_from_slice(&temp_buf[..n]);
-                    // 限制最大数据量为 16MB
-                    if buf.len() > 16 * 1024 * 1024 {
-                        tracing::error!("Request too large: {} bytes", buf.len());
-                        let response = StorageResponse::error("Request too large (max 16MB)");
-                        let response_bytes = serde_json::to_vec(&response).unwrap_or_default();
-                        let _ = server.write_all(&response_bytes).await;
-                        return;
-                    }
-
-                    // 仅在 JSON 已完整时结束读取，避免分片导致的截断解析
-                    if serde_json::from_slice::<serde_json::Value>(&buf).is_ok() {
-                        break String::from("json_complete");
-                    }
-                }
-                Ok(Err(e)) => {
-                    // 检查是否是 "管道已结束" 错误（正常情况，客户端已发送完数据）
-                    let is_pipe_ended = e.raw_os_error() == Some(109); // ERROR_BROKEN_PIPE
-                    if !is_pipe_ended {
-                        tracing::error!("Read error: {}", e);
-                        break format!("read_error:{}", e);
-                    } else {
-                        break String::from("broken_pipe_109");
-                    }
-                }
-                Err(_) => {
-                    // 单次 read 超时：若已有完整 JSON 则继续处理，否则继续等到全局超时
-                    if !buf.is_empty() && serde_json::from_slice::<serde_json::Value>(&buf).is_ok()
-                    {
-                        break String::from("single_read_timeout_but_json_complete");
-                    }
-                    continue;
-                }
-            }
+    let buf = match read_ipc_frame(&mut server).await {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::error!("Reverse IPC read error: {}", e);
+            let response = StorageResponse::error(&e);
+            let response_bytes = serde_json::to_vec(&response).unwrap_or_default();
+            let _ = write_ipc_frame(&mut server, &response_bytes).await;
+            return;
         }
     };
 
@@ -492,19 +524,52 @@ async fn handle_client(
     }
 
     // 解析请求
-    let response = match serde_json::from_slice::<serde_json::Value>(&buf) {
-        Ok(req) => process_request(&req, &storage, &ocr_cache, &app_handle),
-        Err(e) => StorageResponse::error(&format!(
-            "Invalid JSON: {} (bytes={}, reason={})",
-            e,
-            buf.len(),
-            read_end_reason
-        )),
+    let req = match serde_json::from_slice::<serde_json::Value>(&buf) {
+        Ok(req) => req,
+        Err(e) => {
+            let response =
+                StorageResponse::error(&format!("Invalid JSON: {} (bytes={})", e, buf.len()));
+            let response_bytes = serde_json::to_vec(&response).unwrap_or_default();
+            if let Err(e) = write_ipc_frame(&mut server, &response_bytes).await {
+                tracing::error!("Write error: {}", e);
+            }
+            return;
+        }
     };
+
+    if req.get("command").and_then(|c| c.as_str()) == Some("get_temp_image") {
+        match get_temp_image_bytes(&req, &storage, &ocr_cache) {
+            Ok((image_bytes, mime_type)) => {
+                let metadata = StorageResponse::success(serde_json::json!({
+                    "mime_type": mime_type,
+                    "binary_body_len": image_bytes.len(),
+                    "binary_frame": true,
+                }));
+                let metadata_bytes = serde_json::to_vec(&metadata).unwrap_or_default();
+                if let Err(e) = write_ipc_frame(&mut server, &metadata_bytes).await {
+                    tracing::error!("Write binary metadata error: {}", e);
+                    return;
+                }
+                if let Err(e) = write_ipc_binary_frame(&mut server, &image_bytes).await {
+                    tracing::error!("Write binary body error: {}", e);
+                }
+            }
+            Err(e) => {
+                let response = StorageResponse::error(&e);
+                let response_bytes = serde_json::to_vec(&response).unwrap_or_default();
+                if let Err(e) = write_ipc_frame(&mut server, &response_bytes).await {
+                    tracing::error!("Write error: {}", e);
+                }
+            }
+        }
+        return;
+    }
+
+    let response = process_request(&req, &storage, &app_handle);
 
     // 发送响应
     let response_bytes = serde_json::to_vec(&response).unwrap_or_default();
-    if let Err(e) = server.write_all(&response_bytes).await {
+    if let Err(e) = write_ipc_frame(&mut server, &response_bytes).await {
         tracing::error!("Write error: {}", e);
     }
 }
@@ -513,7 +578,6 @@ async fn handle_client(
 fn process_request(
     req: &serde_json::Value,
     storage: &StorageState,
-    ocr_cache: &OcrImageCache,
     app_handle: &tauri::AppHandle,
 ) -> StorageResponse {
     let command = req.get("command").and_then(|c| c.as_str()).unwrap_or("");
@@ -729,64 +793,6 @@ fn process_request(
                 Err(e) => StorageResponse::error(&e),
             }
         }
-        "get_temp_image" => {
-            // Return image data from in-memory OCR cache (avoids CNG decryption / Windows Hello)
-            let screenshot_id_val = req.get("screenshot_id").cloned();
-            let screenshot_id = match screenshot_id_val {
-                Some(v) => {
-                    if v.is_i64() {
-                        v.as_i64().unwrap_or(-1)
-                    } else if v.is_u64() {
-                        v.as_u64().map(|x| x as i64).unwrap_or(-1)
-                    } else if v.is_string() {
-                        v.as_str().and_then(|s| s.parse::<i64>().ok()).unwrap_or(-1)
-                    } else {
-                        -1
-                    }
-                }
-                None => -1,
-            };
-
-            if screenshot_id < 0 {
-                return StorageResponse::error("Invalid screenshot_id");
-            }
-
-            // Look up the in-memory cache first (no CNG decryption needed)
-            let cached = {
-                let cache = ocr_cache.lock().unwrap_or_else(|e| e.into_inner());
-                cache.get(&screenshot_id).cloned()
-            };
-
-            match cached {
-                Some(jpeg_bytes) => {
-                    let b64_data = base64::Engine::encode(
-                        &base64::engine::general_purpose::STANDARD,
-                        &jpeg_bytes,
-                    );
-                    StorageResponse::success(serde_json::json!({
-                        "image_data": b64_data,
-                        "mime_type": "image/jpeg",
-                    }))
-                }
-                None => {
-                    // Fallback to storage (may trigger CNG) for non-capture callers
-                    match storage.get_screenshot_by_id(screenshot_id) {
-                        Ok(Some(record)) => match storage.read_image(&record.image_path) {
-                            Ok((b64_data, mime)) => StorageResponse::success(serde_json::json!({
-                                "image_data": b64_data,
-                                "mime_type": mime,
-                            })),
-                            Err(e) => {
-                                StorageResponse::error(&format!("Failed to read image: {}", e))
-                            }
-                        },
-                        Ok(None) => StorageResponse::error("Screenshot not found"),
-                        Err(e) => StorageResponse::error(&e),
-                    }
-                }
-            }
-        }
-
         "list_screenshots_for_clustering" => {
             let start_ts = req.get("start_ts").and_then(|v| v.as_f64()).unwrap_or(0.0);
             let end_ts = req.get("end_ts").and_then(|v| v.as_f64()).unwrap_or(0.0);
@@ -1007,6 +1013,54 @@ fn process_request(
     response
 }
 
+fn parse_screenshot_id(req: &serde_json::Value) -> Result<i64, String> {
+    let Some(v) = req.get("screenshot_id") else {
+        return Err("Invalid screenshot_id".to_string());
+    };
+    let screenshot_id = if v.is_i64() {
+        v.as_i64().unwrap_or(-1)
+    } else if v.is_u64() {
+        v.as_u64().map(|x| x as i64).unwrap_or(-1)
+    } else if v.is_string() {
+        v.as_str().and_then(|s| s.parse::<i64>().ok()).unwrap_or(-1)
+    } else {
+        -1
+    };
+    if screenshot_id < 0 {
+        Err("Invalid screenshot_id".to_string())
+    } else {
+        Ok(screenshot_id)
+    }
+}
+
+fn get_temp_image_bytes(
+    req: &serde_json::Value,
+    storage: &StorageState,
+    ocr_cache: &OcrImageCache,
+) -> Result<(Vec<u8>, String), String> {
+    let screenshot_id = parse_screenshot_id(req)?;
+
+    let cached = {
+        let cache = ocr_cache.lock().unwrap_or_else(|e| e.into_inner());
+        cache.get(&screenshot_id).cloned()
+    };
+
+    if let Some(jpeg_bytes) = cached {
+        return Ok((jpeg_bytes, "image/jpeg".to_string()));
+    }
+
+    match storage.get_screenshot_by_id(screenshot_id) {
+        Ok(Some(record)) => {
+            let (bytes, mime) = storage
+                .read_image_bytes(&record.image_path)
+                .map_err(|e| format!("Failed to read image: {}", e))?;
+            Ok((bytes, mime))
+        }
+        Ok(None) => Err("Screenshot not found".to_string()),
+        Err(e) => Err(e),
+    }
+}
+
 /// 生成反向 IPC 管道名
 pub fn generate_reverse_pipe_name() -> String {
     let mut rng = rand::thread_rng();
@@ -1191,56 +1245,14 @@ async fn handle_nmh_client(
     app_handle: tauri::AppHandle,
     expected_token: String,
 ) {
-    // Read the full request (same pattern as handle_client)
-    let mut buf = Vec::with_capacity(4 * 1024 * 1024);
-    let mut temp_buf = vec![0u8; 64 * 1024];
-    let read_timeout = tokio::time::Duration::from_secs(30);
-    let start_time = tokio::time::Instant::now();
-    let read_end_reason = {
-        loop {
-            if start_time.elapsed() > read_timeout {
-                tracing::warn!("NMH read timeout after {} bytes", buf.len());
-                break String::from("overall_timeout");
-            }
-
-            match tokio::time::timeout(
-                tokio::time::Duration::from_millis(500),
-                server.read(&mut temp_buf),
-            )
-            .await
-            {
-                Ok(Ok(0)) => {
-                    break String::from("peer_closed");
-                }
-                Ok(Ok(n)) => {
-                    buf.extend_from_slice(&temp_buf[..n]);
-                    if buf.len() > 16 * 1024 * 1024 {
-                        let response = StorageResponse::error("Request too large (max 16MB)");
-                        let response_bytes = serde_json::to_vec(&response).unwrap_or_default();
-                        let _ = server.write_all(&response_bytes).await;
-                        return;
-                    }
-
-                    if serde_json::from_slice::<serde_json::Value>(&buf).is_ok() {
-                        break String::from("json_complete");
-                    }
-                }
-                Ok(Err(e)) => {
-                    if e.raw_os_error() != Some(109) {
-                        tracing::error!("NMH read error: {}", e);
-                        break format!("read_error:{}", e);
-                    } else {
-                        break String::from("broken_pipe_109");
-                    }
-                }
-                Err(_) => {
-                    if !buf.is_empty() && serde_json::from_slice::<serde_json::Value>(&buf).is_ok()
-                    {
-                        break String::from("single_read_timeout_but_json_complete");
-                    }
-                    continue;
-                }
-            }
+    let buf = match read_ipc_frame(&mut server).await {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::error!("NMH read error: {}", e);
+            let response = StorageResponse::error(&e);
+            let response_bytes = serde_json::to_vec(&response).unwrap_or_default();
+            let _ = write_ipc_frame(&mut server, &response_bytes).await;
+            return;
         }
     };
 
@@ -1265,16 +1277,11 @@ async fn handle_nmh_client(
                 .await
             }
         }
-        Err(e) => StorageResponse::error(&format!(
-            "Invalid JSON: {} (bytes={}, reason={})",
-            e,
-            buf.len(),
-            read_end_reason
-        )),
+        Err(e) => StorageResponse::error(&format!("Invalid JSON: {} (bytes={})", e, buf.len())),
     };
 
     let response_bytes = serde_json::to_vec(&response).unwrap_or_default();
-    if let Err(e) = server.write_all(&response_bytes).await {
+    if let Err(e) = write_ipc_frame(&mut server, &response_bytes).await {
         tracing::error!("NMH write error: {}", e);
     }
 }

--- a/src-tauri/src/storage/encryption.rs
+++ b/src-tauri/src/storage/encryption.rs
@@ -1,7 +1,7 @@
 //! Row-level and ChromaDB encryption/decryption helpers.
 
 use crate::credential_manager::{
-    decrypt_row_key_with_cng, decrypt_with_master_key, encrypt_row_key_with_cng,
+    decrypt_row_key_with_cng, decrypt_with_master_key, encrypt_with_exported_public_key,
     encrypt_with_master_key, get_cached_public_key, load_public_key_from_file,
 };
 use rand::RngCore;
@@ -18,6 +18,12 @@ impl StorageState {
         compiler_fence(Ordering::SeqCst);
     }
 
+    pub(crate) fn wrap_row_key_for_storage(&self, row_key: &[u8]) -> Result<Vec<u8>, String> {
+        let public_key = self.get_public_key()?;
+        encrypt_with_exported_public_key(&public_key, row_key)
+            .map_err(|e| format!("Failed to wrap row key with public key: {}", e))
+    }
+
     pub(super) fn encrypt_payload_with_row_key(
         &self,
         plaintext: &[u8],
@@ -28,8 +34,7 @@ impl StorageState {
         let encrypted_data = encrypt_with_master_key(&row_key, plaintext)
             .map_err(|e| format!("Failed to encrypt payload: {}", e))?;
 
-        let encrypted_key = encrypt_row_key_with_cng(&row_key)
-            .map_err(|e| format!("Failed to wrap row key: {}", e))?;
+        let encrypted_key = self.wrap_row_key_for_storage(&row_key)?;
 
         Self::zeroize_bytes(&mut row_key);
         Ok((encrypted_data, encrypted_key))

--- a/src-tauri/src/storage/image_io.rs
+++ b/src-tauri/src/storage/image_io.rs
@@ -68,6 +68,60 @@ impl StorageState {
         result
     }
 
+    /// Read an encrypted image file and return raw image bytes.
+    pub fn read_image_bytes(&self, path: &str) -> Result<(Vec<u8>, String), String> {
+        let diag_start = std::time::Instant::now();
+
+        let (key_enc, abs_path) = {
+            let guard = self.get_connection_named("read_image_bytes")?;
+            let conn = guard.as_ref().unwrap();
+
+            if let Some(hash) = path.strip_prefix("memory://") {
+                let result: Option<(Option<Vec<u8>>, String)> = conn
+                    .query_row(
+                        "SELECT content_key_encrypted, image_path FROM screenshots WHERE image_hash = ? AND is_deleted = 0",
+                        [hash],
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )
+                    .ok();
+                match result {
+                    Some((key, real_path)) => (key, self.resolve_image_path(&real_path)),
+                    None => return Err(format!("No screenshot found for hash: {}", hash)),
+                }
+            } else {
+                let key: Option<Vec<u8>> = conn
+                    .query_row(
+                        "SELECT content_key_encrypted FROM screenshots WHERE image_path = ? AND is_deleted = 0",
+                        [path],
+                        |row| row.get(0),
+                    )
+                    .ok();
+
+                let resolved = self.resolve_image_path(path);
+                (key, resolved)
+            }
+        };
+
+        let query_elapsed = diag_start.elapsed();
+        let mut row_key = key_enc
+            .as_ref()
+            .and_then(|enc| decrypt_row_key_with_cng(enc).ok())
+            .ok_or_else(|| "Failed to unwrap image row key".to_string())?;
+
+        let abs_path_str = abs_path.to_string_lossy().to_string();
+        let result = read_encrypted_image_bytes(&abs_path_str, &row_key);
+        Self::zeroize_bytes(&mut row_key);
+        if diag_start.elapsed().as_secs() >= 5 {
+            tracing::warn!(
+                "[DIAG:DB] read_image_bytes({}) query {:?}, total {:?}",
+                path,
+                query_elapsed,
+                diag_start.elapsed()
+            );
+        }
+        result
+    }
+
     /// Derive the cached thumbnail path from an original image path.
     /// E.g. `screenshots/foo.png.enc` → `screenshots/thumbs/foo.thumb.jpg.enc`
     pub fn thumbnail_path_for(original: &Path) -> PathBuf {
@@ -560,6 +614,15 @@ pub fn read_encrypted_image_as_base64(
     path: &str,
     row_key: &[u8],
 ) -> Result<(String, String), String> {
+    let (image_data, mime_type) = read_encrypted_image_bytes(path, row_key)?;
+    let base64_data =
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &image_data);
+
+    Ok((base64_data, mime_type))
+}
+
+/// Read an encrypted image file and return raw image bytes (with decryption).
+pub fn read_encrypted_image_bytes(path: &str, row_key: &[u8]) -> Result<(Vec<u8>, String), String> {
     let path = Path::new(path);
 
     if !path.exists() {
@@ -602,8 +665,5 @@ pub fn read_encrypted_image_as_base64(
         data
     };
 
-    let base64_data =
-        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &image_data);
-
-    Ok((base64_data, mime_type.to_string()))
+    Ok((image_data, mime_type.to_string()))
 }

--- a/src-tauri/src/storage/migration/dedup.rs
+++ b/src-tauri/src/storage/migration/dedup.rs
@@ -96,7 +96,7 @@ impl StorageState {
                 };
 
                 // Create or reuse page_icon entry
-                match Self::get_or_create_page_icon_id(conn, &plaintext) {
+                match self.get_or_create_page_icon_id(conn, &plaintext) {
                     Ok(icon_id) => {
                         // Update screenshot and NULL out the inline column
                         if let Err(e) = conn.execute(
@@ -209,7 +209,7 @@ impl StorageState {
                 }
 
                 // Create or reuse link_set entry
-                match Self::get_or_create_link_set_id(conn, &links) {
+                match self.get_or_create_link_set_id(conn, &links) {
                     Ok(link_set_id) => {
                         if let Err(e) = conn.execute(
                             "UPDATE screenshots SET link_set_id = ?, visible_links_enc = NULL WHERE id = ?",

--- a/src-tauri/src/storage/migration/plaintext.rs
+++ b/src-tauri/src/storage/migration/plaintext.rs
@@ -1,8 +1,7 @@
 //! Plaintext screenshot file encryption, backfill, and cleanup.
 
 use crate::credential_manager::{
-    decrypt_row_key_with_cng, decrypt_with_master_key, encrypt_row_key_with_cng,
-    encrypt_with_master_key,
+    decrypt_row_key_with_cng, decrypt_with_master_key, encrypt_with_master_key,
 };
 use rand::RngCore;
 use rusqlite::params;
@@ -96,8 +95,7 @@ impl StorageState {
         rand::thread_rng().fill_bytes(&mut row_key);
         let encrypted = encrypt_with_master_key(&row_key, &data)
             .map_err(|e| format!("Failed to encrypt: {}", e))?;
-        let encrypted_key = encrypt_row_key_with_cng(&row_key)
-            .map_err(|e| format!("Failed to wrap row key: {}", e))?;
+        let encrypted_key = self.wrap_row_key_for_storage(&row_key)?;
         Self::zeroize_bytes(&mut row_key);
 
         // Generate new filename

--- a/src-tauri/src/storage/screenshot.rs
+++ b/src-tauri/src/storage/screenshot.rs
@@ -1,6 +1,6 @@
 //! Screenshot CRUD operations (save, get, delete, commit, abort).
 
-use crate::credential_manager::{encrypt_row_key_with_cng, encrypt_with_master_key};
+use crate::credential_manager::encrypt_with_master_key;
 use chrono::{DateTime, Utc};
 use rand::RngCore;
 use roaring::RoaringBitmap;
@@ -124,7 +124,8 @@ impl StorageState {
         // Encrypt image data
         let encrypted_image = encrypt_with_master_key(&row_key, &image_data)
             .map_err(|e| format!("Failed to encrypt image: {}", e))?;
-        let encrypted_row_key = encrypt_row_key_with_cng(&row_key)
+        let encrypted_row_key = self
+            .wrap_row_key_for_storage(&row_key)
             .map_err(|e| format!("Failed to wrap image row key: {}", e))?;
 
         // Generate filename (use .enc extension to indicate encrypted file)
@@ -189,12 +190,12 @@ impl StorageState {
         // Use dedup tables for page_icon and visible_links
         let page_icon_id: Option<i64> = match &request.page_icon {
             Some(value) if !value.is_empty() => {
-                Some(Self::get_or_create_page_icon_id(conn, value)?)
+                Some(self.get_or_create_page_icon_id(conn, value)?)
             }
             _ => None,
         };
         let link_set_id: Option<i64> = match &request.visible_links {
-            Some(links) if !links.is_empty() => Some(Self::get_or_create_link_set_id(conn, links)?),
+            Some(links) if !links.is_empty() => Some(self.get_or_create_link_set_id(conn, links)?),
             _ => None,
         };
 
@@ -330,7 +331,8 @@ impl StorageState {
 
         let encrypted_image = encrypt_with_master_key(&row_key, &image_data)
             .map_err(|e| format!("Failed to encrypt image: {}", e))?;
-        let encrypted_row_key = encrypt_row_key_with_cng(&row_key)
+        let encrypted_row_key = self
+            .wrap_row_key_for_storage(&row_key)
             .map_err(|e| format!("Failed to wrap image row key: {}", e))?;
         let img_encrypt_dur = t1.elapsed();
 
@@ -413,12 +415,12 @@ impl StorageState {
         // Use dedup tables for page_icon and visible_links
         let page_icon_id: Option<i64> = match &request.page_icon {
             Some(value) if !value.is_empty() => {
-                Some(Self::get_or_create_page_icon_id(conn, value)?)
+                Some(self.get_or_create_page_icon_id(conn, value)?)
             }
             _ => None,
         };
         let link_set_id: Option<i64> = match &request.visible_links {
-            Some(links) if !links.is_empty() => Some(Self::get_or_create_link_set_id(conn, links)?),
+            Some(links) if !links.is_empty() => Some(self.get_or_create_link_set_id(conn, links)?),
             _ => None,
         };
 
@@ -750,6 +752,58 @@ impl StorageState {
             added: 0,
             skipped: 0,
         })
+    }
+
+    /// Abort stale pending screenshots during monitor startup.
+    ///
+    /// The caller supplies a cancellation check so startup recovery can stop as
+    /// soon as fresh capture work begins.
+    pub fn abort_startup_pending_screenshots<F>(
+        &self,
+        mut should_cancel: F,
+    ) -> Result<usize, String>
+    where
+        F: FnMut() -> bool,
+    {
+        let pending_ids: Vec<i64> = {
+            let guard = self.get_connection_named("list_startup_pending_screenshots")?;
+            let conn = guard.as_ref().unwrap();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id FROM screenshots WHERE status = 'pending' AND is_deleted = 0 ORDER BY id ASC",
+                )
+                .map_err(|e| format!("Failed to prepare pending screenshot query: {}", e))?;
+            let ids: Vec<i64> = stmt
+                .query_map([], |row| row.get(0))
+                .map_err(|e| format!("Failed to query pending screenshots: {}", e))?
+                .filter_map(|r| r.ok())
+                .collect();
+            ids
+        };
+
+        let mut aborted = 0usize;
+        for screenshot_id in pending_ids {
+            if should_cancel() {
+                tracing::info!(
+                    "[DIAG:STARTUP] pending screenshot cleanup cancelled after {} aborts",
+                    aborted
+                );
+                break;
+            }
+            match self.abort_screenshot(
+                screenshot_id,
+                Some("startup recovery: stale pending screenshot"),
+            ) {
+                Ok(_) => aborted += 1,
+                Err(e) => tracing::warn!(
+                    "[DIAG:STARTUP] failed to abort pending screenshot {}: {}",
+                    screenshot_id,
+                    e
+                ),
+            }
+        }
+
+        Ok(aborted)
     }
 
     /// Get screenshots within a time range.
@@ -2025,6 +2079,7 @@ impl StorageState {
     /// Get or create a page_icon dedup entry. Returns the row ID.
     /// Uses INSERT OR IGNORE + SELECT pattern for atomic upsert.
     pub(crate) fn get_or_create_page_icon_id(
+        &self,
         conn: &Connection,
         plaintext: &str,
     ) -> Result<i64, String> {
@@ -2050,7 +2105,8 @@ impl StorageState {
 
         let icon_enc = encrypt_with_master_key(&row_key, plaintext.as_bytes())
             .map_err(|e| format!("Failed to encrypt page_icon: {}", e))?;
-        let icon_key_encrypted = encrypt_row_key_with_cng(&row_key)
+        let icon_key_encrypted = self
+            .wrap_row_key_for_storage(&row_key)
             .map_err(|e| format!("Failed to wrap page_icon row key: {}", e))?;
 
         Self::zeroize_bytes(&mut row_key);
@@ -2076,6 +2132,7 @@ impl StorageState {
 
     /// Get or create a link_set dedup entry. Returns the row ID.
     pub(crate) fn get_or_create_link_set_id(
+        &self,
         conn: &Connection,
         links: &[super::VisibleLink],
     ) -> Result<i64, String> {
@@ -2105,7 +2162,8 @@ impl StorageState {
 
         let links_enc = encrypt_with_master_key(&row_key, json.as_bytes())
             .map_err(|e| format!("Failed to encrypt link_set: {}", e))?;
-        let links_key_encrypted = encrypt_row_key_with_cng(&row_key)
+        let links_key_encrypted = self
+            .wrap_row_key_for_storage(&row_key)
             .map_err(|e| format!("Failed to wrap link_set row key: {}", e))?;
 
         Self::zeroize_bytes(&mut row_key);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -744,6 +744,7 @@ function App() {
 
   useEffect(() => {
     let unlistenExit;
+    let unlistenStopped;
     const setup = async () => {
       unlistenExit = await listen('monitor-exited', (event) => {
         const payload = event?.payload || {};
@@ -756,11 +757,22 @@ function App() {
         setBackendError(message);
         reportBackendError('Python 子服务异常退出', message, details);
       });
+      unlistenStopped = await listen('monitor-stopped', () => {
+        setBackendStatus('offline');
+        backendStatusRef.current = 'offline';
+        setMonitorPaused(false);
+        setBackendError('');
+        lastBackendErrorRef.current = '';
+        backendStartAtRef.current = null;
+      });
     };
     setup();
     return () => {
       if (unlistenExit) {
         unlistenExit();
+      }
+      if (unlistenStopped) {
+        unlistenStopped();
       }
     };
   }, [reportBackendError, formatErrorDetails]);

--- a/src/components/settings/AdvancedSection.jsx
+++ b/src/components/settings/AdvancedSection.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Cpu, ListOrdered, ChevronDown, AlertTriangle, Info, Zap, Monitor, Layers, Database, Loader2, Globe } from 'lucide-react';
+import { Cpu, ListOrdered, ChevronDown, AlertTriangle, Info, Zap, Monitor, Layers, Database, Loader2, Globe, Clock } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 
 const CPU_PERCENT_OPTIONS = [5, 10, 15, 20, 30, 50];
@@ -83,6 +83,7 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
           ocr_queue_max_size: newConfig.ocr_queue_limit_enabled
             ? newConfig.ocr_queue_max_size
             : 999999,
+          ocr_timeout_secs: newConfig.ocr_timeout_secs || 120,
         },
       });
     } catch (err) {
@@ -117,6 +118,14 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
   const handleQueueSizeChange = async (value) => {
     setQueueDropdownOpen(false);
     const newConfig = { ...config, ocr_queue_max_size: value };
+    await saveConfig(newConfig);
+    await syncOcrConfigToMonitor(newConfig);
+  };
+
+  const handleOcrTimeoutChange = async (value) => {
+    const parsed = Number.parseInt(value, 10);
+    const next = Number.isFinite(parsed) ? Math.min(600, Math.max(30, parsed)) : 120;
+    const newConfig = { ...config, ocr_timeout_secs: next };
     await saveConfig(newConfig);
     await syncOcrConfigToMonitor(newConfig);
   };
@@ -356,6 +365,34 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
               </div>
             </div>
           )}
+
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-ide-text font-medium flex items-center gap-2">
+                <Clock className="w-4 h-4 text-ide-muted" />
+                {t('settings.advanced.ocr.timeout_label', 'OCR 超时时间')}
+              </p>
+              <p className="text-xs text-ide-muted mt-1">
+                {t('settings.advanced.ocr.timeout_desc', '设定 OCR 任务的超时时间。冷启动固定允许 180 秒。')}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <input
+                type="number"
+                min="30"
+                max="600"
+                step="10"
+                value={config.ocr_timeout_secs || 120}
+                onChange={(e) => {
+                  const newConfig = { ...config, ocr_timeout_secs: e.target.value };
+                  setConfig(newConfig);
+                }}
+                onBlur={(e) => handleOcrTimeoutChange(e.target.value)}
+                className="w-24 px-3 py-2 bg-ide-panel border border-ide-border rounded-lg text-sm text-ide-text text-right"
+              />
+              <span className="text-xs text-ide-muted">{t('settings.advanced.ocr.seconds', '秒')}</span>
+            </div>
+          </div>
 
           {/* 信息提示 */}
           <div className="flex items-start gap-2 p-2.5 bg-ide-panel/50 border border-ide-border/30 rounded-lg">

--- a/src/components/settings/SettingsDialog.jsx
+++ b/src/components/settings/SettingsDialog.jsx
@@ -229,11 +229,12 @@ function SettingsDialog({
     monitorStatusRef.current = 'loading';
     try {
       await invoke('stop_monitor');
-      setMonitorStatus('stopped');
-      monitorStatusRef.current = 'stopped';
-      onManualStopMonitor?.();
     } catch (e) {
       console.error('Failed to stop monitor', e);
+    } finally {
+      onManualStopMonitor?.();
+      setMonitorStatus('stopped');
+      monitorStatusRef.current = 'stopped';
     }
   };
 
@@ -248,6 +249,8 @@ function SettingsDialog({
       await checkMonitorStatus();
     } catch (e) {
       console.error('Failed to restart monitor', e);
+      setMonitorStatus('stopped');
+      monitorStatusRef.current = 'stopped';
       await checkMonitorStatus();
     }
   };


### PR DESCRIPTION
## Summary
- add v2 length-prefixed IPC framing across Rust, Python monitor, storage client, and NMH
- move OCR/classification/model calls behind a restartable worker process with configurable OCR timeout handling
- return temporary OCR images through binary pipe frames and reduce background CNG protected-key prompts by using exported public-key wrapping
- tighten monitor stop/status handling and startup cleanup for stale pending screenshots