### PR TITLE
storage: add internal CLIP migration baseline

### DIFF
--- a/monitor/requirements.txt
+++ b/monitor/requirements.txt
@@ -8,7 +8,9 @@ onnxruntime-directml==1.24.2
 
 transformers>=4.30.0
 torch
-chromadb>=0.4.0
+# Pinned: ChromaDB on-disk format is not stable across major versions and the
+# vector store is treated as a rebuildable cache keyed to this exact version.
+chromadb==1.5.1
 
 numpy<2.0.0
 

--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -103,7 +103,7 @@ fn compose_index_health_response(
         .as_ref()
         .and_then(|value| value.get("worker_storage_ipc"))
         .cloned();
-    let vector_rows_count = vector_stats
+    let actual_clip_image_rows = vector_stats
         .as_ref()
         .and_then(|stats| value_as_i64(stats.get("count")));
     let pending_retry_queue_count = postprocess
@@ -130,11 +130,40 @@ fn compose_index_health_response(
         })
         .unwrap_or(serde_json::Value::Null);
 
+    // Count-level CLIP image-index check (Milestone 1): compares the
+    // SQLite-derived eligibility estimate against the live Python Chroma
+    // `screenshots` collection count. This is not a per-row or vector-quality
+    // check; equal counts can still hide missing/orphan swaps.
+    let clip_image_index = match actual_clip_image_rows {
+        Some(actual) => {
+            let expected = storage_stats.expected_clip_image_rows;
+            let missing = (expected - actual).max(0);
+            let orphaned = (actual - expected).max(0);
+            serde_json::json!({
+                "expected_eligible_images": expected,
+                "actual_rows": actual,
+                "missing_lower_bound": missing,
+                "orphaned_lower_bound": orphaned,
+                "assessment": if missing == 0 && orphaned == 0 { "count_match" } else { "count_mismatch" },
+                "eligibility": "active screenshot with active OCR row",
+                "eligibility_is_proxy": true,
+            })
+        }
+        None => serde_json::json!({
+            "expected_eligible_images": storage_stats.expected_clip_image_rows,
+            "actual_rows": serde_json::Value::Null,
+            "assessment": "unknown",
+            "eligibility": "active screenshot with active OCR row",
+            "eligibility_is_proxy": true,
+        }),
+    };
+
     serde_json::json!({
         "status": "success",
         "screenshots_count": storage_stats.screenshots_count,
         "ocr_rows_count": storage_stats.ocr_rows_count,
-        "vector_rows_count": vector_rows_count,
+        "vector_rows_count": actual_clip_image_rows,
+        "clip_image_index": clip_image_index,
         "pending_retry_queue_count": pending_retry_queue_count,
         "smart_cluster_pending_count": storage_stats.smart_cluster_pending_count,
         "delete_queue": storage_stats.delete_queue,
@@ -209,6 +238,7 @@ mod tests {
         let storage_stats = IndexStorageStats {
             screenshots_count: 10,
             ocr_rows_count: 12,
+            expected_clip_image_rows: 9,
             smart_cluster_pending_count: 3,
             delete_queue: DeleteQueueStatus {
                 pending_screenshots: 1,
@@ -232,9 +262,42 @@ mod tests {
         assert_eq!(response["screenshots_count"], 10);
         assert_eq!(response["ocr_rows_count"], 12);
         assert_eq!(response["vector_rows_count"], 9);
+        assert_eq!(response["clip_image_index"]["actual_rows"], 9);
+        assert_eq!(response["clip_image_index"]["expected_eligible_images"], 9);
+        assert_eq!(response["clip_image_index"]["assessment"], "count_match");
+        assert_eq!(response["clip_image_index"]["missing_lower_bound"], 0);
         assert_eq!(response["pending_retry_queue_count"], 4);
         assert_eq!(response["monitor_available"], true);
         assert_eq!(response["last_indexing_error"], "chroma down");
+    }
+
+    #[test]
+    fn compose_index_health_response_reports_clip_image_count_mismatch() {
+        let storage_stats = IndexStorageStats {
+            screenshots_count: 20,
+            ocr_rows_count: 40,
+            expected_clip_image_rows: 15,
+            smart_cluster_pending_count: 0,
+            delete_queue: DeleteQueueStatus {
+                pending_screenshots: 0,
+                pending_ocr: 0,
+                running: false,
+            },
+        };
+        let monitor_health = Ok(json!({
+            "status": "success",
+            "worker_started": true,
+            "stats": { "vector_stats": { "count": 9 } },
+            "postprocess": {}
+        }));
+
+        let response = compose_index_health_response(storage_stats, monitor_health);
+
+        assert_eq!(response["clip_image_index"]["assessment"], "count_mismatch");
+        assert_eq!(response["clip_image_index"]["expected_eligible_images"], 15);
+        assert_eq!(response["clip_image_index"]["actual_rows"], 9);
+        assert_eq!(response["clip_image_index"]["missing_lower_bound"], 6);
+        assert_eq!(response["clip_image_index"]["orphaned_lower_bound"], 0);
     }
 
     #[test]
@@ -242,6 +305,7 @@ mod tests {
         let storage_stats = IndexStorageStats {
             screenshots_count: 10,
             ocr_rows_count: 12,
+            expected_clip_image_rows: 9,
             smart_cluster_pending_count: 3,
             delete_queue: DeleteQueueStatus {
                 pending_screenshots: 1,
@@ -255,6 +319,12 @@ mod tests {
 
         assert_eq!(response["screenshots_count"], 10);
         assert_eq!(response["vector_rows_count"], serde_json::Value::Null);
+        assert_eq!(response["clip_image_index"]["assessment"], "unknown");
+        assert_eq!(response["clip_image_index"]["expected_eligible_images"], 9);
+        assert_eq!(
+            response["clip_image_index"]["actual_rows"],
+            serde_json::Value::Null
+        );
         assert_eq!(response["monitor_available"], false);
         assert_eq!(response["monitor_error"], "Monitor not started");
     }

--- a/src-tauri/src/storage/screenshot.rs
+++ b/src-tauri/src/storage/screenshot.rs
@@ -1261,10 +1261,37 @@ impl StorageState {
         .map_err(|e| format!("Failed to count active OCR rows: {}", e))
     }
 
+    /// Estimated expected row count for the derived CLIP image index.
+    ///
+    /// Semantics (Milestone 1): a vector row is expected for every DISTINCT
+    /// `image_hash` among non-deleted screenshots that have at least one
+    /// active OCR row. Distinct-hash because the vector collection is keyed by
+    /// image hash, so duplicate captures share one row. OCR-row existence is a
+    /// stable migration-baseline proxy; Milestone 2 replaces it with a
+    /// first-party per-row ledger.
+    pub fn count_expected_clip_image_rows(&self) -> Result<i64, String> {
+        let guard = self.get_connection_named("count_expected_clip_image_rows")?;
+        let conn = guard
+            .as_ref()
+            .ok_or_else(|| "Database connection is None".to_string())?;
+        conn.query_row(
+            "SELECT COUNT(DISTINCT s.image_hash) FROM screenshots s
+             WHERE s.is_deleted = 0
+               AND EXISTS (
+                   SELECT 1 FROM ocr_results o
+                    WHERE o.screenshot_id = s.id AND o.is_deleted = 0
+               )",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|e| format!("Failed to count expected CLIP image rows: {}", e))
+    }
+
     pub fn get_index_storage_stats(&self) -> Result<IndexStorageStats, String> {
         Ok(IndexStorageStats {
             screenshots_count: self.count_active_screenshots()?,
             ocr_rows_count: self.count_active_ocr_rows()?,
+            expected_clip_image_rows: self.count_expected_clip_image_rows()?,
             smart_cluster_pending_count: self.count_smart_cluster_pending()?,
             delete_queue: self.get_delete_queue_status()?,
         })
@@ -2957,6 +2984,42 @@ mod ocr_lifecycle_tests {
         assert_eq!(ocr_postprocess_retry_decision(3), ("pending", Some(300), 4));
         assert_eq!(ocr_postprocess_retry_decision(4), ("failed", None, 5));
         assert_eq!(ocr_postprocess_retry_decision(99), ("failed", None, 100));
+    }
+
+    #[test]
+    fn expected_clip_images_are_not_counted_per_ocr_row() {
+        let temp = tempfile::tempdir().expect("temp storage directory");
+        let credential_state = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        let storage = StorageState::new(temp.path().to_path_buf(), credential_state);
+        let connection = Connection::open_in_memory().expect("in-memory database");
+        connection
+            .execute_batch(
+                "CREATE TABLE screenshots (
+                    id INTEGER PRIMARY KEY,
+                    image_hash TEXT NOT NULL,
+                    is_deleted INTEGER NOT NULL DEFAULT 0
+                 );
+                 CREATE TABLE ocr_results (
+                    screenshot_id INTEGER NOT NULL,
+                    is_deleted INTEGER NOT NULL DEFAULT 0
+                 );
+                 INSERT INTO screenshots (id, image_hash, is_deleted) VALUES
+                    (1, 'h1', 0),
+                    (2, 'h1', 0),
+                    (3, 'h2', 0),
+                    (4, 'h3', 0),
+                    (5, 'h4', 1),
+                    (6, 'h5', 0);
+                 INSERT INTO ocr_results (screenshot_id, is_deleted) VALUES
+                    (1, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0);
+                 ",
+            )
+            .expect("CLIP eligibility fixture");
+        *storage.db.lock().unwrap_or_else(|e| e.into_inner()) = Some(connection);
+
+        // h1 is one image vector despite three OCR rows; h2/h3 each contribute
+        // one; h4 is deleted; h5 has no OCR row.
+        assert_eq!(storage.count_expected_clip_image_rows().unwrap(), 3);
     }
 
     #[test]

--- a/src-tauri/src/storage/types.rs
+++ b/src-tauri/src/storage/types.rs
@@ -379,6 +379,10 @@ pub struct DeleteQueueStatus {
 pub struct IndexStorageStats {
     pub screenshots_count: i64,
     pub ocr_rows_count: i64,
+    /// Distinct image hashes estimated to be eligible for one CLIP image row
+    /// (non-deleted screenshots with at least one active OCR row). This is a
+    /// stable migration proxy, not an OCR-row count or a per-row health proof.
+    pub expected_clip_image_rows: i64,
     pub smart_cluster_pending_count: i64,
     pub delete_queue: DeleteQueueStatus,
 }


### PR DESCRIPTION
## Summary

- pin ChromaDB to the current on-disk cache contract for a reproducible M2 baseline
- add an internal count-only CLIP image-index baseline derived from distinct active image hashes
- document and test that multiple OCR rows or duplicate captures do not inflate the expected CLIP row count

## Scope

- no user-visible UI changes
- no database schema migration
- no claim of complete index health: count equality cannot detect swapped missing/orphan rows
- CLIP visual search remains available while M2 migrates its implementation

## Testing

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` (133 passed)
- targeted `rustfmt --check` for the three changed Rust files
- `git diff --cached --check`
- frontend suite previously verified unchanged (78 passed)
- i18n check previously verified unchanged