### PR TITLE
Fix updater apply hang and add release smoke gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,64 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/generate-latest-json.mjs ${{ github.ref_name }} release_body.txt
 
+      - name: Smoke test previous stable portable update
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARBONPAPER_UPDATE_SMOKE_MIN_PREVIOUS_VERSION: ${{ vars.CARBONPAPER_UPDATE_SMOKE_MIN_PREVIOUS_VERSION }}
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          $zipFile = "src-tauri/target/release/bundle/nsis/carbonpaper_${version}_x64_portable.zip"
+          $latestJson = "src-tauri/target/release/bundle/nsis/latest.json"
+          $args = @(
+            "-TargetTag", "${{ github.ref_name }}",
+            "-TargetVersion", $version,
+            "-CandidateZip", $zipFile,
+            "-LatestJson", $latestJson,
+            "-TimeoutSeconds", "180",
+            "-SkipIfPreviousReleaseLacksSmokeSupport"
+          )
+          if (-not [string]::IsNullOrWhiteSpace($env:CARBONPAPER_UPDATE_SMOKE_MIN_PREVIOUS_VERSION)) {
+            $args += @("-MinPreviousVersionWithSmokeHook", $env:CARBONPAPER_UPDATE_SMOKE_MIN_PREVIOUS_VERSION)
+          }
+          ./scripts/update-smoke.ps1 @args
+
+      - name: Build forward update smoke target
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          $core = ($version -split '[-+]')[0]
+          $parts = $core.Split('.')
+          if ($parts.Count -ne 3) {
+            throw "Cannot derive forward smoke version from tag version '$version'"
+          }
+          $patch = [int]$parts[2] + 1
+          $futureVersion = "$($parts[0]).$($parts[1]).$patch"
+          "CARBONPAPER_FORWARD_SMOKE_VERSION=$futureVersion" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+          node scripts/bump-version.mjs $futureVersion --label ""
+          npm run tauri -- build --no-bundle
+          npm run pack:portable
+
+      - name: Smoke test candidate forward portable update
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          $futureVersion = $env:CARBONPAPER_FORWARD_SMOKE_VERSION
+          $candidateZip = "src-tauri/target/release/bundle/nsis/carbonpaper_${version}_x64_portable.zip"
+          $futureZip = "src-tauri/target/release/bundle/nsis/carbonpaper_${futureVersion}_x64_portable.zip"
+          $latestJson = "src-tauri/target/release/bundle/nsis/latest.json"
+          ./scripts/update-smoke.ps1 `
+            -TargetTag "${{ github.ref_name }}" `
+            -TargetVersion $futureVersion `
+            -ManifestVersion $futureVersion `
+            -ExpectedAppVersion $futureVersion `
+            -SourcePortableZip $candidateZip `
+            -CandidateZip $futureZip `
+            -LatestJson $latestJson `
+            -TimeoutSeconds 180 `
+            -RequireAppliedMarker
+
       - name: Upload portable zip and latest.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,13 @@ jobs:
       - name: Build NMH binary
         run: npm run build:nmh:release
 
-      - name: Build and release with Tauri
+      - name: Build Tauri draft release
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: ${{ github.ref_name }}
+          releaseDraft: true
 
       - name: Build portable zip
         run: npm run pack:portable
@@ -126,3 +127,8 @@ jobs:
           $zipFile = "src-tauri/target/release/bundle/nsis/carbonpaper_${version}_x64_portable.zip"
           $latestJson = "src-tauri/target/release/bundle/nsis/latest.json"
           gh release upload ${{ github.ref_name }} $zipFile $latestJson --clobber
+
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit ${{ github.ref_name }} --draft=false

--- a/scripts/generate-latest-json.mjs
+++ b/scripts/generate-latest-json.mjs
@@ -82,6 +82,7 @@ const latestJson = {
   notes,
   pub_date: new Date().toISOString(),
   critical,
+  update_smoke_supported: true,
 };
 
 if (min_version) {

--- a/scripts/update-smoke.ps1
+++ b/scripts/update-smoke.ps1
@@ -1,0 +1,541 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [string]$TargetTag,
+    [string]$TargetVersion,
+    [string]$CandidateZip,
+    [string]$LatestJson,
+    [string]$SourcePortableZip,
+    [string]$PreviousTag,
+    [string]$OldPortableZip,
+    [string]$ProductName = "carbonpaper",
+    [string]$ManifestVersion,
+    [string]$ExpectedAppVersion,
+    [int]$TimeoutSeconds = 180,
+    [string]$MinPreviousVersionWithSmokeHook = $env:CARBONPAPER_UPDATE_SMOKE_MIN_PREVIOUS_VERSION,
+    [switch]$SkipIfPreviousReleaseLacksSmokeSupport,
+    [switch]$RequireAppliedMarker,
+    [switch]$KeepWorkDir
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-RepoRoot {
+    return (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..")).Path
+}
+
+function Read-ProjectVersion {
+    param([string]$RepoRoot)
+
+    $tauriConfPath = Join-Path $RepoRoot "src-tauri\tauri.conf.json"
+    $tauriConf = Get-Content -LiteralPath $tauriConfPath -Raw | ConvertFrom-Json
+    return [string]$tauriConf.version
+}
+
+function Compare-SemVerCore {
+    param(
+        [Parameter(Mandatory = $true)][string]$Left,
+        [Parameter(Mandatory = $true)][string]$Right
+    )
+
+    $leftCore = (($Left.Trim() -replace '^v', '') -split '[-+]')[0]
+    $rightCore = (($Right.Trim() -replace '^v', '') -split '[-+]')[0]
+    $leftParts = $leftCore -split '\.'
+    $rightParts = $rightCore -split '\.'
+
+    for ($i = 0; $i -lt 3; $i++) {
+        $leftValue = 0
+        $rightValue = 0
+        if ($i -lt $leftParts.Count -and $leftParts[$i] -match '^\d+$') {
+            $leftValue = [int]$leftParts[$i]
+        }
+        if ($i -lt $rightParts.Count -and $rightParts[$i] -match '^\d+$') {
+            $rightValue = [int]$rightParts[$i]
+        }
+        if ($leftValue -lt $rightValue) { return -1 }
+        if ($leftValue -gt $rightValue) { return 1 }
+    }
+
+    return 0
+}
+
+function Get-FreeTcpPort {
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    try {
+        $listener.Start()
+        return ([System.Net.IPEndPoint]$listener.LocalEndpoint).Port
+    } finally {
+        $listener.Stop()
+    }
+}
+
+function Invoke-Gh {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $output = & gh @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+    }
+    return $output
+}
+
+function Resolve-PreviousReleaseTag {
+    param([string]$TargetTag)
+
+    $json = Invoke-Gh -Arguments @(
+        "release", "list",
+        "--limit", "50",
+        "--exclude-drafts",
+        "--exclude-pre-releases",
+        "--json", "tagName,createdAt"
+    )
+    $releases = $json | ConvertFrom-Json
+    foreach ($release in $releases) {
+        if ([string]::IsNullOrWhiteSpace($TargetTag) -or $release.tagName -ne $TargetTag) {
+            return [string]$release.tagName
+        }
+    }
+    return $null
+}
+
+function Download-PreviousPortableZip {
+    param(
+        [Parameter(Mandatory = $true)][string]$PreviousTag,
+        [Parameter(Mandatory = $true)][string]$DestinationDir,
+        [Parameter(Mandatory = $true)][string]$ProductName
+    )
+
+    New-Item -ItemType Directory -Force -Path $DestinationDir | Out-Null
+    Invoke-Gh -Arguments @(
+        "release", "download", $PreviousTag,
+        "--pattern", "*_x64_portable.zip",
+        "--dir", $DestinationDir,
+        "--clobber"
+    ) | Out-Null
+
+    $preferredPattern = "${ProductName}_*_x64_portable.zip"
+    $zip = Get-ChildItem -LiteralPath $DestinationDir -Filter $preferredPattern -File |
+        Sort-Object Name |
+        Select-Object -First 1
+    if (-not $zip) {
+        $zip = Get-ChildItem -LiteralPath $DestinationDir -Filter "*_x64_portable.zip" -File |
+            Sort-Object Name |
+            Select-Object -First 1
+    }
+    if (-not $zip) {
+        throw "Previous release $PreviousTag does not contain a portable zip asset."
+    }
+
+    return $zip.FullName
+}
+
+function Test-PreviousReleaseSmokeSupport {
+    param([Parameter(Mandatory = $true)][string]$PreviousTag)
+
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "carbonpaper-update-smoke-manifest-$([guid]::NewGuid().ToString('N'))"
+    try {
+        New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+        try {
+            Invoke-Gh -Arguments @(
+                "release", "download", $PreviousTag,
+                "--pattern", "latest.json",
+                "--dir", $tempDir,
+                "--clobber"
+            ) | Out-Null
+        } catch {
+            return $false
+        }
+
+        $manifestFile = Get-ChildItem -LiteralPath $tempDir -Filter "latest.json" -File |
+            Select-Object -First 1
+        if (-not $manifestFile) {
+            return $false
+        }
+
+        $manifest = Get-Content -LiteralPath $manifestFile.FullName -Raw | ConvertFrom-Json
+        return ($manifest.update_smoke_supported -eq $true)
+    } catch {
+        return $false
+    } finally {
+        Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Write-StaticServerScript {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    @'
+import http from "node:http";
+import { createReadStream, existsSync, statSync } from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(process.argv[2]);
+const port = Number(process.argv[3]);
+const rootPrefix = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+
+function sendText(res, status, text) {
+  res.writeHead(status, { "Content-Type": "text/plain; charset=utf-8" });
+  res.end(text);
+}
+
+const server = http.createServer((req, res) => {
+  try {
+    const parsed = new URL(req.url, "http://127.0.0.1");
+    const rel = decodeURIComponent(parsed.pathname).replace(/^\/+/, "") || "latest.json";
+    const filePath = path.resolve(root, rel);
+
+    if (filePath !== root && !filePath.startsWith(rootPrefix)) {
+      sendText(res, 403, "forbidden");
+      return;
+    }
+    if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+      sendText(res, 404, "not found");
+      return;
+    }
+
+    const stat = statSync(filePath);
+    const contentType = filePath.endsWith(".json")
+      ? "application/json"
+      : filePath.endsWith(".zip")
+        ? "application/zip"
+        : "application/octet-stream";
+    res.writeHead(200, {
+      "Content-Type": contentType,
+      "Content-Length": stat.size,
+      "Cache-Control": "no-store",
+    });
+    createReadStream(filePath).pipe(res);
+  } catch (error) {
+    sendText(res, 500, String(error?.stack || error));
+  }
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`serving ${root} on http://127.0.0.1:${port}`);
+});
+'@ | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
+function Wait-ForServer {
+    param(
+        [Parameter(Mandatory = $true)][string]$ManifestUrl,
+        [Parameter(Mandatory = $true)]$ServerProcess,
+        [Parameter(Mandatory = $true)][string]$ServerErrorLog
+    )
+
+    $deadline = (Get-Date).AddSeconds(20)
+    while ((Get-Date) -lt $deadline) {
+        if ($ServerProcess.HasExited) {
+            $serverError = if (Test-Path -LiteralPath $ServerErrorLog) {
+                Get-Content -LiteralPath $ServerErrorLog -Raw
+            } else {
+                ""
+            }
+            throw "Local update manifest server exited early. $serverError"
+        }
+
+        try {
+            Invoke-WebRequest -Uri $ManifestUrl -UseBasicParsing -TimeoutSec 2 | Out-Null
+            return
+        } catch {
+            Start-Sleep -Milliseconds 500
+        }
+    }
+
+    throw "Timed out waiting for local update manifest server at $ManifestUrl"
+}
+
+function Write-SmokeManifest {
+    param(
+        [Parameter(Mandatory = $true)][string]$LatestJson,
+        [Parameter(Mandatory = $true)][string]$OutPath,
+        [Parameter(Mandatory = $true)][string]$CandidateUrl,
+        [Parameter(Mandatory = $true)][string]$ManifestVersion,
+        [Parameter(Mandatory = $true)][string]$CandidateSha256
+    )
+
+    $manifest = Get-Content -LiteralPath $LatestJson -Raw | ConvertFrom-Json
+    if ($manifest.PSObject.Properties.Name -contains "version") {
+        $manifest.version = $ManifestVersion
+    } else {
+        $manifest | Add-Member -NotePropertyName "version" -NotePropertyValue $ManifestVersion
+    }
+    if ($manifest.PSObject.Properties.Name -contains "url") {
+        $manifest.url = $CandidateUrl
+    } else {
+        $manifest | Add-Member -NotePropertyName "url" -NotePropertyValue $CandidateUrl
+    }
+    if ($manifest.PSObject.Properties.Name -contains "sha256") {
+        $manifest.sha256 = $CandidateSha256
+    } else {
+        $manifest | Add-Member -NotePropertyName "sha256" -NotePropertyValue $CandidateSha256
+    }
+    $manifest | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $OutPath -Encoding UTF8
+}
+
+function Save-ProcessEnvironment {
+    param([string[]]$Names)
+
+    $saved = @{}
+    foreach ($name in $Names) {
+        $saved[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
+    }
+    return $saved
+}
+
+function Restore-ProcessEnvironment {
+    param([hashtable]$Saved)
+
+    foreach ($name in $Saved.Keys) {
+        if ($null -eq $Saved[$name]) {
+            Remove-Item -LiteralPath "Env:\$name" -ErrorAction SilentlyContinue
+        } else {
+            Set-Item -LiteralPath "Env:\$name" -Value $Saved[$name]
+        }
+    }
+}
+
+function Stop-SmokeProcesses {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProductName,
+        [Parameter(Mandatory = $true)][string]$InstallDir
+    )
+
+    $installPrefix = (Resolve-Path -LiteralPath $InstallDir).Path
+    Get-Process -Name $ProductName -ErrorAction SilentlyContinue |
+        Where-Object {
+            try {
+                $_.Path -and $_.Path.StartsWith($installPrefix, [System.StringComparison]::OrdinalIgnoreCase)
+            } catch {
+                $false
+            }
+        } |
+        Stop-Process -Force -ErrorAction SilentlyContinue
+}
+
+$repoRoot = Get-RepoRoot
+if ([string]::IsNullOrWhiteSpace($TargetVersion)) {
+    if (-not [string]::IsNullOrWhiteSpace($TargetTag)) {
+        $TargetVersion = $TargetTag.TrimStart("v")
+    } else {
+        $TargetVersion = Read-ProjectVersion -RepoRoot $repoRoot
+    }
+}
+if ([string]::IsNullOrWhiteSpace($TargetTag)) {
+    $TargetTag = "v$TargetVersion"
+}
+if ([string]::IsNullOrWhiteSpace($ManifestVersion)) {
+    $ManifestVersion = $TargetVersion
+}
+if ([string]::IsNullOrWhiteSpace($ExpectedAppVersion)) {
+    $ExpectedAppVersion = $TargetVersion
+}
+if ([string]::IsNullOrWhiteSpace($CandidateZip)) {
+    $CandidateZip = Join-Path $repoRoot "src-tauri\target\release\bundle\nsis\${ProductName}_${TargetVersion}_x64_portable.zip"
+}
+if ([string]::IsNullOrWhiteSpace($LatestJson)) {
+    $LatestJson = Join-Path $repoRoot "src-tauri\target\release\bundle\nsis\latest.json"
+}
+if ([string]::IsNullOrWhiteSpace($SourcePortableZip) -and -not [string]::IsNullOrWhiteSpace($OldPortableZip)) {
+    $SourcePortableZip = $OldPortableZip
+}
+
+$candidateZipPath = (Resolve-Path -LiteralPath $CandidateZip).Path
+$latestJsonPath = (Resolve-Path -LiteralPath $LatestJson).Path
+
+if ([string]::IsNullOrWhiteSpace($SourcePortableZip)) {
+    if ([string]::IsNullOrWhiteSpace($PreviousTag)) {
+        $PreviousTag = Resolve-PreviousReleaseTag -TargetTag $TargetTag
+    }
+    if ([string]::IsNullOrWhiteSpace($PreviousTag)) {
+        Write-Host "No previous stable release found. Skipping update smoke test for bootstrap release."
+        exit 0
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($MinPreviousVersionWithSmokeHook)) {
+        $previousVersion = $PreviousTag.TrimStart("v")
+        if ((Compare-SemVerCore -Left $previousVersion -Right $MinPreviousVersionWithSmokeHook) -lt 0) {
+            Write-Host "Previous release $PreviousTag is older than smoke-hook baseline $MinPreviousVersionWithSmokeHook. Skipping bootstrap smoke test."
+            exit 0
+        }
+    }
+
+    if ($SkipIfPreviousReleaseLacksSmokeSupport) {
+        if (-not (Test-PreviousReleaseSmokeSupport -PreviousTag $PreviousTag)) {
+            Write-Host "Previous release $PreviousTag does not advertise update_smoke_supported=true. Skipping bootstrap smoke test."
+            exit 0
+        }
+    }
+}
+
+$existing = Get-Process -Name $ProductName -ErrorAction SilentlyContinue
+if ($existing) {
+    $ids = ($existing | ForEach-Object { $_.Id }) -join ", "
+    throw "$ProductName is already running (pid: $ids). Stop it before running update smoke test."
+}
+
+$workDir = Join-Path ([System.IO.Path]::GetTempPath()) "carbonpaper-update-smoke-$([guid]::NewGuid().ToString('N'))"
+$httpRoot = Join-Path $workDir "http"
+$oldInstallDir = Join-Path $workDir "old-install"
+$previousDownloadDir = Join-Path $workDir "previous-release"
+$localAppData = Join-Path $workDir "localappdata"
+$roamingAppData = Join-Path $workDir "appdata"
+$resultFile = Join-Path $workDir "update-smoke-result.json"
+$serverScript = Join-Path $workDir "server.mjs"
+$serverOut = Join-Path $workDir "server.out.log"
+$serverErr = Join-Path $workDir "server.err.log"
+$serverProcess = $null
+$succeeded = $false
+$envNames = @(
+    "CARBONPAPER_UPDATE_SMOKE_TEST",
+    "CARBONPAPER_UPDATE_MANIFEST_URL",
+    "CARBONPAPER_UPDATE_SMOKE_RESULT",
+    "CARBONPAPER_UPDATE_SMOKE_EXPECTED_VERSION",
+    "CARBONPAPER_UPDATE_SMOKE_EXPECTED_MANIFEST_VERSION",
+    "CARBONPAPER_UPDATE_SMOKE_REQUIRE_APPLIED",
+    "CARBONPAPER_UPDATE_SMOKE_APPLIED",
+    "CARBONPAPER_START_HIDDEN",
+    "LOCALAPPDATA",
+    "APPDATA"
+)
+$savedEnv = Save-ProcessEnvironment -Names $envNames
+
+try {
+    New-Item -ItemType Directory -Force -Path $httpRoot, $oldInstallDir, $localAppData, $roamingAppData | Out-Null
+
+    if ([string]::IsNullOrWhiteSpace($SourcePortableZip)) {
+        Write-Host "Downloading previous portable zip from release $PreviousTag..."
+        $SourcePortableZip = Download-PreviousPortableZip -PreviousTag $PreviousTag -DestinationDir $previousDownloadDir -ProductName $ProductName
+    }
+    $sourcePortableZipPath = (Resolve-Path -LiteralPath $SourcePortableZip).Path
+
+    Write-Host "Expanding source portable zip: $sourcePortableZipPath"
+    Expand-Archive -LiteralPath $sourcePortableZipPath -DestinationPath $oldInstallDir -Force
+    $oldExe = Join-Path $oldInstallDir "$ProductName.exe"
+    if (-not (Test-Path -LiteralPath $oldExe)) {
+        $oldExe = Get-ChildItem -LiteralPath $oldInstallDir -Filter "$ProductName.exe" -Recurse -File |
+            Select-Object -First 1 |
+            ForEach-Object { $_.FullName }
+    }
+    if (-not $oldExe -or -not (Test-Path -LiteralPath $oldExe)) {
+        throw "Could not find $ProductName.exe in extracted previous portable zip."
+    }
+
+    $candidateZipName = Split-Path -Leaf $candidateZipPath
+    $candidateSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $candidateZipPath).Hash.ToLowerInvariant()
+    Copy-Item -LiteralPath $candidateZipPath -Destination (Join-Path $httpRoot $candidateZipName) -Force
+
+    $port = Get-FreeTcpPort
+    $candidateUrl = "http://127.0.0.1:$port/$candidateZipName"
+    $manifestUrl = "http://127.0.0.1:$port/latest.json"
+    Write-SmokeManifest -LatestJson $latestJsonPath -OutPath (Join-Path $httpRoot "latest.json") -CandidateUrl $candidateUrl -ManifestVersion $ManifestVersion -CandidateSha256 $candidateSha256
+    Write-StaticServerScript -Path $serverScript
+
+    Write-Host "Starting local update server: $manifestUrl"
+    $serverProcess = Start-Process -FilePath "node" `
+        -ArgumentList @("`"$serverScript`"", "`"$httpRoot`"", "$port") `
+        -PassThru `
+        -WindowStyle Hidden `
+        -RedirectStandardOutput $serverOut `
+        -RedirectStandardError $serverErr
+    Wait-ForServer -ManifestUrl $manifestUrl -ServerProcess $serverProcess -ServerErrorLog $serverErr
+
+    $env:CARBONPAPER_UPDATE_SMOKE_TEST = "1"
+    $env:CARBONPAPER_UPDATE_MANIFEST_URL = $manifestUrl
+    $env:CARBONPAPER_UPDATE_SMOKE_RESULT = $resultFile
+    $env:CARBONPAPER_UPDATE_SMOKE_EXPECTED_VERSION = $ExpectedAppVersion
+    $env:CARBONPAPER_UPDATE_SMOKE_EXPECTED_MANIFEST_VERSION = $ManifestVersion
+    if ($RequireAppliedMarker) {
+        $env:CARBONPAPER_UPDATE_SMOKE_REQUIRE_APPLIED = "1"
+    } else {
+        Remove-Item -LiteralPath "Env:\CARBONPAPER_UPDATE_SMOKE_REQUIRE_APPLIED" -ErrorAction SilentlyContinue
+    }
+    Remove-Item -LiteralPath "Env:\CARBONPAPER_UPDATE_SMOKE_APPLIED" -ErrorAction SilentlyContinue
+    $env:CARBONPAPER_START_HIDDEN = "1"
+    $env:LOCALAPPDATA = $localAppData
+    $env:APPDATA = $roamingAppData
+
+    $updateErrorLog = Join-Path $localAppData "CarbonPaper\update_error.log"
+    Remove-Item -LiteralPath $updateErrorLog -Force -ErrorAction SilentlyContinue
+
+    Write-Host "Starting source app for update smoke test: $oldExe"
+    $oldProcess = Start-Process -FilePath $oldExe `
+        -ArgumentList @("--hidden") `
+        -WorkingDirectory (Split-Path -Parent $oldExe) `
+        -PassThru `
+        -WindowStyle Hidden
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $lastPhase = $null
+    $lastStatus = $null
+    $result = $null
+
+    while ((Get-Date) -lt $deadline) {
+        if ($serverProcess.HasExited) {
+            $serverError = if (Test-Path -LiteralPath $serverErr) { Get-Content -LiteralPath $serverErr -Raw } else { "" }
+            throw "Local update server exited during smoke test. $serverError"
+        }
+
+        if (Test-Path -LiteralPath $resultFile) {
+            try {
+                $result = Get-Content -LiteralPath $resultFile -Raw | ConvertFrom-Json
+            } catch {
+                $result = $null
+            }
+
+            if ($result -and ($result.phase -ne $lastPhase -or $result.status -ne $lastStatus)) {
+                Write-Host "Smoke status: status=$($result.status) phase=$($result.phase) current=$($result.current_version) target=$($result.target_version)"
+                $lastPhase = $result.phase
+                $lastStatus = $result.status
+            }
+
+            if ($result -and $result.status -eq "success") {
+                if ($result.current_version -ne $ExpectedAppVersion) {
+                    throw "Updated app reported version $($result.current_version), expected $ExpectedAppVersion."
+                }
+                if (Test-Path -LiteralPath $updateErrorLog) {
+                    $updateError = Get-Content -LiteralPath $updateErrorLog -Raw
+                    throw "Update script wrote update_error.log: $updateError"
+                }
+                $succeeded = $true
+                Write-Host "Update smoke test passed: source app updated via manifest $ManifestVersion and started app version $ExpectedAppVersion."
+                break
+            }
+
+            if ($result -and $result.status -eq "failure") {
+                throw "Update smoke test failed in app: $($result.error)"
+            }
+        }
+
+        if ($oldProcess.HasExited -and -not (Test-Path -LiteralPath $resultFile)) {
+            throw "Previous app exited before writing update smoke status."
+        }
+
+        Start-Sleep -Seconds 1
+    }
+
+    if (-not $succeeded) {
+        $statusDump = if (Test-Path -LiteralPath $resultFile) {
+            Get-Content -LiteralPath $resultFile -Raw
+        } else {
+            "<no status file>"
+        }
+        throw "Timed out after $TimeoutSeconds seconds waiting for update smoke success. Last status: $statusDump"
+    }
+} finally {
+    Restore-ProcessEnvironment -Saved $savedEnv
+
+    if ($serverProcess -and -not $serverProcess.HasExited) {
+        Stop-Process -Id $serverProcess.Id -Force -ErrorAction SilentlyContinue
+    }
+
+    if (Test-Path -LiteralPath $oldInstallDir) {
+        Stop-SmokeProcesses -ProductName $ProductName -InstallDir $oldInstallDir
+    }
+
+    if ($succeeded -and -not $KeepWorkDir) {
+        Remove-Item -LiteralPath $workDir -Recurse -Force -ErrorAction SilentlyContinue
+    } else {
+        Write-Host "Update smoke work directory: $workDir"
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -728,6 +728,16 @@ pub fn run() {
 
                 build_tray(app)?;
 
+                if updater::is_update_smoke_test_enabled() {
+                    if let Some(window) = app.get_webview_window("main") {
+                        if let Err(e) = window.destroy() {
+                            tracing::warn!("Failed to destroy window for update smoke test: {}", e);
+                        }
+                    }
+                    updater::maybe_run_update_smoke_test(app.handle().clone());
+                    return Ok(());
+                }
+
                 // 只有非隐藏启动时才应用 acrylic 效果
                 if !start_hidden {
                     if let Some(window) = app.get_webview_window("main") {

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -3,13 +3,21 @@ use sha2::{Digest, Sha256};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Mutex;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 
 use crate::registry_config;
 use crate::resource_utils::{file_in_local_appdata, normalize_path_for_command};
 
 const UPDATE_CHECK_URL: &str =
     "https://github.com/White-NX/carbonPaper/releases/latest/download/latest.json";
+const UPDATE_SMOKE_TEST_ENV: &str = "CARBONPAPER_UPDATE_SMOKE_TEST";
+const UPDATE_SMOKE_MANIFEST_URL_ENV: &str = "CARBONPAPER_UPDATE_MANIFEST_URL";
+const UPDATE_SMOKE_RESULT_ENV: &str = "CARBONPAPER_UPDATE_SMOKE_RESULT";
+const UPDATE_SMOKE_EXPECTED_VERSION_ENV: &str = "CARBONPAPER_UPDATE_SMOKE_EXPECTED_VERSION";
+const UPDATE_SMOKE_EXPECTED_MANIFEST_VERSION_ENV: &str =
+    "CARBONPAPER_UPDATE_SMOKE_EXPECTED_MANIFEST_VERSION";
+const UPDATE_SMOKE_REQUIRE_APPLIED_ENV: &str = "CARBONPAPER_UPDATE_SMOKE_REQUIRE_APPLIED";
+const UPDATE_SMOKE_APPLIED_ENV: &str = "CARBONPAPER_UPDATE_SMOKE_APPLIED";
 
 /// Metadata about an available update (version, download URL, SHA256 hash, release notes).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,6 +43,217 @@ impl UpdaterState {
         Self {
             manifest: Mutex::new(None),
         }
+    }
+}
+
+pub(crate) fn is_update_smoke_test_enabled() -> bool {
+    std::env::var(UPDATE_SMOKE_TEST_ENV).ok().as_deref() == Some("1")
+}
+
+fn validate_loopback_update_url(raw: &str) -> Result<(), String> {
+    let url = reqwest::Url::parse(raw)
+        .map_err(|e| format!("Invalid update smoke test URL '{}': {}", raw, e))?;
+    match url.scheme() {
+        "http" | "https" => {}
+        scheme => {
+            return Err(format!(
+                "Update smoke test URL must use http or https, got '{}'",
+                scheme
+            ))
+        }
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| "Update smoke test URL must include a host".to_string())?;
+    let is_loopback = host.eq_ignore_ascii_case("localhost")
+        || host == "127.0.0.1"
+        || host == "::1"
+        || host == "[::1]";
+    if !is_loopback {
+        return Err(format!(
+            "Update smoke test URL must point at localhost, 127.0.0.1, or ::1, got '{}'",
+            host
+        ));
+    }
+
+    Ok(())
+}
+
+fn update_check_url() -> Result<String, String> {
+    if is_update_smoke_test_enabled() {
+        let url = std::env::var(UPDATE_SMOKE_MANIFEST_URL_ENV).map_err(|_| {
+            format!(
+                "{} must be set when {}=1",
+                UPDATE_SMOKE_MANIFEST_URL_ENV, UPDATE_SMOKE_TEST_ENV
+            )
+        })?;
+        validate_loopback_update_url(&url)?;
+        return Ok(url);
+    }
+
+    Ok(UPDATE_CHECK_URL.to_string())
+}
+
+fn write_update_smoke_status(
+    status: &str,
+    phase: &str,
+    current_version: &str,
+    target_version: Option<&str>,
+    error: Option<&str>,
+) {
+    let Ok(path) = std::env::var(UPDATE_SMOKE_RESULT_ENV) else {
+        return;
+    };
+    let path = PathBuf::from(path);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let payload = serde_json::json!({
+        "status": status,
+        "phase": phase,
+        "current_version": current_version,
+        "target_version": target_version,
+        "error": error,
+        "pid": std::process::id(),
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    });
+    let serialized = serde_json::to_string_pretty(&payload)
+        .unwrap_or_else(|_| format!(r#"{{"status":"{}","phase":"{}"}}"#, status, phase));
+    let _ = std::fs::write(path, serialized);
+}
+
+pub(crate) fn maybe_run_update_smoke_test(app: AppHandle) {
+    if !is_update_smoke_test_enabled() {
+        return;
+    }
+
+    tauri::async_runtime::spawn(async move {
+        let current_version = app.config().version.clone().unwrap_or_default();
+        let expected_version = std::env::var(UPDATE_SMOKE_EXPECTED_VERSION_ENV).ok();
+        let expected_manifest_version = std::env::var(UPDATE_SMOKE_EXPECTED_MANIFEST_VERSION_ENV)
+            .ok()
+            .or_else(|| expected_version.clone());
+        let require_applied = std::env::var(UPDATE_SMOKE_REQUIRE_APPLIED_ENV)
+            .ok()
+            .as_deref()
+            == Some("1");
+        let update_applied = std::env::var(UPDATE_SMOKE_APPLIED_ENV).ok().as_deref() == Some("1");
+
+        if expected_version.as_deref() == Some(current_version.as_str())
+            && (!require_applied || update_applied)
+        {
+            tracing::info!(
+                "[UPDATE_SMOKE] expected version {} is running",
+                current_version
+            );
+            write_update_smoke_status(
+                "success",
+                "updated_app_started",
+                &current_version,
+                expected_manifest_version.as_deref(),
+                None,
+            );
+            app.exit(0);
+            return;
+        }
+
+        tracing::info!(
+            "[UPDATE_SMOKE] starting update smoke test current_version={} target_version={:?} final_app_version={:?} require_applied={}",
+            current_version,
+            expected_manifest_version,
+            expected_version,
+            require_applied
+        );
+        write_update_smoke_status(
+            "running",
+            "check_started",
+            &current_version,
+            expected_manifest_version.as_deref(),
+            None,
+        );
+
+        let result = async {
+            let check = updater_check(app.clone(), app.state::<UpdaterState>()).await?;
+            if !check.available {
+                return Err(format!(
+                    "No update available for smoke test (current version {})",
+                    check.current_version
+                ));
+            }
+            if let Some(expected) = expected_manifest_version.as_deref() {
+                if check.version.as_deref() != Some(expected) {
+                    return Err(format!(
+                        "Smoke test manifest points to {:?}, expected {}",
+                        check.version, expected
+                    ));
+                }
+            }
+
+            write_update_smoke_status(
+                "running",
+                "download_started",
+                &current_version,
+                check.version.as_deref(),
+                None,
+            );
+            updater_download(app.clone(), app.state::<UpdaterState>()).await?;
+
+            write_update_smoke_status(
+                "running",
+                "extract_started",
+                &current_version,
+                check.version.as_deref(),
+                None,
+            );
+            updater_extract().await?;
+
+            write_update_smoke_status(
+                "running",
+                "apply_started",
+                &current_version,
+                check.version.as_deref(),
+                None,
+            );
+            updater_apply(
+                app.clone(),
+                app.state::<crate::monitor::MonitorState>(),
+                app.state::<std::sync::Arc<crate::capture::CaptureState>>(),
+            )
+            .await
+        }
+        .await;
+
+        if let Err(e) = result {
+            tracing::error!("[UPDATE_SMOKE] failed: {}", e);
+            write_update_smoke_status(
+                "failure",
+                "failed",
+                &current_version,
+                expected_manifest_version.as_deref(),
+                Some(&e),
+            );
+            app.exit(1);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_loopback_update_url;
+
+    #[test]
+    fn update_smoke_url_allows_loopback_hosts() {
+        assert!(validate_loopback_update_url("http://127.0.0.1:8787/latest.json").is_ok());
+        assert!(validate_loopback_update_url("http://localhost:8787/latest.json").is_ok());
+        assert!(validate_loopback_update_url("http://[::1]:8787/latest.json").is_ok());
+    }
+
+    #[test]
+    fn update_smoke_url_rejects_non_loopback_hosts() {
+        assert!(validate_loopback_update_url("https://example.com/latest.json").is_err());
+        assert!(validate_loopback_update_url("file:///tmp/latest.json").is_err());
     }
 }
 
@@ -80,13 +299,17 @@ pub async fn updater_check(
     app: AppHandle,
     state: tauri::State<'_, UpdaterState>,
 ) -> Result<CheckResult, String> {
-    if !registry_config::get_bool("network_enabled").unwrap_or(true) {
+    if !is_update_smoke_test_enabled()
+        && !registry_config::get_bool("network_enabled").unwrap_or(true)
+    {
         return Err("Network features are disabled".to_string());
     }
     let current_version = app.config().version.clone().unwrap_or_default();
 
-    let response = reqwest::get(UPDATE_CHECK_URL)
+    let response = reqwest::get(update_check_url()?)
         .await
+        .map_err(|e| format!("Failed to fetch update manifest: {}", e))?
+        .error_for_status()
         .map_err(|e| format!("Failed to fetch update manifest: {}", e))?;
 
     let manifest: UpdateManifest = response
@@ -131,7 +354,9 @@ pub async fn updater_download(
     app: AppHandle,
     state: tauri::State<'_, UpdaterState>,
 ) -> Result<(), String> {
-    if !registry_config::get_bool("network_enabled").unwrap_or(true) {
+    if !is_update_smoke_test_enabled()
+        && !registry_config::get_bool("network_enabled").unwrap_or(true)
+    {
         return Err("Network features are disabled".to_string());
     }
     let manifest = state
@@ -140,6 +365,9 @@ pub async fn updater_download(
         .unwrap()
         .clone()
         .ok_or("No update manifest cached. Call updater_check first.")?;
+    if is_update_smoke_test_enabled() {
+        validate_loopback_update_url(&manifest.url)?;
+    }
 
     let staging = staging_dir()?;
     let zip_path = staging.join("update.zip");
@@ -337,7 +565,13 @@ try {{
     Copy-Item -Path '{extract_dir}\*' -Destination '{app_dir}' -Recurse -Force
 
     # Start the updated app
-    Start-Process -FilePath (Join-Path '{app_dir}' '{exe_name}')
+    $updatedExe = Join-Path '{app_dir}' '{exe_name}'
+    if ($env:CARBONPAPER_UPDATE_SMOKE_TEST -eq '1') {{
+        $env:CARBONPAPER_UPDATE_SMOKE_APPLIED = '1'
+        Start-Process -FilePath $updatedExe -WindowStyle Hidden
+    }} else {{
+        Start-Process -FilePath $updatedExe
+    }}
 
     # Cleanup staging directory
     Start-Sleep -Seconds 2


### PR DESCRIPTION
## Summary
- add a timeout around monitor shutdown during update apply so the updater does not hang indefinitely
- add CI-only update smoke hooks with localhost-only manifest/package overrides
- add release workflow gates for previous stable -> candidate and candidate -> temporary future update paths
- generate `update_smoke_supported` in latest.json so the first bootstrap release can skip unsupported historical clients

## Verification
- cargo test --manifest-path src-tauri\\Cargo.toml --lib
- pwsh parser check for scripts/update-smoke.ps1
- node --check scripts/generate-latest-json.mjs
- git diff --check