### PR TITLE
fix: prevent updater apply hang

### DIFF
--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -1,12 +1,12 @@
 use crate::capture::CaptureState;
-use crate::resource_utils::{find_existing_file_in_resources, normalize_path_for_command};
-use crate::reverse_ipc::{generate_reverse_pipe_name, ReverseIpcServer};
-use crate::storage::StorageState;
+#[cfg(test)]
+use crate::monitor_ipc::parse_ipc_response;
 use crate::monitor_ipc::{
     generate_auth_token, generate_random_pipe_name, inject_ipc_auth, send_ipc_request_on_client,
 };
-#[cfg(test)]
-use crate::monitor_ipc::parse_ipc_response;
+use crate::resource_utils::{find_existing_file_in_resources, normalize_path_for_command};
+use crate::reverse_ipc::{generate_reverse_pipe_name, ReverseIpcServer};
+use crate::storage::StorageState;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::process::{Child, Command};
@@ -214,27 +214,26 @@ pub async fn send_ipc_request_reused(
         );
     }
 
-    let mut guard = state.python_ipc_client.lock().await;
-    let needs_connect = guard
-        .as_ref()
-        .map(|existing| existing.pipe_name != pipe_name)
-        .unwrap_or(true);
-    if needs_connect {
-        let client = connect_to_pipe(pipe_name).await?;
-        *guard = Some(PersistentIpcClient {
-            pipe_name: pipe_name.to_string(),
-            client,
-            requests: 0,
-        });
-        tracing::debug!(
-            "[DIAG:IPC] persistent connection established pipe={}",
-            pipe_name
-        );
-    }
+    let mut persistent = {
+        let mut guard = state.python_ipc_client.lock().await;
+        match guard.take() {
+            Some(existing) if existing.pipe_name == pipe_name => existing,
+            _ => {
+                drop(guard);
+                let client = connect_to_pipe(pipe_name).await?;
+                tracing::debug!(
+                    "[DIAG:IPC] persistent connection established pipe={}",
+                    pipe_name
+                );
+                PersistentIpcClient {
+                    pipe_name: pipe_name.to_string(),
+                    client,
+                    requests: 0,
+                }
+            }
+        }
+    };
 
-    let persistent = guard
-        .as_mut()
-        .ok_or_else(|| "Persistent IPC client unavailable".to_string())?;
     let result = send_ipc_request_on_client(
         &mut persistent.client,
         &req,
@@ -258,13 +257,27 @@ pub async fn send_ipc_request_reused(
                     ipc_started.elapsed().as_millis()
                 );
             }
