### PR TITLE
fix(ci): avoid duplicate release workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  create:
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

- remove the redundant `create` event from the release workflow
- keep `push.tags: v*` as the single release trigger

Creating a version tag emits both `create` and tag `push` events. Since both matched the release job guard, one tag could start two identical release runs.

## Validation

- verified the workflow retains the `v*` tag push trigger
- verified no `create` trigger remains
- `git diff --check`

## User-visible impact

None. Version tags still start the release workflow, but only once.