+            let pipe_still_current = {
+                let guard = state.pipe_name.lock().unwrap_or_else(|e| e.into_inner());
+                guard.as_deref() == Some(pipe_name)
+            };
+            let mut guard = state.python_ipc_client.lock().await;
+            if pipe_still_current && guard.is_none() {
+                *guard = Some(persistent);
+            } else {
+                tracing::debug!(
+                    "[DIAG:IPC] dropping reusable connection command={} pipe_current={} newer_client={}",
+                    command_name,
+                    pipe_still_current,
+                    guard.is_some()
+                );
+            }
         }
         Ok(_) => {
             tracing::debug!(
                 "[DIAG:IPC] closing persistent connection after command={}",
                 command_name
             );
-            *guard = None;
         }
         Err(e) => {
             tracing::warn!(
@@ -273,7 +286,6 @@ pub async fn send_ipc_request_reused(
                 seq_no,
                 e
             );
-            *guard = None;
         }
     }
 

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -252,13 +252,8 @@ pub async fn updater_apply(
     monitor_state: tauri::State<'_, crate::monitor::MonitorState>,
     capture_state: tauri::State<'_, std::sync::Arc<crate::capture::CaptureState>>,
 ) -> Result<(), String> {
-    // 1. Stop the Python monitor
-    let _ = crate::monitor::stop_monitor(monitor_state, capture_state, app.clone()).await;
+    tracing::info!("Update apply: preparing update");
 
-    // 2. Set the updating flag so close is allowed
-    crate::IS_UPDATING.store(true, std::sync::atomic::Ordering::Relaxed);
-
-    // 3. Resolve paths
     let staging = staging_dir()?;
     let extract_dir = staging.join("extracted");
 
@@ -278,6 +273,25 @@ pub async fn updater_apply(
         .unwrap_or_default()
         .to_string_lossy()
         .to_string();
+
+    crate::IS_UPDATING.store(true, std::sync::atomic::Ordering::Relaxed);
+
+    tracing::info!("Update apply: stopping monitor before update");
+    match tokio::time::timeout(
+        tokio::time::Duration::from_secs(15),
+        crate::monitor::stop_monitor(monitor_state, capture_state, app.clone()),
+    )
+    .await
+    {
+        Ok(Ok(message)) => tracing::info!("Update apply: monitor stopped: {}", message),
+        Ok(Err(e)) => {
+            tracing::warn!(
+                "Update apply: monitor stop failed, continuing update: {}",
+                e
+            )
+        }
+        Err(_) => tracing::warn!("Update apply: monitor stop timed out, continuing update"),
+    }
 
     // 4. Generate PowerShell update script
     let ps_script = format!(
@@ -343,6 +357,7 @@ try {{
 
     // Write the PowerShell script
     let ps_path = staging.join("update.ps1");
+    tracing::info!("Update apply: writing script to {}", ps_path.display());
     std::fs::write(&ps_path, &ps_script)
         .map_err(|e| format!("Failed to write update script: {}", e))?;
 
@@ -350,6 +365,7 @@ try {{
 
     // 5. Spawn detached PowerShell process
     use std::process::Command;
+    tracing::info!("Update apply: launching update script");
     Command::new("powershell.exe")
         .args([
             "-ExecutionPolicy",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -952,6 +952,7 @@ function App() {
   const handleDownloadUpdate = async () => {
     setUpdateDownloading(true);
     setUpdateDownloadError(null);
+    setUpdateDownloadProgress({ phase: 'downloading', downloaded: 0, contentLength: 0 });
     try {
       await downloadAndInstallUpdate((progress) => {
         setUpdateDownloadProgress(progress);

--- a/src/components/UpdateModal.jsx
+++ b/src/components/UpdateModal.jsx
@@ -19,10 +19,18 @@ export function UpdateModal({
   if (!isVisible || !updateInfo) return null;
 
   const { version, body, critical } = updateInfo;
+  const phase = downloadProgress?.phase || 'downloading';
   const hasValidTotal = downloadProgress && downloadProgress.contentLength > 0;
   const progressPercent = hasValidTotal
     ? Math.round((downloadProgress.downloaded / downloadProgress.contentLength) * 100)
     : 0;
+  const isApplying = phase === 'applying';
+  const isExtracting = phase === 'extracting';
+  const statusLabel = isApplying
+    ? t('updateModal.applying')
+    : isExtracting
+      ? t('updateModal.extracting')
+      : t('updateModal.downloading');
 
   const IconComponent = critical ? AlertCircle : ArrowUpCircle;
   const iconColorClass = critical ? 'text-red-500' : 'text-ide-accent';
@@ -69,9 +77,11 @@ export function UpdateModal({
           {downloading && (
             <div className="w-full space-y-1.5 shrink-0 pt-2">
               <div className="flex justify-between text-xs">
-                <span className="text-ide-text font-medium">{t('updateModal.downloading')}</span>
+                <span className="text-ide-text font-medium">{statusLabel}</span>
                 <span className="text-ide-muted">
-                  {hasValidTotal 
+                  {isApplying || isExtracting
+                    ? t(`updateModal.${phase}`)
+                    : hasValidTotal
                     ? `${progressPercent}%` 
                     : downloadProgress ? `${(downloadProgress.downloaded / 1024 / 1024).toFixed(1)} MB` : '0%'
                   }
@@ -80,7 +90,7 @@ export function UpdateModal({
               <div className="w-full h-2 bg-ide-bg rounded-full overflow-hidden border border-ide-border">
                 <div 
                   className="h-full bg-ide-accent rounded-full transition-all duration-300 ease-out" 
-                  style={{ width: `${progressPercent}%` }}
+                  style={{ width: `${isApplying || isExtracting ? 100 : progressPercent}%` }}
                 />
               </div>
             </div>

--- a/src/components/settings/AboutSection.jsx
+++ b/src/components/settings/AboutSection.jsx
@@ -16,10 +16,18 @@ export default function AboutSection({
   onDownloadUpdate,
 }) {
   const { t } = useTranslation();
+  const phase = downloadProgress?.phase || 'downloading';
   const hasValidTotal = downloading && downloadProgress.contentLength > 0;
   const progressPercent = hasValidTotal
       ? Math.round((downloadProgress.downloaded / downloadProgress.contentLength) * 100)
       : 0;
+  const isApplying = phase === 'applying';
+  const isExtracting = phase === 'extracting';
+  const statusLabel = isApplying
+    ? t('updateModal.applying')
+    : isExtracting
+      ? t('updateModal.extracting')
+      : t('updateModal.downloading');
 
   const renderUpdateButton = () => {
     if (downloading) {
@@ -28,11 +36,13 @@ export default function AboutSection({
           <div className="w-full h-2 bg-ide-bg rounded-full overflow-hidden">
             <div
               className="h-full bg-ide-accent rounded-full transition-all duration-300"
-              style={{ width: `${progressPercent}%` }}
+              style={{ width: `${isApplying || isExtracting ? 100 : progressPercent}%` }}
             />
           </div>
           <div className="text-[10px] text-ide-muted text-center">
-            {hasValidTotal ? `${progressPercent}%` : `${(downloadProgress.downloaded / 1024 / 1024).toFixed(1)} MB`}
+            {isApplying || isExtracting
+              ? statusLabel
+              : hasValidTotal ? `${progressPercent}%` : `${(downloadProgress.downloaded / 1024 / 1024).toFixed(1)} MB`}
           </div>
         </div>
       );

--- a/src/components/settings/SettingsDialog.jsx
+++ b/src/components/settings/SettingsDialog.jsx
@@ -410,7 +410,7 @@ function SettingsDialog({
   const handleDownloadUpdate = async () => {
     if (!updateInfo) return;
     setDownloading(true);
-    setDownloadProgress({ downloaded: 0, contentLength: 0 });
+    setDownloadProgress({ phase: 'downloading', downloaded: 0, contentLength: 0 });
     try {
       await downloadAndInstallUpdate((progress) => {
         setDownloadProgress(progress);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -628,6 +628,8 @@
     "hide": "Hide to Background",
     "retry": "Retry",
     "downloading": "Downloading...",
+    "extracting": "Extracting update...",
+    "applying": "Applying update...",
     "downloadFailed": "Download failed: {{error}}",
     "criticalNotice": "This update includes important security fixes or feature improvements. To ensure your data safety and the best experience, needs update as soon as possible."
   },

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -563,6 +563,8 @@
     "hide": "隐藏到后台",
     "retry": "重试",
     "downloading": "正在下载...",
+    "extracting": "正在解压更新...",
+    "applying": "正在应用更新...",
     "downloadFailed": "下载失败: {{error}}",
     "criticalNotice": "该更新包含重要的安全修复或功能改进，为了您的数据安全和最佳体验，需要尽快更新。"
   },

--- a/src/lib/update_api.js
+++ b/src/lib/update_api.js
@@ -23,10 +23,15 @@ export async function checkForUpdate() {
  * @param {function} [onProgress] - Progress callback ({ downloaded, contentLength })
  */
 export async function downloadAndInstallUpdate(onProgress) {
+  const emitProgress = (progress) => {
+    if (onProgress) onProgress(progress);
+  };
+
   // Listen for download progress events
   const unlisten = onProgress
     ? await listen('updater-download-progress', (event) => {
-        onProgress({
+        emitProgress({
+          phase: 'downloading',
           downloaded: event.payload.downloaded,
           contentLength: event.payload.content_length,
         });
@@ -34,14 +39,12 @@ export async function downloadAndInstallUpdate(onProgress) {
     : null;
 
   try {
+    emitProgress({ phase: 'downloading', downloaded: 0, contentLength: 0 });
     await invoke('updater_download');
 
-    // Signal 100% before extract phase
-    if (onProgress) {
-      onProgress({ downloaded: 1, contentLength: 1 });
-    }
-
+    emitProgress({ phase: 'extracting', downloaded: 1, contentLength: 1 });
     await invoke('updater_extract');
+    emitProgress({ phase: 'applying', downloaded: 1, contentLength: 1 });
     await invoke('updater_apply');
   } finally {
     if (unlisten) unlisten();

--- a/src/lib/update_api.test.js
+++ b/src/lib/update_api.test.js
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { downloadAndInstallUpdate } from './update_api';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}));
+
+describe('downloadAndInstallUpdate', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    listen.mockReset();
+  });
+
+  it('reports explicit phases after download reaches 100 percent', async () => {
+    const unlisten = vi.fn();
+    const progressEvents = [];
+
+    listen.mockResolvedValue(unlisten);
+    invoke.mockResolvedValue(undefined);
+
+    await downloadAndInstallUpdate((progress) => {
+      progressEvents.push(progress);
+    });
+
+    expect(listen).toHaveBeenCalledWith('updater-download-progress', expect.any(Function));
+    expect(invoke.mock.calls.map(([command]) => command)).toEqual([
+      'updater_download',
+      'updater_extract',
+      'updater_apply',
+    ]);
+    expect(progressEvents).toEqual([
+      { phase: 'downloading', downloaded: 0, contentLength: 0 },
+      { phase: 'extracting', downloaded: 1, contentLength: 1 },
+      { phase: 'applying', downloaded: 1, contentLength: 1 },
+    ]);
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- prevent updater apply from hanging indefinitely while stopping the monitor before writing the update script
- avoid holding the persistent monitor IPC mutex across awaited pipe requests
- show explicit update phases after download completes instead of leaving the UI at a misleading 100% download state
- add a frontend regression test for update phase reporting

## Root cause
The v0.8.0 monitor IPC reuse path held `python_ipc_client` while awaiting IPC responses. During update apply, `stop_monitor()` later needed the same client state for cleanup. If a long monitor IPC request was active, the updater could remain stuck after extraction and before `update.ps1` was written, leaving the UI at 100%.

## Tests
- `npm run test:rust`
- `npm run test:frontend`
- `npm run i18n:check`
- `npm run build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff --check`
