### PR TITLE
m2: add sentinel-triggered MiniLM migration

### DIFF
--- a/docs/python-removal-roadmap.md
+++ b/docs/python-removal-roadmap.md
@@ -175,8 +175,9 @@ snapshot; SQLite remains authoritative, and the payload can be replaced by an
 ANN layout when the M2.5 query path needs it without changing persistence or
 generation semantics. Runtime publication never deletes finalized sidecars;
 unreferenced generations are cleaned during the next startup, before readers
-are exposed. M2.4 owns paged rebuild/migration orchestration; M2.5 owns
-dual-write and production query cutover.
+are exposed. M2.4 owns the paged MiniLM migration and the temporary
+Chroma/Rust index dual-write; M2.5 owns shadow queries, production query
+cutover, and the later CLIP overlap.
 
 - Prefer a two-layer derived design:
   1. a SQLite `derived_embeddings` cache holding the migrated/generated float32 vector plus `index_kind`, `subject_key`, dimensions, model id/revision, embedding version, source fingerprint, and timestamps;
@@ -189,19 +190,90 @@ dual-write and production query cutover.
 - New vectors become query-visible only after the embedding row and completed ledger state commit. ANN generation lag must be safe: queries use the last complete generation plus a bounded exact-scan delta, or wait for an atomic generation swap.
 - Deletion, model-version invalidation, duplicate image hashes, session lock/unlock, and interrupted writes need first-party tests.
 
-#### M2.4 — Explicit rebuild and Chroma migration
+#### M2.4 — Sentinel-triggered MiniLM migration — DONE 2026-07-24
 
-- Add one explicit, idempotent, paged rebuild/migration command per index kind. It is resumable from the ledger, idle-gated by default, manually forceable, cancellable, and never an automatic unbounded background loop.
-- Migrate `task_vectors` by `screenshot_id`; rehydrate process/title/category/OCR metadata from SQLite rather than trusting Chroma metadata as user truth.
-- Migrate `screenshots` vectors as float arrays, never by routine image re-encoding. Export id/embedding/metadata while the Python/Chroma fallback still exists; decrypt `image_path`, require `memory://<image_hash>`, verify the legacy `md5("memory://" + image_hash)` id, and map to an active SQLite screenshot. Rows that cannot be mapped remain on the legacy backend and block cutover; they are not silently dropped or automatically re-encoded.
-- Keep `task_centroids` and any Chroma operations needed by Python HDBSCAN/PaCMAP until Milestone 4. During the overlap, either continue Python ownership of those collections or dual-write the `task_vectors` inputs it needs. Do not delete `chromadb` from default dependencies in Milestone 2 merely because Rust search has cut over.
+The Chroma `task_vectors` collection is a ~30-day hot layer whose expired
+vectors are compressed into `task_centroids`, so "every SQLite screenshot has
+a MiniLM vector" is **not** a migration completion condition, and the Rust
+coverage denominator for the later cutover gate is the set of valid, mappable
+vectors in the Chroma snapshot — not all screenshots.
+
+The mandatory copy is entirely sentinel-triggered. For each vector-space
+revision, the absence of
+`app_metadata.minilm_auto_migration_done_<revision>` starts one full-scope,
+idempotent copy at startup. The worker waits for Windows Hello unlock before
+reading encrypted OCR inputs. A crash, process exit, or transient worker
+failure leaves the sentinel unset; the next launch/unlock resumes from the
+durable cursor and snapshot. Legacy manual/time-bounded run records are never
+resumed or allowed to settle the sentinel; the automatic mode starts a fresh
+full copy instead.
+Terminally quarantined invalid/orphan rows may finish as
+`completed_with_errors` and still settle the sentinel; transient orchestration
+failures remain unfinished and retry automatically.
+
+The whole run executes under global maintenance mode: a non-dismissable
+full-window overlay, `MAINTENANCE_IN_PROGRESS` rejection at MCP and reverse
+IPC boundaries (with a small session/crypto/status/dual-write allowlist),
+gated monitor start/stop/pause/resume commands, and a paused
+retention/delete-queue loop. Capture is paused for the duration; the previous
+monitor running/paused state is recorded and restored exactly. The migration
+cannot be started from settings and cannot be cancelled; closing the app is
+the only interruption.
+
+The full hot-layer ID snapshot is built asynchronously by an internal Python
+protocol (`start_task_vectors_export` → status polling → exact-id pages →
+`finish_task_vectors_export`), persisted with an atomically renamed manifest
+under `data/migrations/minilm/<export_id>/`, and bounded by a 10-minute logical
+build deadline plus 24 h idle / 7 d hard / 1 h `.tmp` TTLs. It has no
+user-facing time range or cancellation option.
+Pages carry vectors as one little-endian float32 blob in Base64
+(`embeddings_f32_le_b64`, ~256 KB per 128-row page) instead of tens of
+thousands of JSON floats. Run state is durable in
+`minilm_migration_runs` / `minilm_migration_subjects` /
+`minilm_migration_run_errors`: each page commits ledger rows, embeddings,
+counters, and the export cursor in one transaction, so a crash either retries
+an uncommitted page or continues after it, and an interrupted run resumes by
+re-attaching to the persisted snapshot (a snapshot Python can no longer
+restore forces a cursor reset rather than a silently reordered page walk).
+Rust accepts only canonical positive screenshot ids and finite, non-zero
+384-dimensional vectors (zero vectors are quarantined, never imported), maps
+them to active SQLite screenshots, and rehydrates process/title/category/OCR
+from SQLite. A valid legacy vector whose current SQLite text is empty is still
+copied but marked `legacy_chroma_unverified` instead of being recomputed.
+Orphan Chroma ids, corrupt vectors, and rows that disappear after the snapshot
+remain persisted diagnostics and yield `completed_with_errors`. After the
+copy, a full-scope run deletes Rust `semantic_text` rows outside the snapshot
+scope (`reconcile`), and Python's hot-layer expiry now mirrors deletions to
+Rust through reverse IPC with a persisted retry queue, so the Rust collection
+tracks — rather than outgrows — the Chroma hot layer. A disk preflight
+(`estimated peak × 1.25 + 1 GiB`, with a 64 MiB transient allowance) rejects
+the run before any vector write; generation publication runs on a blocking
+worker with progress phases `publishing_sync` / `publishing_verify` /
+`publishing_commit`. The migration never requests cancellation; the final
+`sync_all` window is surfaced to the user as an uninterruptible safe write.
+
+The MiniLM source contract remains exactly `process | title | OCR[:200]`; its
+versioned fingerprint excludes category and is computed from the final
+Rust-rehydrated model input. Legacy Chroma rows do not record their producing
+runtime, so imported and newly generated vectors share the reviewed
+compatibility contract `minilm-l12-vector-space-v1`. Python capture paths
+best-effort dual-write their vectors to Rust through authenticated reverse IPC;
+Rust ignores Python metadata and recomputes the fingerprint. The migration
+never runs inference to manufacture a missing vector.
+Chroma/Python remains the authoritative query backend in this phase: there is
+no shadow-query or production-query switch in M2.4.
+
+`task_centroids` and all Chroma operations needed by Python HDBSCAN/PaCMAP stay
+unchanged until Milestone 4. The separate CLIP `screenshots` float-copy
+migration remains step 6 of M2.5, immediately before CLIP new-capture
+dual-write and shadow query. `chromadb` therefore remains a default dependency.
 
 #### M2.5 — Dual-write, shadow-query, then cut over by capability
 
 Recommended sequence:
 
 1. MiniLM Rust inference parity.
-2. MiniLM derived-cache/index dual-write and migration.
+2. MiniLM derived-cache/index dual-write and migration. **Done in M2.4.**
 3. Rust semantic shadow queries compared locally with Chroma; Python remains authoritative.
 4. Cut over semantic-text retrieval and Smart Cluster calibration prefilter; keep rollback.
 5. Reranker parity and shadow scoring; cut over calibration only after score/order gates pass. The Python Smart Cluster worker may temporarily call the Rust reranker, but its Python fallback remains until Milestone 3.
@@ -387,6 +459,6 @@ Do not delete a Python component until its Rust replacement has shipped as defau
 
 ## Immediate Next Step
 
-Continue from `m2/derived-vector-store` with M2.4, preferably beginning in `m2/minilm-dual-write-migration`: add an explicit, idempotent, paged, resumable MiniLM rebuild/migration command backed by `derived_index_jobs`; rehydrate process/title/category/OCR inputs from SQLite; dual-write new MiniLM vectors to Chroma and the Rust store; expose progress, cancellation, force-run, and unmappable/error diagnostics. Python/Chroma remains authoritative until the later shadow-query gate passes.
+Continue with M2.5 MiniLM shadow queries: compare Rust semantic retrieval locally against Chroma using the migrated generation and bounded delta path, record score/order parity and latency, and keep Python/Chroma authoritative until the release gate and rollback checks pass. The coverage denominator for that gate is the set of valid, mappable vectors in the Chroma hot-layer snapshot, not all SQLite screenshots. Then cut over MiniLM semantic retrieval independently before beginning the separate CLIP vector migration/cutover sequence.
 
 No Rust backend becomes authoritative until its Python behavior contract, dual-write/migration, shadow-query, lifecycle, performance, and rollback gates pass. The first recommended cutover is MiniLM semantic retrieval; CLIP follows only after both legacy-vector migration and new-capture Rust image indexing work. Chroma remains for Milestone 4 task clustering, and Python BGE remains for Milestone 5 classification. Until subject-level Rust ledgers exist, the internal count-level CLIP comparison is only a migration baseline, not a product health judgment.

--- a/monitor/monitor/clustering_commands.py
+++ b/monitor/monitor/clustering_commands.py
@@ -18,6 +18,11 @@ HANDLED_CLUSTERING_COMMANDS = {
     "smart_cluster_stop_drain",
     "smart_cluster_worker_status",
     "smart_cluster_calibrate_preview",
+    "start_task_vectors_export",
+    "get_task_vectors_export_status",
+    "export_task_vectors_page",
+    "finish_task_vectors_export",
+    "upsert_task_vectors",
 }
 
 
@@ -167,6 +172,78 @@ def handle_clustering_command(
                 "model_path": _resolve_model_path(),
             }
         except Exception as e:
+            return {"error": str(e)}
+
+    if cmd == "start_task_vectors_export":
+        service_error = _requires_service(manager=manager)
+        if service_error:
+            return service_error
+        auth_error = _requires_auth(auth_gate)
+        if auth_error:
+            return auth_error
+        try:
+            result = manager.start_task_vectors_export(
+                export_id=req.get("export_id", ""),
+            )
+            return {"status": "success", **result}
+        except Exception as e:
+            logger.exception("start_task_vectors_export failed")
+            return {"error": str(e)}
+
+    if cmd == "get_task_vectors_export_status":
+        service_error = _requires_service(manager=manager)
+        if service_error:
+            return service_error
+        auth_error = _requires_auth(auth_gate)
+        if auth_error:
+            return auth_error
+        try:
+            result = manager.get_task_vectors_export_status(req.get("export_id", ""))
+            return {"status": "success", **result}
+        except Exception as e:
+            logger.exception("get_task_vectors_export_status failed")
+            return {"error": str(e)}
+
+    if cmd == "export_task_vectors_page":
+        service_error = _requires_service(manager=manager)
+        if service_error:
+            return service_error
+        auth_error = _requires_auth(auth_gate)
+        if auth_error:
+            return auth_error
+        try:
+            result = manager.export_task_vectors_page(
+                export_id=req.get("export_id", ""),
+                cursor=req.get("cursor", 0),
+                limit=req.get("limit", 128),
+            )
+            return {"status": "success", **result}
+        except Exception as e:
+            logger.exception("export_task_vectors_page failed")
+            return {"error": str(e)}
+
+    if cmd == "finish_task_vectors_export":
+        service_error = _requires_service(manager=manager)
+        if service_error:
+            return service_error
+        auth_error = _requires_auth(auth_gate)
+        if auth_error:
+            return auth_error
+        released = manager.finish_task_vectors_export(req.get("export_id", ""))
+        return {"status": "success", "released": released}
+
+    if cmd == "upsert_task_vectors":
+        service_error = _requires_service(manager=manager)
+        if service_error:
+            return service_error
+        auth_error = _requires_auth(auth_gate)
+        if auth_error:
+            return auth_error
+        try:
+            count = manager.upsert_task_vectors(req.get("records", []))
+            return {"status": "success", "upserted": count}
+        except Exception as e:
+            logger.exception("upsert_task_vectors failed")
             return {"error": str(e)}
 
     if cmd == "smart_cluster_drain_now":

--- a/monitor/storage_client.py
+++ b/monitor/storage_client.py
@@ -85,6 +85,8 @@ READ_RETRY_COMMANDS = {
 
 IDEMPOTENT_RETRY_COMMANDS = {
     'update_screenshot_category',
+    'upsert_minilm_derived_embeddings',
+    'delete_minilm_derived_embeddings',
     'set_ocr_postprocess_status',
     'record_ocr_postprocess_retry',
     'smart_cluster_enqueue_pending',
@@ -725,6 +727,33 @@ class StorageClient:
         if response.get('status') == 'success':
             return response.get('data', {'screenshots': []})
         raise RuntimeError(response.get('error', 'Unknown error during IPC get_screenshots_with_ocr_by_ids'))
+
+    def upsert_minilm_derived_embeddings(self, records: List[Dict[str, Any]]) -> bool:
+        """Best-effort batch dual-write of Python-produced MiniLM vectors to Rust."""
+        if not records:
+            return True
+        if len(records) > 128:
+            raise ValueError('MiniLM dual-write batch exceeds 128 records')
+        response = self._send_request({
+            'command': 'upsert_minilm_derived_embeddings',
+            'records': records,
+        })
+        if response.get('status') != 'success':
+            return False
+        errors = response.get('data', {}).get('errors', [])
+        return not errors
+
+    def delete_minilm_derived_embeddings(self, screenshot_ids: List[int]) -> bool:
+        """Mirror hot-layer expiry into the Rust-derived semantic cache."""
+        if not screenshot_ids:
+            return True
+        if len(screenshot_ids) > 128:
+            raise ValueError('MiniLM delete batch exceeds 128 records')
+        response = self._send_request({
+            'command': 'delete_minilm_derived_embeddings',
+            'screenshot_ids': [int(value) for value in screenshot_ids],
+        })
+        return response.get('status') == 'success'
 
     def update_screenshot_category(
         self,

--- a/monitor/task_clustering.py
+++ b/monitor/task_clustering.py
@@ -17,10 +17,14 @@ import gc
 import sys
 import json
 import time
+import base64
 import logging
+import secrets
+import shutil
 import threading
 import hashlib
 import numpy as np
+from concurrent.futures import ThreadPoolExecutor
 from typing import List, Dict, Any, Optional, Tuple
 
 from clustering_resources import (
@@ -43,6 +47,12 @@ class ModelNotAvailableError(Exception):
 # Constants
 # ---------------------------------------------------------------------------
 EMBEDDING_DIM = 384
+RUST_DUAL_WRITE_BATCH_SIZE = 32
+MAX_TASK_VECTOR_EXPORTS = 4
+TASK_VECTOR_EXPORT_LOGICAL_TIMEOUT_SECS = 10 * 60
+TASK_VECTOR_EXPORT_IDLE_TTL_SECS = 24 * 60 * 60
+TASK_VECTOR_EXPORT_HARD_TTL_SECS = 7 * 24 * 60 * 60
+TASK_VECTOR_EXPORT_TMP_TTL_SECS = 60 * 60
 HOT_LAYER_DAYS = 30
 CENTROID_MATCH_THRESHOLD = 0.55   # cosine similarity threshold for assigning to existing cluster
 MIN_CLUSTER_SIZE = 5
@@ -489,9 +499,17 @@ class HotColdManager:
         self._storage_client = storage_client
         self._embedder = TaskEmbedder()
         self._engine = ClusteringEngine()
+        self._task_vector_exports = {}
+        self._task_vector_export_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="task-vector-export",
+        )
+        self._pending_rust_deletes = set()
         # run_clustering calls helpers/properties that also acquire this lock.
         # Use RLock to avoid self-deadlock on nested acquisitions.
         self._lock = threading.RLock()
+
+        self._load_pending_rust_deletes()
 
         logger.info("[task_clustering] HotColdManager ready (lazy loading collections)")
 
@@ -558,6 +576,468 @@ class HotColdManager:
 
     # ---- Hot layer operations --------------------------------------------
 
+    @staticmethod
+    def _task_vector_sort_key(doc_id: str):
+        try:
+            parsed = int(doc_id)
+            if parsed > 0 and str(parsed) == doc_id:
+                return (0, parsed)
+        except (TypeError, ValueError):
+            pass
+        return (1, doc_id)
+
+    @staticmethod
+    def _migration_artifact_root() -> str:
+        data_dir = os.environ.get("CARBONPAPER_DATA_DIR")
+        if not data_dir:
+            local_appdata = os.environ.get("LOCALAPPDATA", os.path.expanduser("~"))
+            data_dir = os.path.join(local_appdata, "CarbonPaper", "data")
+        return os.path.join(data_dir, "migrations", "minilm")
+
+    @classmethod
+    def _task_vector_export_dir(cls, export_id: str) -> str:
+        return os.path.join(cls._migration_artifact_root(), export_id)
+
+    @classmethod
+    def _rust_delete_retry_path(cls) -> str:
+        return os.path.join(cls._migration_artifact_root(), "rust-delete-retry.json")
+
+    @staticmethod
+    def _validate_export_id(export_id: str) -> str:
+        export_id = str(export_id or "")
+        if not (16 <= len(export_id) <= 128) or any(
+            not (ch.isalnum() or ch in "-_") for ch in export_id
+        ):
+            raise ValueError("invalid task vector export id")
+        return export_id
+
+    def _cleanup_task_vector_exports(self) -> None:
+        now_wall = time.time()
+        now_mono = time.monotonic()
+        root = self._migration_artifact_root()
+        try:
+            os.makedirs(root, exist_ok=True)
+            for name in os.listdir(root):
+                path = os.path.join(root, name)
+                if not os.path.isdir(path):
+                    continue
+                try:
+                    age = now_wall - os.path.getmtime(path)
+                    ttl = (
+                        TASK_VECTOR_EXPORT_TMP_TTL_SECS
+                        if name.endswith(".tmp")
+                        else TASK_VECTOR_EXPORT_HARD_TTL_SECS
+                    )
+                    if age > ttl:
+                        shutil.rmtree(path, ignore_errors=True)
+                except OSError:
+                    pass
+        except OSError:
+            logger.debug("[task_clustering] failed to clean export artifacts", exc_info=True)
+
+        with self._lock:
+            expired = [
+                export_id
+                for export_id, state in self._task_vector_exports.items()
+                if state.get("status") != "preparing"
+                and now_mono - state.get("last_access", now_mono)
+                > TASK_VECTOR_EXPORT_IDLE_TTL_SECS
+            ]
+            for export_id in expired:
+                self._task_vector_exports.pop(export_id, None)
+
+    def _build_task_vectors_export(
+        self,
+        export_id: str,
+        stop_event: threading.Event,
+    ) -> None:
+        final_dir = self._task_vector_export_dir(export_id)
+        temp_dir = final_dir + ".tmp"
+        try:
+            results = self.hot_collection.get(include=[])
+            ids = [str(doc_id) for doc_id in (results.get("ids") or [])]
+            ids.sort(key=self._task_vector_sort_key)
+
+            with self._lock:
+                state = self._task_vector_exports.get(export_id)
+                if (
+                    state is None
+                    or state.get("status") != "preparing"
+                    or stop_event.is_set()
+                ):
+                    return
+
+            os.makedirs(self._migration_artifact_root(), exist_ok=True)
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            os.makedirs(temp_dir, exist_ok=False)
+            ids_path = os.path.join(temp_dir, "ids.json")
+            with open(ids_path + ".tmp", "w", encoding="utf-8") as stream:
+                json.dump(ids, stream, ensure_ascii=False, separators=(",", ":"))
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(ids_path + ".tmp", ids_path)
+            manifest = {
+                "export_id": export_id,
+                "total": len(ids),
+                "created_at": time.time(),
+            }
+            manifest_path = os.path.join(temp_dir, "manifest.json")
+            with open(manifest_path + ".tmp", "w", encoding="utf-8") as stream:
+                json.dump(manifest, stream, separators=(",", ":"))
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(manifest_path + ".tmp", manifest_path)
+
+            with self._lock:
+                state = self._task_vector_exports.get(export_id)
+                if (
+                    state is None
+                    or state.get("status") != "preparing"
+                    or stop_event.is_set()
+                ):
+                    shutil.rmtree(temp_dir, ignore_errors=True)
+                    return
+                if os.path.isdir(final_dir):
+                    shutil.rmtree(final_dir, ignore_errors=True)
+                os.replace(temp_dir, final_dir)
+                state.update({
+                    "status": "ready",
+                    "total": len(ids),
+                    "ids": tuple(ids),
+                    "last_access": time.monotonic(),
+                    "finished_at": time.time(),
+                })
+        except Exception as exc:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            with self._lock:
+                state = self._task_vector_exports.get(export_id)
+                if state is not None and state.get("status") == "preparing":
+                    state.update({
+                        "status": "failed",
+                        "error": str(exc),
+                        "last_access": time.monotonic(),
+                    })
+            logger.exception("task_vectors export snapshot failed")
+
+    def start_task_vectors_export(
+        self,
+        export_id: str,
+    ) -> Dict[str, Any]:
+        """Start a persistent ID snapshot without blocking the IPC worker."""
+        self._cleanup_task_vector_exports()
+        export_id = self._validate_export_id(export_id or secrets.token_hex(16))
+        now_mono = time.monotonic()
+        with self._lock:
+            existing = self._task_vector_exports.get(export_id)
+            if existing is not None:
+                return self.get_task_vectors_export_status(export_id)
+            if len(self._task_vector_exports) >= MAX_TASK_VECTOR_EXPORTS:
+                oldest = min(
+                    self._task_vector_exports,
+                    key=lambda key: self._task_vector_exports[key].get("created_mono", now_mono),
+                )
+                self._task_vector_exports.pop(oldest, None)
+            stop_event = threading.Event()
+            self._task_vector_exports[export_id] = {
+                "status": "preparing",
+                "total": 0,
+                "ids": None,
+                "error": None,
+                "created_mono": now_mono,
+                "created_at": time.time(),
+                "last_access": now_mono,
+                "stop_event": stop_event,
+            }
+        self._task_vector_export_executor.submit(
+            self._build_task_vectors_export,
+            export_id,
+            stop_event,
+        )
+        return {"export_id": export_id, "state": "preparing", "total": 0}
+
+    def _restore_task_vector_export(self, export_id: str) -> Optional[Dict[str, Any]]:
+        export_dir = self._task_vector_export_dir(export_id)
+        manifest_path = os.path.join(export_dir, "manifest.json")
+        ids_path = os.path.join(export_dir, "ids.json")
+        if not (os.path.isfile(manifest_path) and os.path.isfile(ids_path)):
+            return None
+        try:
+            with open(manifest_path, "r", encoding="utf-8") as stream:
+                manifest = json.load(stream)
+            with open(ids_path, "r", encoding="utf-8") as stream:
+                ids = tuple(str(value) for value in json.load(stream))
+            if manifest.get("export_id") != export_id or int(manifest.get("total", -1)) != len(ids):
+                raise ValueError("task vector export manifest does not match ids")
+            return {
+                "status": "ready",
+                "total": len(ids),
+                "ids": ids,
+                "error": None,
+                "created_mono": time.monotonic(),
+                "created_at": float(manifest.get("created_at", time.time())),
+                "last_access": time.monotonic(),
+                "stop_event": threading.Event(),
+                "finished_at": os.path.getmtime(manifest_path),
+            }
+        except Exception:
+            logger.exception("failed to restore task_vectors export %s", export_id)
+            return None
+
+    def get_task_vectors_export_status(self, export_id: str) -> Dict[str, Any]:
+        export_id = self._validate_export_id(export_id)
+        self._cleanup_task_vector_exports()
+        with self._lock:
+            state = self._task_vector_exports.get(export_id)
+        if state is None:
+            restored = self._restore_task_vector_export(export_id)
+            if restored is not None:
+                with self._lock:
+                    self._task_vector_exports[export_id] = restored
+                    state = restored
+        if state is None:
+            return {"export_id": export_id, "state": "missing", "total": 0}
+
+        with self._lock:
+            state = self._task_vector_exports[export_id]
+            elapsed = time.monotonic() - state.get("created_mono", time.monotonic())
+            if (
+                state.get("status") == "preparing"
+                and elapsed > TASK_VECTOR_EXPORT_LOGICAL_TIMEOUT_SECS
+            ):
+                state["status"] = "timed_out"
+                state["error"] = "task vector ID snapshot exceeded its 10 minute deadline"
+                state["stop_event"].set()
+            state["last_access"] = time.monotonic()
+            return {
+                "export_id": export_id,
+                "state": state.get("status", "missing"),
+                "total": int(state.get("total", 0) or 0),
+                "error": state.get("error"),
+                "created_at": state.get("created_at"),
+                "finished_at": state.get("finished_at"),
+            }
+
+    def export_task_vectors_page(
+        self,
+        export_id: str,
+        cursor: int = 0,
+        limit: int = 128,
+    ) -> Dict[str, Any]:
+        """Export one page from a stable id snapshot, preserving snapshot order.
+
+        Vectors travel as one little-endian float32 blob wrapped in Base64
+        instead of tens of thousands of JSON floats, keeping a 128-row page
+        around 256 KB of pipe traffic.
+        """
+        export_id = self._validate_export_id(export_id)
+        cursor = max(0, int(cursor))
+        limit = max(1, min(500, int(limit)))
+        with self._lock:
+            snapshot = self._task_vector_exports.get(export_id)
+        if snapshot is None:
+            snapshot = self._restore_task_vector_export(export_id)
+            if snapshot is not None:
+                with self._lock:
+                    self._task_vector_exports[export_id] = snapshot
+        if snapshot is None:
+            raise ValueError("unknown or expired task vector export")
+        with self._lock:
+            snapshot = self._task_vector_exports[export_id]
+            if snapshot.get("status") != "ready":
+                raise ValueError(f"task vector export is {snapshot.get('status')}")
+            snapshot["last_access"] = time.monotonic()
+            snapshot_ids = snapshot["ids"]
+            page_ids = list(snapshot_ids[cursor:cursor + limit])
+            total = len(snapshot_ids)
+
+        if not page_ids:
+            return {
+                "ids": [],
+                "dimensions": EMBEDDING_DIM,
+                "embeddings_f32_le_b64": "",
+                "missing_ids": [],
+                "errors": [],
+                "next_cursor": cursor,
+                "done": True,
+                "total": total,
+            }
+
+        results = self.hot_collection.get(ids=page_ids, include=["embeddings"])
+        returned_ids = [str(doc_id) for doc_id in (results.get("ids") or [])]
+        embeddings = results.get("embeddings")
+        if embeddings is None:
+            embeddings = []
+        vectors_by_id = {}
+        errors = []
+        for doc_id, vector in zip(returned_ids, embeddings):
+            try:
+                row = np.asarray(vector, dtype="<f4").reshape(-1)
+                if row.shape[0] != EMBEDDING_DIM:
+                    raise ValueError(
+                        f"expected {EMBEDDING_DIM} dimensions, got {row.shape[0]}"
+                    )
+                vectors_by_id[doc_id] = row
+            except Exception as exc:
+                errors.append({"id": doc_id, "error": str(exc)})
+
+        ordered_ids = [doc_id for doc_id in page_ids if doc_id in vectors_by_id]
+        if ordered_ids:
+            payload = np.concatenate([vectors_by_id[doc_id] for doc_id in ordered_ids])
+            embeddings_b64 = base64.b64encode(payload.tobytes()).decode("ascii")
+        else:
+            embeddings_b64 = ""
+        missing_ids = [
+            doc_id
+            for doc_id in page_ids
+            if doc_id not in vectors_by_id
+            and not any(entry["id"] == doc_id for entry in errors)
+        ]
+        next_cursor = cursor + len(page_ids)
+        return {
+            "ids": ordered_ids,
+            "dimensions": EMBEDDING_DIM,
+            "embeddings_f32_le_b64": embeddings_b64,
+            "missing_ids": missing_ids,
+            "errors": errors,
+            "next_cursor": next_cursor,
+            "done": next_cursor >= total,
+            "total": total,
+        }
+
+    def finish_task_vectors_export(self, export_id: str) -> bool:
+        """Release memory and persistent artifacts after a completed migration."""
+        export_id = self._validate_export_id(export_id)
+        with self._lock:
+            state = self._task_vector_exports.pop(export_id, None)
+            if state is not None:
+                state["stop_event"].set()
+        shutil.rmtree(self._task_vector_export_dir(export_id), ignore_errors=True)
+        shutil.rmtree(self._task_vector_export_dir(export_id) + ".tmp", ignore_errors=True)
+        return state is not None
+
+    def _load_pending_rust_deletes(self) -> None:
+        path = self._rust_delete_retry_path()
+        try:
+            with open(path, "r", encoding="utf-8") as stream:
+                values = json.load(stream)
+            self._pending_rust_deletes = {
+                str(value) for value in values if str(value).isdigit() and int(value) > 0
+            }
+        except FileNotFoundError:
+            self._pending_rust_deletes = set()
+        except Exception:
+            logger.exception("failed to load pending Rust MiniLM deletions")
+            self._pending_rust_deletes = set()
+
+    def _persist_pending_rust_deletes(self) -> None:
+        path = self._rust_delete_retry_path()
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            temp_path = path + ".tmp"
+            # The whole snapshot-write-replace sequence stays under the lock:
+            # concurrent writers would otherwise race on the same .tmp file
+            # (os.replace fails on Windows while the file is open).
+            with self._lock:
+                snapshot = sorted(self._pending_rust_deletes, key=int)
+                with open(temp_path, "w", encoding="utf-8") as stream:
+                    json.dump(snapshot, stream)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                os.replace(temp_path, path)
+        except Exception:
+            logger.exception("failed to persist pending Rust MiniLM deletions")
+
+    def _flush_pending_rust_deletes(self) -> None:
+        if not self._storage_client:
+            return
+        with self._lock:
+            pending = sorted(self._pending_rust_deletes, key=int)
+        if not pending:
+            return
+        for offset in range(0, len(pending), 128):
+            batch = pending[offset:offset + 128]
+            try:
+                # IPC happens outside the lock; the manager lock also guards
+                # Chroma operations and must not wait on pipe round-trips.
+                if not self._storage_client.delete_minilm_derived_embeddings(
+                    [int(value) for value in batch]
+                ):
+                    break
+                with self._lock:
+                    self._pending_rust_deletes.difference_update(batch)
+            except Exception:
+                logger.debug("Rust MiniLM delete retry failed", exc_info=True)
+                break
+        self._persist_pending_rust_deletes()
+
+    def _queue_rust_deletes(self, ids: List[str]) -> None:
+        with self._lock:
+            self._pending_rust_deletes.update(str(value) for value in ids)
+        self._persist_pending_rust_deletes()
+        self._flush_pending_rust_deletes()
+
+    def upsert_task_vectors(self, records: List[Dict[str, Any]]) -> int:
+        """Write Rust-generated MiniLM vectors to the authoritative hot layer."""
+        if not isinstance(records, list) or not records:
+            return 0
+        if len(records) > 128:
+            raise ValueError("task vector upsert batch exceeds 128 records")
+
+        ids, embeddings, metadatas, documents = [], [], [], []
+        for record in records:
+            doc_id = str(record.get("id", ""))
+            if not doc_id.isdigit() or int(doc_id) <= 0 or str(int(doc_id)) != doc_id:
+                raise ValueError(f"invalid task vector id: {doc_id!r}")
+            vector = np.asarray(record.get("embedding", []), dtype=np.float32)
+            if vector.shape != (EMBEDDING_DIM,) or not np.isfinite(vector).all():
+                raise ValueError(f"invalid task vector for id {doc_id}")
+            timestamp = float(record.get("timestamp", 0) or 0)
+            if timestamp > 1e12:
+                timestamp /= 1000.0
+            process_name = str(record.get("process_name", "") or "")
+            window_title = str(record.get("window_title", "") or "")
+            category = str(record.get("category", "") or "")
+            document = str(record.get("document", "") or "")
+            ids.append(doc_id)
+            embeddings.append(vector.tolist())
+            metadatas.append({
+                "screenshot_id": int(doc_id),
+                "timestamp": timestamp,
+                "process_name": self._encrypt(process_name) if process_name else "",
+                "window_title": self._encrypt(window_title) if window_title else "",
+                "category": category,
+                "layer": "hot",
+            })
+            documents.append(self._encrypt(document))
+
+        self.hot_collection.upsert(
+            ids=ids,
+            embeddings=embeddings,
+            metadatas=metadatas,
+            documents=documents,
+        )
+        return len(ids)
+
+    def _dual_write_rust(self, ids: List[str], vectors) -> None:
+        """Best-effort reverse-IPC copy; Chroma success remains authoritative."""
+        if not self._storage_client or not ids:
+            return
+        try:
+            for offset in range(0, len(ids), RUST_DUAL_WRITE_BATCH_SIZE):
+                batch_ids = ids[offset:offset + RUST_DUAL_WRITE_BATCH_SIZE]
+                batch_vectors = vectors[offset:offset + RUST_DUAL_WRITE_BATCH_SIZE]
+                records = [
+                    {
+                        "screenshot_id": int(doc_id),
+                        "embedding": np.asarray(vector, dtype=np.float32).tolist(),
+                    }
+                    for doc_id, vector in zip(batch_ids, batch_vectors)
+                ]
+                if not self._storage_client.upsert_minilm_derived_embeddings(records):
+                    logger.debug("[task_clustering] Rust MiniLM dual-write returned row errors")
+        except Exception as e:
+            logger.debug("[task_clustering] Rust MiniLM dual-write failed (non-fatal): %s", e)
+
     def add_snapshot(
         self,
         screenshot_id: int,
@@ -609,6 +1089,8 @@ class HotColdManager:
             metadatas=[metadata],
             documents=[self._encrypt(combined)],
         )
+        self._dual_write_rust([doc_id], [vector])
+        self._flush_pending_rust_deletes()
 
         # Enqueue for smart cluster evaluation. Best-effort and O(1) — the
         # actual scoring happens in a separate idle-aware worker so this stays
@@ -759,6 +1241,7 @@ class HotColdManager:
             )
             if expired["ids"]:
                 self.hot_collection.delete(ids=expired["ids"])
+                self._queue_rust_deletes(expired["ids"])
                 logger.info("Removed %d expired vectors from hot layer", len(expired["ids"]))
         except Exception as e:
             logger.warning("Failed to clean expired hot vectors: %s", e)
@@ -898,6 +1381,7 @@ class HotColdManager:
                         embeddings=vectors.tolist(),
                         metadatas=batch_metas,
                     )
+                    self._dual_write_rust(batch_ids, vectors)
                     added += len(batch_ids)
                     logger.info("Backfilled %d/%d (page offset %d)", added, total, offset)
                 except Exception as e:

--- a/monitor/tests/test_minilm_migration.py
+++ b/monitor/tests/test_minilm_migration.py
@@ -1,0 +1,288 @@
+import base64
+
+import numpy as np
+import pytest
+import time
+
+import task_clustering as tc
+from monitor.clustering_commands import handle_clustering_command
+
+
+class FakeCollection:
+    def __init__(self):
+        self.rows = {}
+        self.last_get = None
+        self.get_calls = []
+
+    def get(self, ids=None, include=None, where=None, offset=0, limit=None):
+        self.last_get = {
+            "ids": ids,
+            "include": include,
+            "where": where,
+            "offset": offset,
+            "limit": limit,
+        }
+        self.get_calls.append(self.last_get)
+        if ids is not None:
+            selected = [(doc_id, self.rows[doc_id]) for doc_id in ids if doc_id in self.rows]
+        else:
+            selected = list(self.rows.items())
+            if where:
+                if "$and" in where:
+                    bounds = {
+                        "$gte": where["$and"][0]["timestamp"]["$gte"],
+                        "$lte": where["$and"][1]["timestamp"]["$lte"],
+                    }
+                else:
+                    bounds = where["timestamp"]
+                selected = [
+                    item
+                    for item in selected
+                    if item[1]["metadata"]["timestamp"] >= bounds.get("$gte", float("-inf"))
+                    and item[1]["metadata"]["timestamp"] <= bounds.get("$lte", float("inf"))
+                ]
+            selected = selected[offset: offset + limit if limit is not None else None]
+        return {
+            "ids": [item[0] for item in selected],
+            "embeddings": [item[1]["embedding"] for item in selected],
+        }
+
+    def add(self, ids, embeddings, metadatas, documents=None):
+        for index, doc_id in enumerate(ids):
+            self.rows[doc_id] = {
+                "embedding": embeddings[index],
+                "metadata": metadatas[index],
+                "document": documents[index] if documents else None,
+            }
+
+    def upsert(self, ids, embeddings, metadatas, documents=None):
+        self.add(ids, embeddings, metadatas, documents)
+
+
+class FakeClient:
+    def __init__(self):
+        self.collection = FakeCollection()
+
+    def get_or_create_collection(self, **_kwargs):
+        return self.collection
+
+
+class FakeStorageClient:
+    def __init__(self):
+        self.dual_writes = []
+        self.pending = []
+        self.deletes = []
+        self.fail_deletes = False
+
+    def upsert_minilm_derived_embeddings(self, records):
+        self.dual_writes.append(records)
+        return True
+
+    def delete_minilm_derived_embeddings(self, screenshot_ids):
+        if self.fail_deletes:
+            return False
+        self.deletes.append(screenshot_ids)
+        return True
+
+    def encrypt_for_chromadb(self, text):
+        return text
+
+    def smart_cluster_enqueue_pending(self, screenshot_id):
+        self.pending.append(screenshot_id)
+        return True
+
+
+def _wait_for_export(manager, export_id, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        status = manager.get_task_vectors_export_status(export_id)
+        if status["state"] == "ready":
+            return status
+        if status["state"] in {"failed", "timed_out", "missing"}:
+            raise AssertionError(status)
+        time.sleep(0.01)
+    raise AssertionError("export did not become ready")
+
+
+def test_export_snapshot_is_stable_ordered_and_vector_only():
+    manager = tc.HotColdManager(FakeClient())
+    vector = [0.25] * tc.EMBEDDING_DIM
+    assert manager.upsert_task_vectors([
+        {
+            "id": doc_id,
+            "embedding": vector,
+            "process_name": "app.exe",
+            "window_title": "Title",
+            "category": "work",
+            "timestamp": 123.0,
+            "document": "app.exe | Title",
+        }
+        for doc_id in ("10", "2", "7")
+    ]) == 3
+    snapshot = manager.start_task_vectors_export(
+        export_id="export-snapshot-0001",
+    )
+    assert snapshot["state"] == "preparing"
+    snapshot = _wait_for_export(manager, snapshot["export_id"])
+    assert snapshot["total"] == 3
+    assert manager.hot_collection.get_calls[0]["include"] == []
+    assert manager.hot_collection.get_calls[0]["where"] is None
+
+    # Rows added after begin are outside the snapshot; rows removed after begin
+    # are reported explicitly instead of shifting later pages.
+    manager.upsert_task_vectors([{
+        "id": "3",
+        "embedding": vector,
+        "timestamp": 123.0,
+    }])
+    manager.hot_collection.rows.pop("7")
+
+    first = manager.export_task_vectors_page(
+        export_id=snapshot["export_id"],
+        cursor=0,
+        limit=2,
+    )
+    expected_blob = base64.b64encode(
+        np.asarray(vector, dtype="<f4").tobytes()
+    ).decode("ascii")
+    assert first == {
+        "ids": ["2"],
+        "dimensions": tc.EMBEDDING_DIM,
+        "embeddings_f32_le_b64": expected_blob,
+        "missing_ids": ["7"],
+        "errors": [],
+        "next_cursor": 2,
+        "done": False,
+        "total": 3,
+    }
+    second = manager.export_task_vectors_page(
+        export_id=snapshot["export_id"],
+        cursor=first["next_cursor"],
+        limit=2,
+    )
+    assert second == {
+        "ids": ["10"],
+        "dimensions": tc.EMBEDDING_DIM,
+        "embeddings_f32_le_b64": expected_blob,
+        "missing_ids": [],
+        "errors": [],
+        "next_cursor": 3,
+        "done": True,
+        "total": 3,
+    }
+    assert manager.finish_task_vectors_export(snapshot["export_id"]) is True
+    with pytest.raises(ValueError, match="unknown or expired"):
+        manager.export_task_vectors_page(snapshot["export_id"])
+
+
+def test_new_snapshot_dual_writes_after_chroma_success(monkeypatch):
+    storage = FakeStorageClient()
+    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
+    vector = np.full((tc.EMBEDDING_DIM,), 0.5, dtype=np.float32)
+    monkeypatch.setattr(tc.TaskEmbedder, "is_model_available", staticmethod(lambda: True))
+    monkeypatch.setattr(manager._embedder, "encode_single", lambda _text: vector)
+
+    manager.add_snapshot(9, "app.exe", "Title", "OCR", 456.0, "work")
+
+    assert "9" in manager.hot_collection.rows
+    assert storage.dual_writes == [[{
+        "screenshot_id": 9,
+        "embedding": vector.tolist(),
+    }]]
+    assert storage.pending == [9]
+
+
+def test_dual_write_chunks_large_backfill_pages():
+    storage = FakeStorageClient()
+    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
+    ids = [str(index) for index in range(1, 66)]
+    vectors = np.zeros((65, tc.EMBEDDING_DIM), dtype=np.float32)
+
+    manager._dual_write_rust(ids, vectors)
+
+    assert [len(batch) for batch in storage.dual_writes] == [32, 32, 1]
+
+
+def test_queued_rust_deletes_flush_and_survive_ipc_failure():
+    storage = FakeStorageClient()
+    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
+
+    manager._queue_rust_deletes(["12", "3"])
+    assert storage.deletes == [[3, 12]]
+    assert manager._pending_rust_deletes == set()
+
+    storage.fail_deletes = True
+    manager._queue_rust_deletes(["7"])
+    assert manager._pending_rust_deletes == {"7"}
+
+    # The retry file is the durable source: a fresh manager reloads the ids
+    # that were queued while IPC was failing.
+    restored = tc.HotColdManager(FakeClient(), storage_client=storage)
+    assert restored._pending_rust_deletes == {"7"}
+
+
+def test_migration_commands_require_auth_and_dispatch_to_manager():
+    manager = tc.HotColdManager(FakeClient())
+    denied = handle_clustering_command(
+        {"command": "start_task_vectors_export", "export_id": "export-command-0001"},
+        scheduler=None,
+        manager=manager,
+        auth_gate=lambda **_kwargs: False,
+    )
+    assert "AUTH_REQUIRED" in denied["error"]
+
+    begun = handle_clustering_command(
+        {"command": "start_task_vectors_export", "export_id": "export-command-0001"},
+        scheduler=None,
+        manager=manager,
+        auth_gate=lambda **_kwargs: True,
+    )
+    assert begun["state"] == "preparing"
+    _wait_for_export(manager, begun["export_id"])
+    assert manager.hot_collection.last_get["where"] is None
+    export_status = handle_clustering_command(
+        {
+            "command": "get_task_vectors_export_status",
+            "export_id": begun["export_id"],
+        },
+        scheduler=None,
+        manager=manager,
+        auth_gate=lambda **_kwargs: True,
+    )
+    page = handle_clustering_command(
+        {
+            "command": "export_task_vectors_page",
+            "export_id": begun["export_id"],
+        },
+        scheduler=None,
+        manager=manager,
+        auth_gate=lambda **_kwargs: True,
+    )
+    released = handle_clustering_command(
+        {
+            "command": "finish_task_vectors_export",
+            "export_id": begun["export_id"],
+        },
+        scheduler=None,
+        manager=manager,
+        auth_gate=lambda **_kwargs: True,
+    )
+    assert page["status"] == "success"
+    assert page["done"] is True
+    assert export_status["state"] == "ready"
+    assert released == {"status": "success", "released": True}
+
+    result = handle_clustering_command(
+        {
+            "command": "upsert_task_vectors",
+            "records": [{
+                "id": "11",
+                "embedding": [0.0] * tc.EMBEDDING_DIM,
+                "timestamp": 1.0,
+            }],
+        },
+        scheduler=None,
+        manager=manager,
+        auth_gate=lambda **_kwargs: True,
+    )
+    assert result == {"status": "success", "upserted": 1}

--- a/scripts/security-guards.cjs
+++ b/scripts/security-guards.cjs
@@ -174,6 +174,9 @@ const COMMAND_TIERS = {
   'ml_runtime::debug_trigger_ocr_model_repair_notification': 'session_required',
   'semantic_runtime::get_ml_semantic_status': 'public',
   'semantic_runtime::restart_ml_semantic_worker': 'runtime_public',
+  'minilm_migration::get_minilm_rebuild_status': 'public',
+  'minilm_migration::list_minilm_rebuild_errors': 'session_required',
+  'maintenance::get_maintenance_status': 'public',
 };
 
 function read(file) {

--- a/src-tauri/src/credential_manager.rs
+++ b/src-tauri/src/credential_manager.rs
@@ -1128,8 +1128,7 @@ fn decrypt_master_key_with_cng_flags(
     flags: windows::Win32::Security::Cryptography::NCRYPT_FLAGS,
     owner_hwnd: Option<isize>,
 ) -> Result<Vec<u8>, CredentialError> {
-    use windows::Win32::Foundation::NTE_SILENT_CONTEXT;
-    use windows::Win32::Security::Cryptography::{NCryptDecrypt, NCryptFreeObject, NCRYPT_HANDLE};
+    use windows::Win32::Security::Cryptography::{NCryptFreeObject, NCRYPT_HANDLE};
 
     let key = open_or_create_cng_key()?;
     if let Some(hwnd) = owner_hwnd {
@@ -1154,21 +1153,38 @@ fn decrypt_master_key_with_cng_flags(
         })?;
     }
 
+    let result = ncrypt_decrypt_with_key(key, ciphertext, flags);
+    // SAFETY: this is the final use of the owned key handle.
+    let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(key.0)) };
+    result
+}
+
+/// Runs the size-query + decrypt `NCryptDecrypt` pair against a borrowed key
+/// handle. The caller keeps ownership of the handle and frees it, which lets
+/// [`CngKeySession`] reuse one handle across a whole batch.
+#[cfg(windows)]
+fn ncrypt_decrypt_with_key(
+    key: windows::Win32::Security::Cryptography::NCRYPT_KEY_HANDLE,
+    ciphertext: &[u8],
+    flags: windows::Win32::Security::Cryptography::NCRYPT_FLAGS,
+) -> Result<Vec<u8>, CredentialError> {
+    use windows::Win32::Foundation::NTE_SILENT_CONTEXT;
+    use windows::Win32::Security::Cryptography::NCryptDecrypt;
+
+    let map_error = |stage: &str, e: windows::core::Error| {
+        if e.code() == NTE_SILENT_CONTEXT {
+            CredentialError::AuthRequired
+        } else {
+            CredentialError::SystemError(format!("{stage}: {e}"))
+        }
+    };
+
     // Query plaintext size before allocating the output buffer.
     let mut out_len: u32 = 0;
     // SAFETY: key and ciphertext are live; the null output buffer requests only the
     // plaintext length and `out_len` points to writable stack storage.
-    unsafe { NCryptDecrypt(key, Some(ciphertext), None, None, &mut out_len, flags) }.map_err(
-        |e| {
-            // SAFETY: key ownership remains local when decryption fails.
-            let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(key.0)) };
-            if e.code() == NTE_SILENT_CONTEXT {
-                CredentialError::AuthRequired
-            } else {
-                CredentialError::SystemError(format!("NCryptDecrypt size failed: {}", e))
-            }
-        },
-    )?;
+    unsafe { NCryptDecrypt(key, Some(ciphertext), None, None, &mut out_len, flags) }
+        .map_err(|e| map_error("NCryptDecrypt size failed", e))?;
 
     let mut output = vec![0u8; out_len as usize];
     // SAFETY: output is uniquely mutable and sized from CNG's query; all handles and
@@ -1183,18 +1199,8 @@ fn decrypt_master_key_with_cng_flags(
             flags,
         )
     }
-    .map_err(|e| {
-        // SAFETY: key ownership remains local when decryption fails.
-        let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(key.0)) };
-        if e.code() == NTE_SILENT_CONTEXT {
-            CredentialError::AuthRequired
-        } else {
-            CredentialError::SystemError(format!("NCryptDecrypt failed: {}", e))
-        }
-    })?;
+    .map_err(|e| map_error("NCryptDecrypt failed", e))?;
 
-    // SAFETY: this is the final use of the owned key handle.
-    let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(key.0)) };
     output.truncate(out_len as usize);
     Ok(output)
 }
@@ -1213,6 +1219,68 @@ pub fn decrypt_row_key_with_cng_silent(ciphertext: &[u8]) -> Result<Vec<u8>, Cre
     use windows::Win32::Security::Cryptography::{NCRYPT_PAD_PKCS1_FLAG, NCRYPT_SILENT_FLAG};
 
     decrypt_master_key_with_cng_flags(ciphertext, NCRYPT_PAD_PKCS1_FLAG | NCRYPT_SILENT_FLAG, None)
+}
+
+/// Reusable CNG unwrap session that keeps the private-key handle open for a
+/// whole batch.
+///
+/// Every one-shot [`decrypt_row_key_with_cng_silent`] call pays a
+/// provider-open + key-open + free RPC round-trip to the key-isolation
+/// service before the actual RSA decrypt. Batch readers (the MiniLM
+/// migration fingerprints tens of thousands of OCR boxes) amortize that
+/// fixed cost by opening the handle once. Handles are not tied to a thread,
+/// but each worker thread must open its own session so no handle receives
+/// concurrent `NCryptDecrypt` calls.
+#[cfg(windows)]
+pub struct CngKeySession {
+    key: windows::Win32::Security::Cryptography::NCRYPT_KEY_HANDLE,
+}
+
+#[cfg(windows)]
+impl CngKeySession {
+    /// Opens the persisted key for silent batch unwrapping. Background use
+    /// only: a locked session surfaces as `AuthRequired` on decrypt instead
+    /// of popping system UI.
+    pub fn open_silent() -> Result<Self, CredentialError> {
+        Ok(Self {
+            key: open_or_create_cng_key()?,
+        })
+    }
+
+    /// Silently unwraps one row key with the cached handle.
+    pub fn unwrap_row_key(&self, ciphertext: &[u8]) -> Result<Vec<u8>, CredentialError> {
+        use windows::Win32::Security::Cryptography::{NCRYPT_PAD_PKCS1_FLAG, NCRYPT_SILENT_FLAG};
+
+        ncrypt_decrypt_with_key(self.key, ciphertext, NCRYPT_PAD_PKCS1_FLAG | NCRYPT_SILENT_FLAG)
+    }
+}
+
+#[cfg(windows)]
+impl Drop for CngKeySession {
+    fn drop(&mut self) {
+        use windows::Win32::Security::Cryptography::{NCryptFreeObject, NCRYPT_HANDLE};
+
+        // SAFETY: the session exclusively owns the handle; this is its final use.
+        let _ = unsafe { NCryptFreeObject(NCRYPT_HANDLE(self.key.0)) };
+    }
+}
+
+#[cfg(not(windows))]
+pub struct CngKeySession;
+
+#[cfg(not(windows))]
+impl CngKeySession {
+    pub fn open_silent() -> Result<Self, CredentialError> {
+        Err(CredentialError::SystemError(
+            "CNG is only available on Windows".to_string(),
+        ))
+    }
+
+    pub fn unwrap_row_key(&self, _ciphertext: &[u8]) -> Result<Vec<u8>, CredentialError> {
+        Err(CredentialError::SystemError(
+            "CNG is only available on Windows".to_string(),
+        ))
+    }
 }
 
 fn encode_master_key_file(ciphertext: &[u8]) -> Vec<u8> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,8 +13,10 @@ mod error_window;
 mod i18n;
 mod idle;
 mod logging;
+mod maintenance;
 mod mcp_server;
 mod mcp_token;
+mod minilm_migration;
 #[allow(dead_code)]
 mod ml_contracts;
 #[allow(dead_code)]
@@ -224,6 +226,12 @@ async fn run_delete_queue_maintenance_loop(app_handle: tauri::AppHandle) {
 
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        // Retention and delete-queue work would race the MiniLM migration's
+        // Chroma snapshot; stand still while maintenance mode is active.
+        if maintenance::is_active() {
+            continue;
+        }
 
         let storage = app_handle.state::<Arc<StorageState>>().inner().clone();
 
@@ -798,6 +806,7 @@ pub fn run() {
         .manage(MonitorState::new())
         .manage(Arc::new(ml_runtime::MlRuntimeState::new()))
         .manage(Arc::new(semantic_runtime::SemanticRuntimeState::new()))
+        .manage(Arc::new(minilm_migration::MinilmMigrationState::new()))
         .manage(Arc::new(CaptureState::default()))
         .manage(AnalysisState::default())
         .manage(updater::UpdaterState::new())
@@ -935,6 +944,10 @@ pub fn run() {
                         std::thread::spawn(move || {
                             StorageState::backfill_plaintext_process_names(storage_clone);
                         });
+
+                        // Sentinel-gated one-time M2.4a Chroma copy; waits for
+                        // unlock internally before starting.
+                        minilm_migration::spawn_minilm_auto_migration(app.handle().clone());
 
                         let app_handle_cleanup = app.handle().clone();
                         tauri::async_runtime::spawn(async move {
@@ -1092,6 +1105,9 @@ pub fn run() {
             ml_runtime::debug_trigger_ocr_model_repair_notification,
             semantic_runtime::get_ml_semantic_status,
             semantic_runtime::restart_ml_semantic_worker,
+            minilm_migration::get_minilm_rebuild_status,
+            minilm_migration::list_minilm_rebuild_errors,
+            maintenance::get_maintenance_status,
             monitor::monitor_remove_local_anchors_by_process,
             // 安全告警调试触发（设置 → 高级 → 调试）
             script_integrity::debug_trigger_security_alert,

--- a/src-tauri/src/maintenance.rs
+++ b/src-tauri/src/maintenance.rs
@@ -1,0 +1,127 @@
+//! Global application maintenance mode.
+//!
+//! While a maintenance task (currently the explicit MiniLM migration) is
+//! running, background mutation paths must stand still so the migration's
+//! Chroma snapshot and the Rust-derived cache cannot drift apart. The flag is
+//! process-global because it gates surfaces that do not carry a Tauri
+//! `AppHandle` (reverse IPC, MCP dispatch, background loops).
+//!
+//! Allowed while active: status queries, Windows Hello authentication, error
+//! listing, and app exit. The migration itself has no user cancellation path.
+
+use serde::Serialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+pub const MAINTENANCE_IN_PROGRESS: &str = "MAINTENANCE_IN_PROGRESS";
+
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+static REASON: Mutex<Option<String>> = Mutex::new(None);
+
+/// RAII guard: maintenance mode ends when the guard drops, so a panicking or
+/// early-returning worker cannot leave the app locked.
+pub struct MaintenanceGuard {
+    _private: (),
+}
+
+impl Drop for MaintenanceGuard {
+    fn drop(&mut self) {
+        ACTIVE.store(false, Ordering::SeqCst);
+        *REASON.lock().unwrap_or_else(|error| error.into_inner()) = None;
+    }
+}
+
+/// Enter maintenance mode. Returns `None` if another maintenance task is
+/// already active.
+pub fn enter(reason: &str) -> Option<MaintenanceGuard> {
+    if ACTIVE
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return None;
+    }
+    *REASON.lock().unwrap_or_else(|error| error.into_inner()) = Some(reason.to_string());
+    Some(MaintenanceGuard { _private: () })
+}
+
+pub fn is_active() -> bool {
+    ACTIVE.load(Ordering::SeqCst)
+}
+
+/// Standard rejection for gated entry points.
+pub fn guard() -> Result<(), String> {
+    if is_active() {
+        Err(MAINTENANCE_IN_PROGRESS.to_string())
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MaintenanceStatus {
+    pub active: bool,
+    pub reason: Option<String>,
+}
+
+#[tauri::command]
+pub fn get_maintenance_status() -> MaintenanceStatus {
+    MaintenanceStatus {
+        active: is_active(),
+        reason: REASON
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone(),
+    }
+}
+
+/// Reverse-IPC commands that remain usable during maintenance: session/crypto
+/// helpers the migration itself depends on, read-only status, MiniLM
+/// dual-write mirroring, and NMH session bookkeeping. Everything that writes
+/// screenshots, OCR, or clustering state is rejected.
+pub fn reverse_ipc_command_allowed(command: &str) -> bool {
+    matches!(
+        command,
+        "get_public_key"
+            | "get_auth_status"
+            | "get_idle_state"
+            | "encrypt_for_chromadb"
+            | "decrypt_from_chromadb"
+            | "decrypt_many_from_chromadb"
+            | "screenshot_exists"
+            | "get_screenshots_with_ocr_by_ids"
+            | "upsert_minilm_derived_embeddings"
+            | "delete_minilm_derived_embeddings"
+            | "register_nmh"
+            | "unregister_nmh"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_is_exclusive_and_releases_on_drop() {
+        let guard = enter("test").expect("first enter succeeds");
+        assert!(is_active());
+        assert!(enter("second").is_none());
+        assert_eq!(super::guard().unwrap_err(), MAINTENANCE_IN_PROGRESS);
+        drop(guard);
+        assert!(!is_active());
+        assert!(super::guard().is_ok());
+    }
+
+    #[test]
+    fn reverse_ipc_allowlist_rejects_mutations() {
+        assert!(reverse_ipc_command_allowed(
+            "upsert_minilm_derived_embeddings"
+        ));
+        assert!(reverse_ipc_command_allowed("get_auth_status"));
+        assert!(!reverse_ipc_command_allowed("save_screenshot"));
+        assert!(!reverse_ipc_command_allowed("save_extension_screenshot"));
+        assert!(!reverse_ipc_command_allowed("commit_screenshot"));
+        assert!(!reverse_ipc_command_allowed(
+            "smart_cluster_record_assignment"
+        ));
+    }
+}

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -450,6 +450,14 @@ async fn handle_tools_call(
         None => return JsonRpcResponse::error(id, -32602, "Missing params".into()),
     };
 
+    if crate::maintenance::is_active() {
+        return JsonRpcResponse::error(
+            id,
+            -32000,
+            crate::maintenance::MAINTENANCE_IN_PROGRESS.into(),
+        );
+    }
+
     let tool_name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
     let args = params
         .get("arguments")

--- a/src-tauri/src/minilm_migration.rs
+++ b/src-tauri/src/minilm_migration.rs
@@ -1,0 +1,1425 @@
+//! Resumable, foreground MiniLM migration orchestration.
+//!
+//! M2.4a (mandatory): copy the current Chroma `task_vectors` hot-layer
+//! collection into the Rust-derived cache from a stable, persisted ID
+//! snapshot, then remove Rust rows that are outside the snapshot scope so the
+//! two stores stay behaviorally equivalent. No inference runs in this phase.
+//! The copy is triggered exclusively by the `app_metadata` sentinel at
+//! startup (`spawn_minilm_auto_migration`); there is no manual start, no
+//! user cancellation, and no gap-repair inference anymore. An interrupted
+//! run simply resumes on the next launch/unlock from the persisted cursor.
+//!
+//! The whole run executes under global maintenance mode with durable
+//! `minilm_migration_runs` state, so a crash resumes from the persisted
+//! cursor instead of starting over. Chroma/Python remains the authoritative
+//! query backend throughout M2.4.
+
+use crate::credential_manager::CredentialManagerState;
+use crate::monitor::{authenticated_monitor_command, MonitorState};
+use crate::storage::{
+    BackgroundReadError, BackgroundScreenshotSummary, DerivedEmbeddingWrite, DerivedIndexJobSpec,
+    DerivedIndexJobStatus, DerivedIndexKind, EnsureDerivedIndexJobResult, MinilmMigrationPageRow,
+    MinilmMigrationRunRecord, StorageState,
+};
+use base64::Engine as _;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tauri::{AppHandle, Manager, State};
+
+pub const MINILM_MODEL_ID: &str = "paraphrase-multilingual-MiniLM-L12-v2";
+/// Compatibility contract for the shared MiniLM vector space. Legacy Chroma
+/// rows do not retain per-row runtime provenance, so the derived index records
+/// the reviewed vector-space contract instead of pretending every copied row
+/// came from one concrete ONNX artifact revision.
+pub const MINILM_VECTOR_SPACE_REVISION: &str = "minilm-l12-vector-space-v1";
+const MINILM_MIGRATION_MODE: &str = "sentinel_copy_chroma_hot_layer_v1";
+pub const MINILM_EMBEDDING_VERSION: u32 = 1;
+pub const MINILM_DIMENSIONS: usize = 384;
+/// Zero (or numerically negligible) vectors would poison cosine/ANN queries;
+/// they are quarantined as diagnostics instead of imported.
+pub const MINILM_MIN_L2_NORM: f32 = 1e-6;
+/// The MiniLM source contract consumes at most this many OCR characters, so
+/// batch reads only need to decrypt boxes until the prefix is covered.
+pub const MINILM_OCR_SNIPPET_CHARS: usize = 200;
+const CHROMA_PAGE_SIZE: u64 = 128;
+const MAX_DIAGNOSTICS: usize = 500;
+const AUTH_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const SNAPSHOT_POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// Python enforces a 10 minute logical snapshot deadline; allow a little slack
+/// before the Rust side also gives up.
+const SNAPSHOT_DEADLINE: Duration = Duration::from_secs(11 * 60);
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MinilmMigrationDiagnostic {
+    pub subject_key: Option<String>,
+    pub phase: String,
+    pub code: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MinilmRebuildStatus {
+    pub running: bool,
+    pub phase: String,
+    pub run_id: Option<String>,
+    pub mode: String,
+    pub chroma_total: u64,
+    pub chroma_processed: u64,
+    pub migrated: u64,
+    pub legacy_unverified: u64,
+    pub already_current: u64,
+    pub failed: u64,
+    pub discarded: u64,
+    pub unmappable: u64,
+    pub removed_extra: u64,
+    pub publish_current: u64,
+    pub publish_total: u64,
+    pub required_free_bytes: u64,
+    pub available_free_bytes: u64,
+    pub last_error: Option<String>,
+    pub started_at: Option<String>,
+    pub heartbeat_at: Option<String>,
+    pub finished_at: Option<String>,
+}
+
+impl Default for MinilmRebuildStatus {
+    fn default() -> Self {
+        Self {
+            running: false,
+            phase: "idle".to_string(),
+            run_id: None,
+            mode: String::new(),
+            chroma_total: 0,
+            chroma_processed: 0,
+            migrated: 0,
+            legacy_unverified: 0,
+            already_current: 0,
+            failed: 0,
+            discarded: 0,
+            unmappable: 0,
+            removed_extra: 0,
+            publish_current: 0,
+            publish_total: 0,
+            required_free_bytes: 0,
+            available_free_bytes: 0,
+            last_error: None,
+            started_at: None,
+            heartbeat_at: None,
+            finished_at: None,
+        }
+    }
+}
+
+fn status_from_run(run: &MinilmMigrationRunRecord, running: bool) -> MinilmRebuildStatus {
+    MinilmRebuildStatus {
+        running,
+        phase: run.phase.clone(),
+        run_id: Some(run.run_id.clone()),
+        mode: run.mode.clone(),
+        chroma_total: run.chroma_total,
+        chroma_processed: run.chroma_processed,
+        migrated: run.migrated,
+        legacy_unverified: run.legacy_unverified,
+        already_current: run.already_current,
+        failed: run.failed,
+        discarded: run.discarded,
+        unmappable: run.unmappable,
+        removed_extra: run.removed_extra,
+        publish_current: run.publish_current,
+        publish_total: run.publish_total,
+        required_free_bytes: run.required_free_bytes,
+        available_free_bytes: run.available_free_bytes,
+        last_error: run.last_error.clone(),
+        started_at: Some(run.started_at.clone()),
+        heartbeat_at: Some(run.heartbeat_at.clone()),
+        finished_at: run.finished_at.clone(),
+    }
+}
+
+pub struct MinilmMigrationState {
+    running: AtomicBool,
+    status: Mutex<MinilmRebuildStatus>,
+    diagnostics: Mutex<Vec<MinilmMigrationDiagnostic>>,
+    run_id: Mutex<Option<String>>,
+}
+
+impl Default for MinilmMigrationState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MinilmMigrationState {
+    pub fn new() -> Self {
+        Self {
+            running: AtomicBool::new(false),
+            status: Mutex::new(MinilmRebuildStatus::default()),
+            diagnostics: Mutex::new(Vec::new()),
+            run_id: Mutex::new(None),
+        }
+    }
+
+    fn update(&self, update: impl FnOnce(&mut MinilmRebuildStatus)) {
+        let mut status = self.status.lock().unwrap_or_else(|e| e.into_inner());
+        update(&mut status);
+    }
+
+    fn diagnostic(
+        &self,
+        subject_key: Option<String>,
+        phase: &str,
+        code: &str,
+        error: impl Into<String>,
+    ) {
+        let error = error.into();
+        let mut diagnostics = self.diagnostics.lock().unwrap_or_else(|e| e.into_inner());
+        if diagnostics.len() >= MAX_DIAGNOSTICS {
+            diagnostics.remove(0);
+        }
+        diagnostics.push(MinilmMigrationDiagnostic {
+            subject_key,
+            phase: phase.to_string(),
+            code: code.to_string(),
+            error,
+        });
+    }
+}
+
+struct SourceRow {
+    text: String,
+    spec: DerivedIndexJobSpec,
+}
+
+#[derive(Deserialize)]
+struct TaskVectorExportStart {
+    export_id: String,
+}
+
+#[derive(Deserialize)]
+struct TaskVectorExportStatus {
+    state: String,
+    #[serde(default)]
+    total: u64,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct TaskVectorExportError {
+    id: Option<String>,
+    error: String,
+}
+
+#[derive(Deserialize)]
+struct TaskVectorExportPage {
+    ids: Vec<String>,
+    dimensions: usize,
+    #[serde(default)]
+    embeddings_f32_le_b64: String,
+    #[serde(default)]
+    missing_ids: Vec<String>,
+    #[serde(default)]
+    errors: Vec<TaskVectorExportError>,
+    next_cursor: u64,
+    done: bool,
+    total: u64,
+}
+
+pub fn build_minilm_task_text(process_name: &str, window_title: &str, ocr_text: &str) -> String {
+    let mut parts = Vec::with_capacity(3);
+    if !process_name.is_empty() {
+        parts.push(process_name.to_string());
+    }
+    if !window_title.is_empty() {
+        parts.push(window_title.to_string());
+    }
+    if !ocr_text.is_empty() {
+        let snippet: String = ocr_text.chars().take(MINILM_OCR_SNIPPET_CHARS).collect();
+        let snippet = snippet.trim();
+        if !snippet.is_empty() {
+            parts.push(snippet.to_string());
+        }
+    }
+    parts.join(" | ")
+}
+
+pub fn minilm_source_fingerprint(text: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"minilm-task-text-v1\0");
+    digest.update(text.as_bytes());
+    format!("{:x}", digest.finalize())
+}
+
+fn minilm_spec(screenshot_id: i64, text: &str) -> DerivedIndexJobSpec {
+    DerivedIndexJobSpec {
+        index_kind: DerivedIndexKind::SemanticText,
+        subject_key: screenshot_id.to_string(),
+        model_id: MINILM_MODEL_ID.to_string(),
+        model_revision: MINILM_VECTOR_SPACE_REVISION.to_string(),
+        embedding_version: MINILM_EMBEDDING_VERSION,
+        source_fingerprint: minilm_source_fingerprint(text),
+    }
+}
+
+fn source_rows(
+    summaries: Vec<BackgroundScreenshotSummary>,
+    ocr: &HashMap<i64, String>,
+) -> Vec<SourceRow> {
+    summaries
+        .into_iter()
+        .map(|summary| {
+            let text = build_minilm_task_text(
+                summary.process_name.as_deref().unwrap_or(""),
+                summary.window_title.as_deref().unwrap_or(""),
+                ocr.get(&summary.id).map(String::as_str).unwrap_or(""),
+            );
+            let spec = minilm_spec(summary.id, &text);
+            SourceRow { text, spec }
+        })
+        .collect()
+}
+
+fn validate_vector(vector: &[f32]) -> Result<(), String> {
+    if vector.len() != MINILM_DIMENSIONS {
+        return Err(format!(
+            "Expected {MINILM_DIMENSIONS} dimensions, got {}",
+            vector.len()
+        ));
+    }
+    if vector.iter().any(|value| !value.is_finite()) {
+        return Err("Embedding contains a non-finite value".to_string());
+    }
+    let norm_squared: f32 = vector.iter().map(|value| value * value).sum();
+    if norm_squared.sqrt() <= MINILM_MIN_L2_NORM {
+        return Err("Embedding is a zero vector".to_string());
+    }
+    Ok(())
+}
+
+/// Decode the little-endian float32 page payload into per-id vectors.
+fn decode_export_page_vectors(page: &TaskVectorExportPage) -> Result<Vec<Vec<f32>>, String> {
+    if page.dimensions != MINILM_DIMENSIONS {
+        return Err(format!(
+            "Chroma export page has {} dimensions, expected {MINILM_DIMENSIONS}",
+            page.dimensions
+        ));
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(page.embeddings_f32_le_b64.as_bytes())
+        .map_err(|error| format!("Invalid Base64 embedding payload: {error}"))?;
+    let expected = page
+        .ids
+        .len()
+        .checked_mul(page.dimensions)
+        .and_then(|floats| floats.checked_mul(4))
+        .ok_or_else(|| "Chroma export page size overflow".to_string())?;
+    if bytes.len() != expected {
+        return Err(format!(
+            "Chroma export payload is {} bytes, expected {expected} for {} ids",
+            bytes.len(),
+            page.ids.len()
+        ));
+    }
+    let mut vectors = Vec::with_capacity(page.ids.len());
+    for row in bytes.chunks_exact(page.dimensions * 4) {
+        vectors.push(
+            row.chunks_exact(4)
+                .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+                .collect(),
+        );
+    }
+    Ok(vectors)
+}
+
+fn parse_monitor_success(response: serde_json::Value) -> Result<serde_json::Value, String> {
+    if let Some(error) = response.get("error").and_then(|value| value.as_str()) {
+        return Err(error.to_string());
+    }
+    if response.get("status").and_then(|value| value.as_str()) == Some("error") {
+        return Err(response
+            .get("error")
+            .and_then(|value| value.as_str())
+            .unwrap_or("Monitor command failed")
+            .to_string());
+    }
+    Ok(response)
+}
+
+fn is_auth_required_error(error: &str) -> bool {
+    error.contains("AUTH_REQUIRED")
+}
+
+fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339()
+}
+
+fn new_run_id() -> String {
+    let mut digest = Sha256::new();
+    digest.update(
+        Utc::now()
+            .timestamp_nanos_opt()
+            .unwrap_or_default()
+            .to_le_bytes(),
+    );
+    digest.update(std::process::id().to_le_bytes());
+    let hex = format!("{:x}", digest.finalize());
+    format!("minilm-{}", &hex[..32])
+}
+
+/// Cancellation no longer exists: the mandatory copy blocks until the user
+/// unlocks. Closing the app is the only interruption, and the run resumes
+/// from its persisted cursor on the next launch/unlock.
+async fn wait_for_auth(app: &AppHandle, state: &MinilmMigrationState) {
+    loop {
+        let authenticated = app
+            .try_state::<Arc<CredentialManagerState>>()
+            .map(|value| value.is_session_valid())
+            .unwrap_or(false);
+        if authenticated {
+            return;
+        }
+        state.update(|status| status.phase = "waiting_for_auth".to_string());
+        tokio::time::sleep(AUTH_POLL_INTERVAL).await;
+    }
+}
+
+async fn monitor_command_with_auth_retry(
+    app: &AppHandle,
+    state: &MinilmMigrationState,
+    payload: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    loop {
+        wait_for_auth(app, state).await;
+        let credential = app.state::<Arc<CredentialManagerState>>();
+        let monitor = app.state::<MonitorState>();
+        let result = authenticated_monitor_command(&credential, &monitor, payload.clone())
+            .await
+            .and_then(parse_monitor_success);
+        match result {
+            Err(error) if is_auth_required_error(&error) => continue,
+            other => return other,
+        }
+    }
+}
+
+async fn background_read_with_auth_retry<T>(
+    app: &AppHandle,
+    state: &MinilmMigrationState,
+    mut read: impl FnMut(&StorageState) -> Result<T, BackgroundReadError>,
+) -> Result<T, String> {
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+    loop {
+        wait_for_auth(app, state).await;
+        match read(&storage) {
+            Ok(value) => return Ok(value),
+            Err(BackgroundReadError::AuthRequired) => continue,
+            Err(BackgroundReadError::Other(error)) => return Err(error),
+        }
+    }
+}
+
+fn background_error(error: BackgroundReadError) -> String {
+    match error {
+        BackgroundReadError::AuthRequired => "AUTH_REQUIRED".to_string(),
+        BackgroundReadError::Other(error) => error,
+    }
+}
+
+/// Persist the worker-owned run record and mirror it into the UI status.
+fn persist_run(
+    storage: &StorageState,
+    state: &MinilmMigrationState,
+    run: &mut MinilmMigrationRunRecord,
+) -> Result<(), String> {
+    run.heartbeat_at = now_rfc3339();
+    run.updated_at = run.heartbeat_at.clone();
+    storage.update_minilm_migration_run(run)?;
+    let running = state.running.load(Ordering::SeqCst);
+    state.update(|status| *status = status_from_run(run, running));
+    Ok(())
+}
+
+fn record_error(
+    storage: &StorageState,
+    state: &MinilmMigrationState,
+    run_id: &str,
+    subject_key: Option<&str>,
+    phase: &str,
+    code: &str,
+    error: &str,
+) {
+    state.diagnostic(subject_key.map(str::to_string), phase, code, error);
+    if let Err(persist_error) =
+        storage.record_minilm_migration_error(run_id, subject_key, phase, code, error)
+    {
+        tracing::warn!("[MINILM] failed to persist migration diagnostic: {persist_error}");
+    }
+}
+
+/// Saved monitor/capture state so the migration can restore exactly what the
+/// user had, instead of unconditionally resuming.
+struct MonitorRestore {
+    was_running: bool,
+    was_paused: bool,
+    started_by_migration: bool,
+}
+
+async fn prepare_monitor_for_migration(app: &AppHandle) -> Result<MonitorRestore, String> {
+    let monitor = app.state::<MonitorState>();
+    let capture = app.state::<Arc<crate::capture::CaptureState>>();
+    let was_running = monitor
+        .process
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .is_some();
+    let was_paused = capture.paused.load(Ordering::SeqCst);
+    let mut started_by_migration = false;
+    if !was_running {
+        // The Chroma hot layer only speaks through the Python monitor.
+        crate::monitor::start_monitor_impl(app.state::<MonitorState>(), app.clone())
+            .await
+            .map_err(|error| format!("Cannot start the monitor for the migration: {error}"))?;
+        started_by_migration = true;
+    }
+    if !was_paused {
+        let _ = crate::monitor::pause_monitor_impl(
+            app.state::<MonitorState>(),
+            app.state::<Arc<crate::capture::CaptureState>>(),
+            app.clone(),
+        )
+        .await;
+    }
+    Ok(MonitorRestore {
+        was_running,
+        was_paused,
+        started_by_migration,
+    })
+}
+
+async fn restore_monitor_after_migration(app: &AppHandle, restore: &MonitorRestore) {
+    if restore.started_by_migration && !restore.was_running {
+        let _ = crate::monitor::stop_monitor_impl(
+            app.state::<MonitorState>(),
+            app.state::<Arc<crate::capture::CaptureState>>(),
+            app.clone(),
+        )
+        .await;
+        return;
+    }
+    if !restore.was_paused {
+        let _ = crate::monitor::resume_monitor_impl(
+            app.state::<MonitorState>(),
+            app.state::<Arc<crate::capture::CaptureState>>(),
+            app.clone(),
+        )
+        .await;
+    }
+}
+
+/// Query the persisted snapshot's readiness without creating a new one.
+/// Returns `None` when Python no longer knows the export (memory and disk).
+async fn attach_chroma_snapshot(
+    app: &AppHandle,
+    state: &MinilmMigrationState,
+    export_id: &str,
+) -> Result<Option<u64>, String> {
+    let response = monitor_command_with_auth_retry(
+        app,
+        state,
+        serde_json::json!({
+            "command": "get_task_vectors_export_status",
+            "export_id": export_id,
+        }),
+    )
+    .await?;
+    let status: TaskVectorExportStatus = serde_json::from_value(response)
+        .map_err(|error| format!("Invalid Chroma export status: {error}"))?;
+    match status.state.as_str() {
+        "ready" => Ok(Some(status.total)),
+        _ => Ok(None),
+    }
+}
+
+/// Start (or re-attach to) the asynchronous Python ID snapshot and wait until
+/// it is ready. `start_task_vectors_export` returns immediately; readiness is
+/// polled so a slow Chroma `get` cannot exhaust one long IPC window.
+async fn wait_for_chroma_snapshot(
+    app: &AppHandle,
+    state: &MinilmMigrationState,
+    export_id: &str,
+) -> Result<u64, String> {
+    let response = monitor_command_with_auth_retry(
+        app,
+        state,
+        serde_json::json!({
+            "command": "start_task_vectors_export",
+            "export_id": export_id,
+        }),
+    )
+    .await?;
+    let started: TaskVectorExportStart = serde_json::from_value(response)
+        .map_err(|error| format!("Invalid Chroma export start response: {error}"))?;
+    if started.export_id != export_id {
+        return Err("Chroma export id mismatch".to_string());
+    }
+
+    let deadline = tokio::time::Instant::now() + SNAPSHOT_DEADLINE;
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            return Err(
+                "Chroma ID snapshot did not become ready within its deadline; restart the monitor and retry"
+                    .to_string(),
+            );
+        }
+        let response = monitor_command_with_auth_retry(
+            app,
+            state,
+            serde_json::json!({
+                "command": "get_task_vectors_export_status",
+                "export_id": export_id,
+            }),
+        )
+        .await?;
+        let status: TaskVectorExportStatus = serde_json::from_value(response)
+            .map_err(|error| format!("Invalid Chroma export status: {error}"))?;
+        match status.state.as_str() {
+            "ready" => return Ok(status.total),
+            "preparing" => tokio::time::sleep(SNAPSHOT_POLL_INTERVAL).await,
+            other => {
+                return Err(format!(
+                    "Chroma ID snapshot is {other}: {}",
+                    status.error.unwrap_or_else(|| "no detail".to_string())
+                ))
+            }
+        }
+    }
+}
+
+/// M2.4a: copy every valid, mappable vector of the snapshot into the Rust
+/// cache. Pages commit transactionally together with the persisted cursor, so
+/// a crash either retries an uncommitted page or continues after it.
+async fn copy_chroma_hot_layer(
+    app: &AppHandle,
+    state: &Arc<MinilmMigrationState>,
+    run: &mut MinilmMigrationRunRecord,
+) -> Result<(), String> {
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+
+    run.phase = "snapshotting_chroma".to_string();
+    persist_run(&storage, state, run)?;
+    // Resume path: re-attach to the persisted snapshot instead of starting a
+    // new export under the same id, which would silently reorder pages under
+    // the durable cursor. A snapshot Python cannot restore forces a reset.
+    let mut total = None;
+    if let Some(export_id) = run.export_id.clone() {
+        total = attach_chroma_snapshot(app, state, &export_id).await?;
+        if total.is_none() {
+            storage.reset_minilm_migration_export(&run.run_id)?;
+            *run = storage
+                .get_minilm_migration_run(&run.run_id)?
+                .ok_or("MiniLM migration run disappeared during reset")?;
+        }
+    }
+    let total = match total {
+        Some(total) => total,
+        None => {
+            let export_id = new_run_id();
+            run.export_id = Some(export_id.clone());
+            run.phase = "snapshotting_chroma".to_string();
+            persist_run(&storage, state, run)?;
+            wait_for_chroma_snapshot(app, state, &export_id).await?
+        }
+    };
+    run.chroma_total = total;
+    run.phase = "copying_chroma".to_string();
+    persist_run(&storage, state, run)?;
+
+    let mut unmappable_total = run.unmappable;
+    let mut cursor = run.export_cursor;
+    loop {
+        let response = monitor_command_with_auth_retry(
+            app,
+            state,
+            serde_json::json!({
+                "command": "export_task_vectors_page",
+                "export_id": run.export_id,
+                "cursor": cursor,
+                "limit": CHROMA_PAGE_SIZE,
+            }),
+        )
+        .await?;
+        let page: TaskVectorExportPage = serde_json::from_value(response)
+            .map_err(|error| format!("Invalid Chroma vector export page: {error}"))?;
+        if page.total != run.chroma_total {
+            return Err(format!(
+                "Chroma export snapshot total changed: expected {}, got {}",
+                run.chroma_total, page.total
+            ));
+        }
+        if !page.done && page.next_cursor <= cursor {
+            return Err("Chroma export cursor did not advance".to_string());
+        }
+        let vectors = decode_export_page_vectors(&page)?;
+
+        for missing_id in &page.missing_ids {
+            unmappable_total += 1;
+            record_error(
+                &storage,
+                state,
+                &run.run_id,
+                Some(missing_id),
+                "copying_chroma",
+                "snapshot_row_missing",
+                "A task_vectors row disappeared after the export snapshot was created",
+            );
+        }
+        for export_error in &page.errors {
+            unmappable_total += 1;
+            record_error(
+                &storage,
+                state,
+                &run.run_id,
+                export_error.id.as_deref(),
+                "copying_chroma",
+                "legacy_vector_decode_failed",
+                &export_error.error,
+            );
+        }
+
+        // Validate outside the transaction: canonical id, shape, finiteness,
+        // and a non-zero norm.
+        let mut valid: Vec<(i64, &str, Vec<f32>)> = Vec::with_capacity(page.ids.len());
+        for (chroma_id, vector) in page.ids.iter().zip(vectors) {
+            let screenshot_id = match chroma_id.parse::<i64>() {
+                Ok(id) if id > 0 && id.to_string() == *chroma_id => id,
+                _ => {
+                    unmappable_total += 1;
+                    record_error(
+                        &storage,
+                        state,
+                        &run.run_id,
+                        Some(chroma_id),
+                        "copying_chroma",
+                        "invalid_subject_key",
+                        "task_vectors id is not a canonical positive screenshot id",
+                    );
+                    continue;
+                }
+            };
+            if let Err(error) = validate_vector(&vector) {
+                unmappable_total += 1;
+                record_error(
+                    &storage,
+                    state,
+                    &run.run_id,
+                    Some(chroma_id),
+                    "copying_chroma",
+                    "invalid_vector",
+                    &error,
+                );
+                continue;
+            }
+            valid.push((screenshot_id, chroma_id, vector));
+        }
+
+        let ids: Vec<i64> = valid.iter().map(|(id, _, _)| *id).collect();
+        let summaries = background_read_with_auth_retry(app, state, |storage| {
+            storage.get_screenshot_summaries_by_ids_silent(&ids)
+        })
+        .await?;
+        let ocr = background_read_with_auth_retry(app, state, |storage| {
+            storage.get_ocr_text_prefixes_by_screenshot_ids_silent(&ids, MINILM_OCR_SNIPPET_CHARS)
+        })
+        .await?;
+        let mut summaries: HashMap<i64, BackgroundScreenshotSummary> = summaries
+            .into_iter()
+            .map(|summary| (summary.id, summary))
+            .collect();
+
+        let mut rows = Vec::with_capacity(valid.len());
+        for (screenshot_id, chroma_id, vector) in valid {
+            let Some(summary) = summaries.remove(&screenshot_id) else {
+                unmappable_total += 1;
+                record_error(
+                    &storage,
+                    state,
+                    &run.run_id,
+                    Some(chroma_id),
+                    "copying_chroma",
+                    "inactive_screenshot",
+                    "No active SQLite screenshot maps to the Chroma row",
+                );
+                continue;
+            };
+            let mut sources = source_rows(vec![summary], &ocr);
+            let source = sources.pop().expect("one source row");
+            // A valid legacy vector whose current SQLite text is empty is
+            // still copied — it must not be recomputed from nothing — but it
+            // is marked so the parity gate can treat it separately.
+            let outcome = if source.text.is_empty() {
+                "legacy_chroma_unverified"
+            } else {
+                "migrated"
+            };
+            rows.push(MinilmMigrationPageRow {
+                job: source.spec,
+                vector,
+                outcome: outcome.to_string(),
+            });
+        }
+
+        storage.commit_minilm_migration_page(&run.run_id, cursor, page.next_cursor, &rows)?;
+        *run = storage
+            .get_minilm_migration_run(&run.run_id)?
+            .ok_or("MiniLM migration run disappeared during copy")?;
+        run.unmappable = unmappable_total;
+        persist_run(&storage, state, run)?;
+        cursor = page.next_cursor;
+        if page.done {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Publish the derived-index generation on a blocking worker. `sync_all`
+/// cannot be interrupted; the UI presents that window as "safely writing to
+/// disk".
+async fn publish_generation(
+    app: &AppHandle,
+    state: &Arc<MinilmMigrationState>,
+    run: &mut MinilmMigrationRunRecord,
+) -> Result<(), String> {
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+    run.phase = "publishing_sync".to_string();
+    persist_run(&storage, state, run)?;
+
+    let blocking_storage = storage.clone();
+    let progress_state = state.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        blocking_storage.publish_derived_index_generation_with_progress(
+            DerivedIndexKind::SemanticText,
+            move |phase, current, total| {
+                // In-memory only: DB writes here would contend with the
+                // publication's own connection usage.
+                progress_state.update(|status| {
+                    status.phase = phase.to_string();
+                    status.publish_current = current;
+                    status.publish_total = total;
+                });
+            },
+            // The migration is no longer cancellable.
+            || false,
+        )
+    })
+    .await
+    .map_err(|error| format!("Generation publication worker crashed: {error:?}"))?;
+
+    match result {
+        Ok(_generation) => {
+            let status_snapshot = state
+                .status
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone();
+            run.publish_current = status_snapshot.publish_current;
+            run.publish_total = status_snapshot.publish_total;
+            run.phase = "publishing_commit".to_string();
+            persist_run(&storage, state, run)?;
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn run_minilm_migration(
+    app: AppHandle,
+    state: Arc<MinilmMigrationState>,
+    mut run: MinilmMigrationRunRecord,
+    maintenance: crate::maintenance::MaintenanceGuard,
+) {
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+
+    let result = async {
+        wait_for_auth(&app, &state).await;
+
+        let restore = prepare_monitor_for_migration(&app).await?;
+        run.monitor_was_running = restore.was_running;
+        run.monitor_was_paused = restore.was_paused;
+
+        let phase_result = async {
+            // Everything after prepare_monitor_for_migration must flow through
+            // phase_result: an early `?` here would skip the monitor restore
+            // below and leave capture silently paused.
+            persist_run(&storage, &state, &mut run)?;
+            copy_chroma_hot_layer(&app, &state, &mut run).await?;
+
+            // Every sentinel-triggered run covers the full Chroma hot layer,
+            // so rows outside the persisted snapshot can always be removed.
+            run.phase = "reconciling".to_string();
+            persist_run(&storage, &state, &mut run)?;
+            let removed = storage.reconcile_minilm_migration_scope(&run.run_id)?;
+            run.removed_extra = removed;
+            persist_run(&storage, &state, &mut run)?;
+
+            publish_generation(&app, &state, &mut run).await
+        }
+        .await;
+
+        // Best-effort snapshot release; the Python-side TTLs cover failures.
+        if phase_result.is_ok() {
+            if let Some(export_id) = run.export_id.clone() {
+                let credential = app.state::<Arc<CredentialManagerState>>();
+                let monitor = app.state::<MonitorState>();
+                let _ = authenticated_monitor_command(
+                    &credential,
+                    &monitor,
+                    serde_json::json!({
+                        "command": "finish_task_vectors_export",
+                        "export_id": export_id,
+                    }),
+                )
+                .await;
+            }
+        }
+
+        restore_monitor_after_migration(&app, &restore).await;
+        phase_result
+    }
+    .await;
+
+    let has_errors = run.failed > 0 || run.unmappable > 0 || run.discarded > 0;
+    run.finished_at = Some(now_rfc3339());
+    match &result {
+        Err(error) => {
+            run.status = "failed".to_string();
+            run.phase = "failed".to_string();
+            run.last_error = Some(error.clone());
+        }
+        _ if has_errors => {
+            run.status = "completed_with_errors".to_string();
+            run.phase = "completed_with_errors".to_string();
+        }
+        _ => {
+            run.status = "completed".to_string();
+            run.phase = "completed".to_string();
+        }
+    }
+    // Terminally quarantined legacy rows do not make the copy unfinished.
+    // Transient orchestration failures keep status `failed`, do not write the
+    // sentinel, and therefore resume after the next launch/unlock.
+    if run_settles_sentinel(&run) {
+        if let Err(error) = storage.mark_minilm_auto_migration_done(&run.vector_space_revision) {
+            tracing::warn!("[MINILM] failed to write the auto-migration sentinel: {error}");
+        }
+    }
+    if let Err(error) = persist_run(&storage, &state, &mut run) {
+        tracing::error!("[MINILM] failed to persist final migration state: {error}");
+    }
+    state.update(|status| {
+        status.running = false;
+    });
+    state.running.store(false, Ordering::SeqCst);
+    drop(maintenance);
+}
+
+fn run_is_resumable(run: &MinilmMigrationRunRecord) -> bool {
+    matches!(run.status.as_str(), "running" | "failed")
+        && run.phase != "completed"
+        && run.phase != "completed_with_errors"
+}
+
+fn run_is_compatible_resume(run: &MinilmMigrationRunRecord) -> bool {
+    run.mode == MINILM_MIGRATION_MODE
+        && run.vector_space_revision == MINILM_VECTOR_SPACE_REVISION
+        && run_is_resumable(run)
+}
+
+/// A run settles the once-per-revision sentinel only after the full snapshot,
+/// reconcile, and generation publication complete. `completed_with_errors`
+/// contains only terminally quarantined legacy rows (invalid ids/vectors,
+/// disappeared rows, or inactive screenshots), not transient worker errors.
+fn run_settles_sentinel(run: &MinilmMigrationRunRecord) -> bool {
+    matches!(run.status.as_str(), "completed" | "completed_with_errors")
+}
+
+/// Single-flight entry for the startup auto-trigger: CAS the running flag,
+/// start the orchestrator, roll the flag back if the start is rejected.
+fn try_start_minilm_migration(
+    app: &AppHandle,
+    migration: &Arc<MinilmMigrationState>,
+) -> Result<MinilmRebuildStatus, String> {
+    if migration
+        .running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err("A MiniLM migration is already running".to_string());
+    }
+    let started = start_minilm_migration_inner(app, migration);
+    if let Err(error) = &started {
+        tracing::warn!("[MINILM] migration start rejected: {error}");
+        migration.running.store(false, Ordering::SeqCst);
+    }
+    started
+}
+
+/// What the startup auto-trigger should do, decided from durable state only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutoMigrationDecision {
+    /// Sentinel present: this revision is settled, never re-trigger.
+    AlreadyDone,
+    /// Without a sentinel, start the mandatory copy. Compatible interrupted
+    /// state is selected later; legacy manual history never settles the marker.
+    Start,
+}
+
+fn auto_migration_decision(sentinel_done: bool) -> AutoMigrationDecision {
+    if sentinel_done {
+        AutoMigrationDecision::AlreadyDone
+    } else {
+        AutoMigrationDecision::Start
+    }
+}
+
+/// Startup auto-trigger for the mandatory M2.4a copy, following the sentinel
+/// design of the plaintext backfill and auto-vacuum markers: consult the
+/// durable marker, wait for the user to unlock, then run the copy exactly
+/// once per vector-space revision. This is the only trigger — there is no
+/// manual start and no cancellation; an interrupted run resumes on the next
+/// launch/unlock.
+pub fn spawn_minilm_auto_migration(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = run_auto_migration(app).await {
+            tracing::warn!("[MINILM] automatic migration not started: {error}");
+        }
+    });
+}
+
+async fn run_auto_migration(app: AppHandle) -> Result<(), String> {
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+    let migration = app.state::<Arc<MinilmMigrationState>>().inner().clone();
+    // Re-evaluate every poll so the unlock-instant decision wins.
+    loop {
+        let sentinel_done = storage.is_minilm_auto_migration_done(MINILM_VECTOR_SPACE_REVISION)?;
+        match auto_migration_decision(sentinel_done) {
+            AutoMigrationDecision::AlreadyDone => return Ok(()),
+            AutoMigrationDecision::Start => {}
+        }
+        if migration.running.load(Ordering::SeqCst) {
+            // A run is already in flight; its outcome settles the sentinel.
+            return Ok(());
+        }
+        // The copy phase decrypts OCR text to fingerprint every vector, and
+        // CNG needs an unlocked session — idle here instead of surfacing the
+        // maintenance overlay stuck in waiting_for_auth right at startup.
+        let authenticated = app
+            .try_state::<Arc<CredentialManagerState>>()
+            .map(|value| value.is_session_valid())
+            .unwrap_or(false);
+        if authenticated {
+            break;
+        }
+        tokio::time::sleep(AUTH_POLL_INTERVAL).await;
+    }
+    tracing::info!("[MINILM] starting the automatic Chroma copy migration");
+    try_start_minilm_migration(&app, &migration).map(|_| ())
+}
+
+fn start_minilm_migration_inner(
+    app: &AppHandle,
+    migration: &Arc<MinilmMigrationState>,
+) -> Result<MinilmRebuildStatus, String> {
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+
+    // Resume only state created by this sentinel-only orchestration mode. Old
+    // manual/time-bounded runs may have partial snapshots and must never be
+    // reconciled as if they covered the complete Chroma hot layer.
+    let mut run = match storage.get_latest_minilm_migration_run()? {
+        Some(previous) if run_is_compatible_resume(&previous) => {
+            let mut resumed = previous;
+            resumed.status = "running".to_string();
+            resumed.phase = "starting".to_string();
+            resumed.last_error = None;
+            resumed.finished_at = None;
+            resumed
+        }
+        _ => MinilmMigrationRunRecord {
+            run_id: new_run_id(),
+            mode: MINILM_MIGRATION_MODE.to_string(),
+            vector_space_revision: MINILM_VECTOR_SPACE_REVISION.to_string(),
+            status: "running".to_string(),
+            phase: "preflight".to_string(),
+            export_id: None,
+            export_cursor: 0,
+            chroma_total: 0,
+            chroma_processed: 0,
+            migrated: 0,
+            legacy_unverified: 0,
+            already_current: 0,
+            failed: 0,
+            discarded: 0,
+            unmappable: 0,
+            removed_extra: 0,
+            publish_current: 0,
+            publish_total: 0,
+            required_free_bytes: 0,
+            available_free_bytes: 0,
+            monitor_was_running: false,
+            monitor_was_paused: false,
+            last_error: None,
+            started_at: now_rfc3339(),
+            heartbeat_at: now_rfc3339(),
+            updated_at: now_rfc3339(),
+            finished_at: None,
+        },
+    };
+    let is_new_run = run.export_id.is_none() && run.chroma_processed == 0;
+
+    // Disk preflight before any vector write. The Chroma snapshot size is not
+    // known yet, so active screenshots are the conservative upper bound.
+    let expected_rows = storage.count_active_screenshots()?.max(0) as u64;
+    let preflight = storage.minilm_migration_disk_preflight(expected_rows)?;
+    run.required_free_bytes = preflight.required_free_bytes;
+    run.available_free_bytes = preflight.available_free_bytes;
+    if !preflight.sufficient {
+        return Err(format!(
+            "INSUFFICIENT_DISK_SPACE: the migration needs about {} MB free, {} MB available",
+            preflight.required_free_bytes / (1024 * 1024),
+            preflight.available_free_bytes / (1024 * 1024),
+        ));
+    }
+
+    let Some(maintenance) = crate::maintenance::enter("minilm_migration") else {
+        return Err(crate::maintenance::MAINTENANCE_IN_PROGRESS.to_string());
+    };
+
+    if is_new_run && storage.get_minilm_migration_run(&run.run_id)?.is_none() {
+        storage.create_minilm_migration_run(&run)?;
+    } else {
+        storage.update_minilm_migration_run(&run)?;
+    }
+
+    *migration
+        .diagnostics
+        .lock()
+        .unwrap_or_else(|e| e.into_inner()) = Vec::new();
+    *migration.run_id.lock().unwrap_or_else(|e| e.into_inner()) = Some(run.run_id.clone());
+    migration.update(|status| *status = status_from_run(&run, true));
+
+    let worker_state = migration.clone();
+    let worker_app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        run_minilm_migration(worker_app, worker_state, run, maintenance).await;
+    });
+    Ok(migration
+        .status
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone())
+}
+
+#[tauri::command]
+pub fn get_minilm_rebuild_status(
+    app: AppHandle,
+    migration: State<'_, Arc<MinilmMigrationState>>,
+) -> Result<MinilmRebuildStatus, String> {
+    if migration.running.load(Ordering::SeqCst) {
+        return Ok(migration
+            .status
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone());
+    }
+    // No live worker: report the latest persisted run so an interrupted
+    // migration is visible (and resumable) after a restart.
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+    match storage.get_latest_minilm_migration_run() {
+        Ok(Some(run)) => {
+            let mut status = status_from_run(&run, false);
+            if run_is_resumable(&run) {
+                status.phase = "interrupted".to_string();
+            }
+            Ok(status)
+        }
+        Ok(None) => Ok(MinilmRebuildStatus::default()),
+        Err(_) => {
+            // Locked/uninitialized database: fall back to the in-memory view
+            // instead of failing a pure status query.
+            Ok(migration
+                .status
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone())
+        }
+    }
+}
+
+#[tauri::command]
+pub fn list_minilm_rebuild_errors(
+    app: AppHandle,
+    credential: State<'_, Arc<CredentialManagerState>>,
+    migration: State<'_, Arc<MinilmMigrationState>>,
+    storage: State<'_, Arc<StorageState>>,
+    offset: Option<u32>,
+    limit: Option<u32>,
+) -> Result<serde_json::Value, String> {
+    crate::commands::check_auth_required(&credential)?;
+    let offset = offset.unwrap_or(0);
+    let limit = limit.unwrap_or(100).clamp(1, 500);
+    let diagnostics = migration
+        .diagnostics
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    let run_id = migration
+        .run_id
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+        .or_else(|| {
+            app.state::<Arc<StorageState>>()
+                .get_latest_minilm_migration_run()
+                .ok()
+                .flatten()
+                .map(|run| run.run_id)
+        });
+    let persisted = match &run_id {
+        Some(run_id) => storage.list_minilm_migration_errors(run_id, offset, limit)?,
+        None => Vec::new(),
+    };
+    let failed = storage.list_derived_index_jobs(
+        DerivedIndexKind::SemanticText,
+        Some(DerivedIndexJobStatus::Failed),
+        offset,
+        limit,
+    )?;
+    let discarded = storage.list_derived_index_jobs(
+        DerivedIndexKind::SemanticText,
+        Some(DerivedIndexJobStatus::Discarded),
+        offset,
+        limit,
+    )?;
+    Ok(serde_json::json!({
+        "run_id": run_id,
+        "diagnostics": diagnostics,
+        "persisted": persisted,
+        "failed": failed,
+        "discarded": discarded,
+    }))
+}
+
+/// Best-effort Python→Rust dual-write for newly produced MiniLM vectors. The
+/// caller-provided metadata is deliberately ignored; source text and its
+/// fingerprint are rehydrated from SQLite.
+pub(crate) fn import_minilm_vector_from_python(
+    storage: &StorageState,
+    screenshot_id: i64,
+    vector: Vec<f32>,
+) -> Result<EnsureDerivedIndexJobResult, String> {
+    if screenshot_id <= 0 {
+        return Err("screenshot_id must be positive".to_string());
+    }
+    validate_vector(&vector)?;
+    let summaries = storage
+        .get_screenshot_summaries_by_ids_silent(&[screenshot_id])
+        .map_err(background_error)?;
+    let ocr = storage
+        .get_ocr_text_prefixes_by_screenshot_ids_silent(&[screenshot_id], MINILM_OCR_SNIPPET_CHARS)
+        .map_err(background_error)?;
+    let mut sources = source_rows(summaries, &ocr);
+    let source = sources
+        .pop()
+        .ok_or_else(|| "No active SQLite screenshot maps to screenshot_id".to_string())?;
+    if source.text.is_empty() {
+        return Err("SQLite source produces an empty MiniLM input".to_string());
+    }
+    let ensured = storage.ensure_derived_index_job(&source.spec)?;
+    if matches!(
+        ensured,
+        EnsureDerivedIndexJobResult::Queued | EnsureDerivedIndexJobResult::Requeued
+    ) {
+        let lease = storage.mark_derived_index_job_processing(&source.spec)?;
+        if let Err(error) = storage.commit_derived_embedding(&DerivedEmbeddingWrite {
+            job: source.spec.clone(),
+            lease_token: lease.clone(),
+            vector,
+        }) {
+            let _ = storage.mark_derived_index_job_failed(
+                &source.spec,
+                &lease,
+                "rust_store_write_failed",
+                &error,
+                None,
+            );
+            return Err(error);
+        }
+    }
+    Ok(ensured)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_text_matches_python_contract_and_unicode_slice() {
+        let ocr = format!("  {}tail", "界".repeat(199));
+        let text = build_minilm_task_text("proc", "title", &ocr);
+        assert!(text.starts_with("proc | title | "));
+        assert_eq!(text.chars().filter(|c| *c == '界').count(), 198);
+        assert!(!text.ends_with("tail"));
+        assert_eq!(build_minilm_task_text("", "", "  "), "");
+    }
+
+    #[test]
+    fn fingerprint_is_versioned_and_deterministic() {
+        let first = minilm_source_fingerprint("proc | title | OCR");
+        assert_eq!(first, minilm_source_fingerprint("proc | title | OCR"));
+        assert_ne!(first, minilm_source_fingerprint("proc | title | OCR2"));
+        assert_eq!(first.len(), 64);
+    }
+
+    #[test]
+    fn spec_records_vector_space_contract_not_one_runtime_artifact() {
+        let spec = minilm_spec(7, "proc | title | OCR");
+        assert_eq!(spec.model_revision, MINILM_VECTOR_SPACE_REVISION);
+        assert_eq!(spec.model_revision, "minilm-l12-vector-space-v1");
+        assert!(!spec
+            .model_revision
+            .chars()
+            .all(|character| character.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn auth_required_detection_accepts_monitor_error_context() {
+        assert!(is_auth_required_error("AUTH_REQUIRED"));
+        assert!(is_auth_required_error(
+            "monitor rejected request: AUTH_REQUIRED"
+        ));
+        assert!(!is_auth_required_error("monitor unavailable"));
+    }
+
+    #[test]
+    fn vector_validation_rejects_wrong_shape_non_finite_and_zero_vectors() {
+        assert!(validate_vector(&vec![0.25; MINILM_DIMENSIONS]).is_ok());
+        assert!(validate_vector(&vec![0.25; 10]).is_err());
+        let mut invalid = vec![0.25; MINILM_DIMENSIONS];
+        invalid[3] = f32::NAN;
+        assert!(validate_vector(&invalid).is_err());
+        assert!(validate_vector(&vec![0.0; MINILM_DIMENSIONS])
+            .unwrap_err()
+            .contains("zero vector"));
+    }
+
+    #[test]
+    fn export_page_base64_roundtrip_and_size_check() {
+        let vector: Vec<f32> = (0..MINILM_DIMENSIONS).map(|i| i as f32 * 0.5).collect();
+        let bytes: Vec<u8> = vector.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let page = TaskVectorExportPage {
+            ids: vec!["7".to_string()],
+            dimensions: MINILM_DIMENSIONS,
+            embeddings_f32_le_b64: base64::engine::general_purpose::STANDARD.encode(&bytes),
+            missing_ids: Vec::new(),
+            errors: Vec::new(),
+            next_cursor: 1,
+            done: true,
+            total: 1,
+        };
+        let decoded = decode_export_page_vectors(&page).unwrap();
+        assert_eq!(decoded, vec![vector]);
+
+        let truncated = TaskVectorExportPage {
+            embeddings_f32_le_b64: base64::engine::general_purpose::STANDARD
+                .encode(&bytes[..bytes.len() - 4]),
+            ids: vec!["7".to_string()],
+            dimensions: MINILM_DIMENSIONS,
+            missing_ids: Vec::new(),
+            errors: Vec::new(),
+            next_cursor: 1,
+            done: true,
+            total: 1,
+        };
+        assert!(decode_export_page_vectors(&truncated).is_err());
+    }
+
+    #[test]
+    fn resumable_run_detection() {
+        let mut run = test_run("running");
+        assert!(run_is_resumable(&run));
+        run.status = "failed".to_string();
+        assert!(run_is_resumable(&run));
+        run.status = "cancelled".to_string();
+        assert!(!run_is_resumable(&run));
+        run.status = "completed".to_string();
+        assert!(!run_is_resumable(&run));
+    }
+
+    #[test]
+    fn resume_rejects_legacy_manual_modes_and_other_vector_spaces() {
+        let run = test_run("failed");
+        assert!(run_is_compatible_resume(&run));
+
+        let mut legacy_manual = run.clone();
+        legacy_manual.mode = "copy_chroma_hot_layer".to_string();
+        assert!(!run_is_compatible_resume(&legacy_manual));
+
+        let mut old_vector_space = run;
+        old_vector_space.vector_space_revision = "minilm-l12-vector-space-v0".to_string();
+        assert!(!run_is_compatible_resume(&old_vector_space));
+    }
+
+    fn test_run(status: &str) -> MinilmMigrationRunRecord {
+        MinilmMigrationRunRecord {
+            run_id: "run".to_string(),
+            mode: MINILM_MIGRATION_MODE.to_string(),
+            vector_space_revision: MINILM_VECTOR_SPACE_REVISION.to_string(),
+            status: status.to_string(),
+            phase: "copying_chroma".to_string(),
+            export_id: None,
+            export_cursor: 0,
+            chroma_total: 0,
+            chroma_processed: 0,
+            migrated: 0,
+            legacy_unverified: 0,
+            already_current: 0,
+            failed: 0,
+            discarded: 0,
+            unmappable: 0,
+            removed_extra: 0,
+            publish_current: 0,
+            publish_total: 0,
+            required_free_bytes: 0,
+            available_free_bytes: 0,
+            monitor_was_running: false,
+            monitor_was_paused: false,
+            last_error: None,
+            started_at: String::new(),
+            heartbeat_at: String::new(),
+            updated_at: String::new(),
+            finished_at: None,
+        }
+    }
+
+    #[test]
+    fn auto_migration_decision_uses_only_the_sentinel() {
+        use AutoMigrationDecision::*;
+        assert_eq!(auto_migration_decision(true), AlreadyDone);
+        // The sentinel is the sole completion authority. Missing means run a
+        // full copy even if legacy history claims it previously completed.
+        assert_eq!(auto_migration_decision(false), Start);
+    }
+
+    #[test]
+    fn only_terminal_full_copy_statuses_settle_the_sentinel() {
+        assert!(run_settles_sentinel(&test_run("completed")));
+        assert!(run_settles_sentinel(&test_run("completed_with_errors")));
+        assert!(!run_settles_sentinel(&test_run("failed")));
+        assert!(!run_settles_sentinel(&test_run("running")));
+    }
+}

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -572,7 +572,7 @@ async fn dispatch_typed_monitor_command(
     forward_command_to_python(&state, payload).await
 }
 
-async fn authenticated_monitor_command(
+pub(crate) async fn authenticated_monitor_command(
     credential_state: &crate::credential_manager::CredentialManagerState,
     state: &MonitorState,
     payload: Value,
@@ -1753,6 +1753,7 @@ pub async fn start_monitor(
     app: AppHandle,
 ) -> Result<String, String> {
     crate::commands::check_main_window(&window)?;
+    crate::maintenance::guard()?;
     start_monitor_impl(state, app).await
 }
 
@@ -2005,6 +2006,7 @@ pub async fn stop_monitor(
     app: AppHandle,
 ) -> Result<String, String> {
     crate::commands::check_main_window(&window)?;
+    crate::maintenance::guard()?;
     stop_monitor_impl(state, capture_state, app).await
 }
 
@@ -2031,6 +2033,7 @@ pub async fn pause_monitor(
     app: AppHandle,
 ) -> Result<String, String> {
     crate::commands::check_main_window(&window)?;
+    crate::maintenance::guard()?;
     pause_monitor_impl(state, capture_state, app).await
 }
 
@@ -2055,6 +2058,7 @@ pub async fn resume_monitor(
     app: AppHandle,
 ) -> Result<String, String> {
     crate::commands::check_main_window(&window)?;
+    crate::maintenance::guard()?;
     resume_monitor_impl(state, capture_state, app).await
 }
 

--- a/src-tauri/src/reverse_ipc.rs
+++ b/src-tauri/src/reverse_ipc.rs
@@ -602,6 +602,11 @@ fn process_request(
     let command = req.get("command").and_then(|c| c.as_str()).unwrap_or("");
     let diag_start = std::time::Instant::now();
 
+    if crate::maintenance::is_active() && !crate::maintenance::reverse_ipc_command_allowed(command)
+    {
+        return StorageResponse::error(crate::maintenance::MAINTENANCE_IN_PROGRESS);
+    }
+
     let response = match command {
         "save_screenshot" => {
             // 解析保存截图请求
@@ -957,6 +962,106 @@ fn process_request(
                     StorageResponse::success(serde_json::json!({ "screenshots": out }))
                 }
                 Err(error) => background_read_error_response(error),
+            }
+        }
+
+        "upsert_minilm_derived_embeddings" => {
+            if !storage.is_session_valid() {
+                return StorageResponse::error("AUTH_REQUIRED");
+            }
+            let Some(records) = req.get("records").and_then(|value| value.as_array()) else {
+                return StorageResponse::error("records must be an array");
+            };
+            if records.len() > 128 {
+                return StorageResponse::error("MiniLM dual-write batch exceeds 128 records");
+            }
+            let mut completed = 0_u64;
+            let mut already_current = 0_u64;
+            let mut errors = Vec::new();
+            for record in records {
+                let screenshot_id = record
+                    .get("screenshot_id")
+                    .and_then(|value| value.as_i64())
+                    .unwrap_or(0);
+                let vector: Vec<f32> =
+                    match record.get("embedding").cloned().map(serde_json::from_value) {
+                        Some(Ok(vector)) => vector,
+                        Some(Err(error)) => {
+                            errors.push(serde_json::json!({
+                                "screenshot_id": screenshot_id,
+                                "error": format!("invalid embedding: {error}"),
+                            }));
+                            continue;
+                        }
+                        None => {
+                            errors.push(serde_json::json!({
+                                "screenshot_id": screenshot_id,
+                                "error": "embedding is required",
+                            }));
+                            continue;
+                        }
+                    };
+                match crate::minilm_migration::import_minilm_vector_from_python(
+                    storage,
+                    screenshot_id,
+                    vector,
+                ) {
+                    Ok(crate::storage::EnsureDerivedIndexJobResult::Queued)
+                    | Ok(crate::storage::EnsureDerivedIndexJobResult::Requeued) => completed += 1,
+                    Ok(_) => already_current += 1,
+                    Err(error) => errors.push(serde_json::json!({
+                        "screenshot_id": screenshot_id,
+                        "error": error,
+                    })),
+                }
+            }
+            StorageResponse::success(serde_json::json!({
+                "completed": completed,
+                "already_current": already_current,
+                "errors": errors,
+            }))
+        }
+
+        "delete_minilm_derived_embeddings" => {
+            if !storage.is_session_valid() {
+                return StorageResponse::error("AUTH_REQUIRED");
+            }
+            let Some(ids) = req.get("screenshot_ids").and_then(|value| value.as_array()) else {
+                return StorageResponse::error("screenshot_ids must be an array");
+            };
+            if ids.len() > 128 {
+                return StorageResponse::error("MiniLM delete batch exceeds 128 records");
+            }
+            let mut deleted = 0_u64;
+            let mut errors = Vec::new();
+            for value in ids {
+                let screenshot_id = value.as_i64().unwrap_or(0);
+                if screenshot_id <= 0 {
+                    errors.push(serde_json::json!({
+                        "screenshot_id": screenshot_id,
+                        "error": "screenshot_id must be positive",
+                    }));
+                    continue;
+                }
+                match storage.delete_derived_index_subject(
+                    crate::storage::DerivedIndexKind::SemanticText,
+                    &screenshot_id.to_string(),
+                ) {
+                    Ok(true) => deleted += 1,
+                    Ok(false) => {}
+                    Err(error) => errors.push(serde_json::json!({
+                        "screenshot_id": screenshot_id,
+                        "error": error,
+                    })),
+                }
+            }
+            if errors.is_empty() {
+                StorageResponse::success(serde_json::json!({ "deleted": deleted }))
+            } else {
+                StorageResponse::error(&format!(
+                    "Failed to delete {} MiniLM rows",
+                    errors.len()
+                ))
             }
         }
 
@@ -1471,6 +1576,11 @@ async fn process_nmh_request(
     app_handle: tauri::AppHandle,
 ) -> StorageResponse {
     let command = req.get("command").and_then(|c| c.as_str()).unwrap_or("");
+
+    if crate::maintenance::is_active() && !crate::maintenance::reverse_ipc_command_allowed(command)
+    {
+        return StorageResponse::error(crate::maintenance::MAINTENANCE_IN_PROGRESS);
+    }
 
     match command {
         "register_nmh" => {

--- a/src-tauri/src/storage/derived_index.rs
+++ b/src-tauri/src/storage/derived_index.rs
@@ -19,10 +19,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const SIDECAR_MAGIC: &[u8; 8] = b"CPDVEC01";
 const SIDECAR_FORMAT_VERSION: u32 = 3;
 const MAX_SUBJECT_KEY_BYTES: usize = 1024;
-const MAX_METADATA_BYTES: usize = 4096;
+pub(super) const MAX_METADATA_BYTES: usize = 4096;
 const MAX_VECTOR_DIMENSIONS: usize = 65_536;
 const SIDECAR_PAGE_SIZE: u32 = 512;
 const LEASE_TOKEN_BYTES: usize = 16;
+pub const DERIVED_GENERATION_CANCELLED: &str = "DERIVED_GENERATION_CANCELLED";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -111,6 +112,15 @@ pub struct DerivedIndexJobRecord {
     pub updated_at: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnsureDerivedIndexJobResult {
+    Queued,
+    Requeued,
+    AlreadyCurrent,
+    AlreadyProcessing,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DerivedIndexGeneration {
     pub index_kind: DerivedIndexKind,
@@ -149,6 +159,130 @@ struct DerivedWorkerJobUpdate<'a> {
 }
 
 impl StorageState {
+    /// Ensure one subject has a ledger entry without reviving a current result.
+    /// A changed model/source contract queues fresh work; a matching completed
+    /// result is always reused so migration cannot accidentally recompute it.
+    pub fn ensure_derived_index_job(
+        &self,
+        spec: &DerivedIndexJobSpec,
+    ) -> Result<EnsureDerivedIndexJobResult, String> {
+        validate_job_spec(spec)?;
+        let mut guard = self.get_connection_named("ensure_derived_index_job")?;
+        let conn = guard.as_mut().ok_or("Database not initialized")?;
+        let tx = conn
+            .transaction()
+            .map_err(|error| format!("Failed to start derived job transaction: {error}"))?;
+        if !derived_subject_is_active(&tx, spec.index_kind, &spec.subject_key)? {
+            return Err("Cannot queue a derived index job for an inactive subject".to_string());
+        }
+
+        let existing = tx
+            .query_row(
+                r#"
+                SELECT status, model_id, model_revision, embedding_version,
+                       source_fingerprint
+                FROM derived_index_jobs
+                WHERE index_kind = ?1 AND subject_key = ?2
+                "#,
+                params![spec.index_kind.as_str(), spec.subject_key],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, String>(4)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(|error| format!("Failed to inspect derived index job: {error}"))?;
+
+        let result = match existing {
+            None => {
+                tx.execute(
+                    r#"
+                    INSERT INTO derived_index_jobs (
+                        index_kind, subject_key, status, attempts, model_id,
+                        model_revision, embedding_version, source_fingerprint, updated_at
+                    ) VALUES (?1, ?2, 'pending', 0, ?3, ?4, ?5, ?6, CURRENT_TIMESTAMP)
+                    "#,
+                    params![
+                        spec.index_kind.as_str(),
+                        spec.subject_key,
+                        spec.model_id,
+                        spec.model_revision,
+                        spec.embedding_version,
+                        spec.source_fingerprint,
+                    ],
+                )
+                .map_err(|error| format!("Failed to create derived index job: {error}"))?;
+                EnsureDerivedIndexJobResult::Queued
+            }
+            Some((status, model_id, model_revision, embedding_version, source_fingerprint)) => {
+                let contract_matches = model_id == spec.model_id
+                    && model_revision == spec.model_revision
+                    && embedding_version == i64::from(spec.embedding_version)
+                    && source_fingerprint == spec.source_fingerprint;
+                if contract_matches {
+                    match DerivedIndexJobStatus::from_db(&status)? {
+                        DerivedIndexJobStatus::Completed => {
+                            EnsureDerivedIndexJobResult::AlreadyCurrent
+                        }
+                        DerivedIndexJobStatus::Processing => {
+                            EnsureDerivedIndexJobResult::AlreadyProcessing
+                        }
+                        DerivedIndexJobStatus::Pending => EnsureDerivedIndexJobResult::Queued,
+                        DerivedIndexJobStatus::Failed
+                        | DerivedIndexJobStatus::WaitingForAuth
+                        | DerivedIndexJobStatus::Discarded => {
+                            tx.execute(
+                                r#"
+                                UPDATE derived_index_jobs
+                                SET status = 'pending', error_code = NULL, error = NULL,
+                                    next_retry_at = NULL, lease_token = NULL,
+                                    updated_at = CURRENT_TIMESTAMP
+                                WHERE index_kind = ?1 AND subject_key = ?2
+                                "#,
+                                params![spec.index_kind.as_str(), spec.subject_key],
+                            )
+                            .map_err(|error| {
+                                format!("Failed to resume derived index job: {error}")
+                            })?;
+                            EnsureDerivedIndexJobResult::Requeued
+                        }
+                    }
+                } else {
+                    tx.execute(
+                        r#"
+                        UPDATE derived_index_jobs
+                        SET status = 'pending', error_code = NULL, error = NULL,
+                            attempts = 0,
+                            next_retry_at = NULL, lease_token = NULL,
+                            model_id = ?3, model_revision = ?4,
+                            embedding_version = ?5, source_fingerprint = ?6,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE index_kind = ?1 AND subject_key = ?2
+                        "#,
+                        params![
+                            spec.index_kind.as_str(),
+                            spec.subject_key,
+                            spec.model_id,
+                            spec.model_revision,
+                            spec.embedding_version,
+                            spec.source_fingerprint,
+                        ],
+                    )
+                    .map_err(|error| format!("Failed to requeue derived index job: {error}"))?;
+                    EnsureDerivedIndexJobResult::Requeued
+                }
+            }
+        };
+        tx.commit()
+            .map_err(|error| format!("Failed to commit derived job transaction: {error}"))?;
+        Ok(result)
+    }
+
     /// Queue or re-queue one derived subject. A changed source/model contract
     /// resets its retry budget and immediately hides any stale vector.
     pub fn upsert_derived_index_job(&self, spec: &DerivedIndexJobSpec) -> Result<(), String> {
@@ -253,6 +387,28 @@ impl StorageState {
                 status: DerivedIndexJobStatus::WaitingForAuth,
                 error_code: Some("authentication_required"),
                 error,
+                next_retry_at: None,
+                increment_attempts: false,
+            },
+        )
+    }
+
+    /// Release a processing lease without charging the retry budget. This is
+    /// used by explicit cancellation so the next run resumes.
+    pub fn requeue_derived_index_job(
+        &self,
+        spec: &DerivedIndexJobSpec,
+        lease_token: &str,
+        reason_code: &str,
+        reason: &str,
+    ) -> Result<(), String> {
+        self.set_derived_worker_job_state(
+            spec,
+            lease_token,
+            DerivedWorkerJobUpdate {
+                status: DerivedIndexJobStatus::Pending,
+                error_code: Some(reason_code),
+                error: Some(reason),
                 next_retry_at: None,
                 increment_attempts: false,
             },
@@ -781,6 +937,26 @@ impl StorageState {
         &self,
         index_kind: DerivedIndexKind,
     ) -> Result<DerivedIndexGeneration, String> {
+        self.publish_derived_index_generation_with_progress(
+            index_kind,
+            |_phase, _current, _total| {},
+            || false,
+        )
+    }
+
+    /// Publish a generation on a blocking worker with cooperative cancellation
+    /// and bounded progress callbacks. `sync_all` itself cannot be interrupted;
+    /// callers should present that phase as a short safe-write interval.
+    pub fn publish_derived_index_generation_with_progress<P, C>(
+        &self,
+        index_kind: DerivedIndexKind,
+        mut progress: P,
+        cancelled: C,
+    ) -> Result<DerivedIndexGeneration, String>
+    where
+        P: FnMut(&str, u64, u64),
+        C: Fn() -> bool,
+    {
         if self.is_migration_in_progress() {
             return Err("Cannot publish a derived index during data migration".to_string());
         }
@@ -808,22 +984,50 @@ impl StorageState {
         let file_name = format!("{}-{generation}.cpdvec", index_kind.as_str());
         let final_path = sidecar_dir.join(&file_name);
         let temp_path = sidecar_dir.join(format!(".{file_name}.tmp"));
-        let checksum_sha256 =
-            match self.write_sidecar_streaming(&temp_path, index_kind, generation, &snapshot) {
+        if cancelled() {
+            return Err(DERIVED_GENERATION_CANCELLED.to_string());
+        }
+        let checksum_sha256 = match self.write_sidecar_streaming(
+            &temp_path,
+            index_kind,
+            generation,
+            &snapshot,
+            &mut progress,
+            &cancelled,
+        ) {
                 Ok(checksum) => checksum,
                 Err(error) => {
                     let _ = fs::remove_file(&temp_path);
                     return Err(error);
                 }
             };
-        if let Err(error) = verify_sidecar(&temp_path, &checksum_sha256) {
+        if cancelled() {
+            let _ = fs::remove_file(&temp_path);
+            return Err(DERIVED_GENERATION_CANCELLED.to_string());
+        }
+        if let Err(error) = verify_sidecar_with_progress(
+            &temp_path,
+            &checksum_sha256,
+            &mut progress,
+            &cancelled,
+        ) {
             let _ = fs::remove_file(&temp_path);
             return Err(error);
         }
+        if cancelled() {
+            let _ = fs::remove_file(&temp_path);
+            return Err(DERIVED_GENERATION_CANCELLED.to_string());
+        }
+        progress("publishing_commit", 0, 1);
         fs::rename(&temp_path, &final_path).map_err(|error| {
             let _ = fs::remove_file(&temp_path);
             format!("Failed to publish derived index generation: {error}")
         })?;
+
+        if cancelled() {
+            let _ = fs::remove_file(&final_path);
+            return Err(DERIVED_GENERATION_CANCELLED.to_string());
+        }
 
         let record = DerivedIndexGeneration {
             index_kind,
@@ -850,6 +1054,7 @@ impl StorageState {
             let _ = fs::remove_file(&final_path);
             return Err(error);
         }
+        progress("publishing_commit", 1, 1);
         Ok(record)
     }
 
@@ -1080,6 +1285,8 @@ impl StorageState {
         index_kind: DerivedIndexKind,
         generation: u64,
         snapshot: &DerivedIndexSnapshotMetadata,
+        progress: &mut impl FnMut(&str, u64, u64),
+        cancelled: &impl Fn() -> bool,
     ) -> Result<String, String> {
         let file = OpenOptions::new()
             .write(true)
@@ -1089,10 +1296,14 @@ impl StorageState {
         let mut writer = BufWriter::new(file);
         let mut hasher = Sha256::new();
         write_sidecar_header(&mut writer, &mut hasher, index_kind, generation, snapshot)?;
+        progress("publishing_write", 0, snapshot.row_count);
 
         let mut after_subject_key: Option<String> = None;
         let mut written_rows = 0u64;
         loop {
+            if cancelled() {
+                return Err(DERIVED_GENERATION_CANCELLED.to_string());
+            }
             let page = self.list_query_visible_embedding_page(
                 index_kind,
                 after_subject_key.as_deref(),
@@ -1108,6 +1319,7 @@ impl StorageState {
                 .checked_add(page.len() as u64)
                 .ok_or_else(|| "Derived generation row count overflow".to_string())?;
             after_subject_key = page.last().map(|row| row.job.subject_key.clone());
+            progress("publishing_write", written_rows, snapshot.row_count);
         }
         if written_rows != snapshot.row_count {
             return Err(format!(
@@ -1116,13 +1328,20 @@ impl StorageState {
             ));
         }
 
+        if cancelled() {
+            return Err(DERIVED_GENERATION_CANCELLED.to_string());
+        }
         writer
             .flush()
             .map_err(|error| format!("Failed to flush derived index temp file: {error}"))?;
+        progress("publishing_sync", 0, 0);
         writer
             .get_ref()
             .sync_all()
             .map_err(|error| format!("Failed to sync derived index temp file: {error}"))?;
+        if cancelled() {
+            return Err(DERIVED_GENERATION_CANCELLED.to_string());
+        }
         Ok(hex::encode(hasher.finalize()))
     }
 }
@@ -1140,7 +1359,7 @@ type RawSnapshotMetadata = (
     Option<i64>,
 );
 
-fn derived_subject_is_active(
+pub(super) fn derived_subject_is_active(
     conn: &rusqlite::Connection,
     index_kind: DerivedIndexKind,
     subject_key: &str,
@@ -1311,7 +1530,7 @@ fn decode_embedding_row(
     })
 }
 
-fn validate_job_spec(spec: &DerivedIndexJobSpec) -> Result<(), String> {
+pub(super) fn validate_job_spec(spec: &DerivedIndexJobSpec) -> Result<(), String> {
     validate_required_text("subject_key", &spec.subject_key, MAX_SUBJECT_KEY_BYTES)?;
     validate_required_text("model_id", &spec.model_id, MAX_METADATA_BYTES)?;
     validate_required_text("model_revision", &spec.model_revision, MAX_METADATA_BYTES)?;
@@ -1377,7 +1596,7 @@ fn normalize_retry_timestamp(value: Option<&str>) -> Result<Option<String>, Stri
         .map_err(|_| "next_retry_at must be RFC3339 or UTC YYYY-MM-DD HH:MM:SS".to_string())
 }
 
-fn encode_vector(vector: &[f32]) -> Result<Vec<u8>, String> {
+pub(super) fn encode_vector(vector: &[f32]) -> Result<Vec<u8>, String> {
     if vector.is_empty() {
         return Err("Derived embedding vector must not be empty".to_string());
     }
@@ -1389,6 +1608,9 @@ fn encode_vector(vector: &[f32]) -> Result<Vec<u8>, String> {
     }
     if vector.iter().any(|value| !value.is_finite()) {
         return Err("Derived embedding vector contains a non-finite value".to_string());
+    }
+    if vector.iter().all(|value| value.abs() <= f32::EPSILON) {
+        return Err("Derived embedding vector must not be a zero vector".to_string());
     }
     let mut bytes = Vec::with_capacity(std::mem::size_of_val(vector));
     for value in vector {
@@ -1497,8 +1719,26 @@ fn write_hashed(writer: &mut impl Write, hasher: &mut Sha256, bytes: &[u8]) -> R
 }
 
 fn verify_sidecar(path: &Path, expected_checksum: &str) -> Result<(), String> {
+    verify_sidecar_with_progress(
+        path,
+        expected_checksum,
+        &mut |_phase, _current, _total| {},
+        &|| false,
+    )
+}
+
+fn verify_sidecar_with_progress(
+    path: &Path,
+    expected_checksum: &str,
+    progress: &mut impl FnMut(&str, u64, u64),
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), String> {
     let file = std::fs::File::open(path)
         .map_err(|error| format!("Failed to open derived index sidecar: {error}"))?;
+    let total = file
+        .metadata()
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
     let mut reader = BufReader::new(file);
     let mut header = [0u8; SIDECAR_MAGIC.len()];
     reader
@@ -1509,8 +1749,14 @@ fn verify_sidecar(path: &Path, expected_checksum: &str) -> Result<(), String> {
     }
     let mut hasher = Sha256::new();
     hasher.update(header);
-    let mut buffer = [0u8; 64 * 1024];
+    let mut verified = header.len() as u64;
+    let mut last_reported = 0_u64;
+    progress("publishing_verify", verified, total);
+    let mut buffer = [0u8; 1024 * 1024];
     loop {
+        if cancelled() {
+            return Err(DERIVED_GENERATION_CANCELLED.to_string());
+        }
         let read = reader
             .read(&mut buffer)
             .map_err(|error| format!("Failed to read derived index sidecar: {error}"))?;
@@ -1518,6 +1764,11 @@ fn verify_sidecar(path: &Path, expected_checksum: &str) -> Result<(), String> {
             break;
         }
         hasher.update(&buffer[..read]);
+        verified = verified.saturating_add(read as u64);
+        if verified.saturating_sub(last_reported) >= 8 * 1024 * 1024 || verified >= total {
+            progress("publishing_verify", verified, total);
+            last_reported = verified;
+        }
     }
     let checksum = hex::encode(hasher.finalize());
     if checksum != expected_checksum {
@@ -1604,6 +1855,96 @@ mod tests {
         vector: Vec<f32>,
     ) -> Result<(), String> {
         storage.commit_derived_embedding(&claimed_write(storage, spec, vector))
+    }
+
+    #[test]
+    fn ensure_job_is_idempotent_until_source_change() {
+        let (_temp, storage) = test_storage();
+        let spec = job(DerivedIndexKind::SemanticText, "41");
+        ensure_active_subject(&storage, &spec);
+        assert_eq!(
+            storage.ensure_derived_index_job(&spec).unwrap(),
+            EnsureDerivedIndexJobResult::Queued
+        );
+        let lease = storage.mark_derived_index_job_processing(&spec).unwrap();
+        storage
+            .commit_derived_embedding(&DerivedEmbeddingWrite {
+                job: spec.clone(),
+                lease_token: lease,
+                vector: vec![0.5, 0.25],
+            })
+            .unwrap();
+        assert_eq!(
+            storage.ensure_derived_index_job(&spec).unwrap(),
+            EnsureDerivedIndexJobResult::AlreadyCurrent
+        );
+        assert_eq!(
+            storage
+                .get_derived_index_job(DerivedIndexKind::SemanticText, "41")
+                .unwrap()
+                .unwrap()
+                .status,
+            DerivedIndexJobStatus::Completed
+        );
+
+        let mut changed = spec.clone();
+        changed.source_fingerprint = "new-source".to_string();
+        assert_eq!(
+            storage.ensure_derived_index_job(&changed).unwrap(),
+            EnsureDerivedIndexJobResult::Requeued
+        );
+    }
+
+    #[test]
+    fn cancellation_requeue_preserves_retry_budget() {
+        let (_temp, storage) = test_storage();
+        let spec = job(DerivedIndexKind::SemanticText, "43");
+        ensure_active_subject(&storage, &spec);
+        storage.ensure_derived_index_job(&spec).unwrap();
+        let lease = storage.mark_derived_index_job_processing(&spec).unwrap();
+        storage
+            .requeue_derived_index_job(&spec, &lease, "cancelled", "cancelled by user")
+            .unwrap();
+        let record = storage
+            .get_derived_index_job(DerivedIndexKind::SemanticText, "43")
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.status, DerivedIndexJobStatus::Pending);
+        assert_eq!(record.attempts, 0);
+        assert_eq!(record.error_code.as_deref(), Some("cancelled"));
+    }
+
+    #[test]
+    fn explicit_ensure_resumes_terminal_and_delayed_jobs() {
+        let (_temp, storage) = test_storage();
+        let discarded = job(DerivedIndexKind::SemanticText, "44");
+        let lease = queue_and_claim(&storage, &discarded);
+        storage
+            .mark_derived_index_job_discarded(&discarded, &lease, "empty_model_input", "empty")
+            .unwrap();
+        assert_eq!(
+            storage.ensure_derived_index_job(&discarded).unwrap(),
+            EnsureDerivedIndexJobResult::Requeued
+        );
+
+        let failed = job(DerivedIndexKind::SemanticText, "45");
+        let lease = queue_and_claim(&storage, &failed);
+        storage
+            .mark_derived_index_job_failed(
+                &failed,
+                &lease,
+                "temporary",
+                "temporary",
+                Some("2100-01-01 00:00:00"),
+            )
+            .unwrap();
+        assert_eq!(
+            storage.ensure_derived_index_job(&failed).unwrap(),
+            EnsureDerivedIndexJobResult::Requeued
+        );
+        storage
+            .mark_derived_index_job_processing(&failed)
+            .expect("explicit ensure clears delayed retry timestamp");
     }
 
     #[test]

--- a/src-tauri/src/storage/encryption.rs
+++ b/src-tauri/src/storage/encryption.rs
@@ -63,11 +63,23 @@ impl StorageState {
         encrypted_data: &[u8],
         encrypted_key: &[u8],
     ) -> Result<Vec<u8>, BackgroundReadError> {
-        let mut row_key =
-            decrypt_row_key_with_cng_silent(encrypted_key).map_err(|error| match error {
-                CredentialError::AuthRequired => BackgroundReadError::AuthRequired,
-                other => BackgroundReadError::Other(format!("Failed to unwrap row key: {}", other)),
-            })?;
+        Self::decrypt_payload_with_unwrap(encrypted_data, encrypted_key, &|ciphertext| {
+            decrypt_row_key_with_cng_silent(ciphertext)
+        })
+    }
+
+    /// Row-payload decryption with an injected row-key unwrap, so batch
+    /// callers can reuse one `CngKeySession` handle instead of paying a CNG
+    /// open/free round-trip for every row.
+    pub(crate) fn decrypt_payload_with_unwrap(
+        encrypted_data: &[u8],
+        encrypted_key: &[u8],
+        unwrap_row_key: &dyn Fn(&[u8]) -> Result<Vec<u8>, CredentialError>,
+    ) -> Result<Vec<u8>, BackgroundReadError> {
+        let mut row_key = unwrap_row_key(encrypted_key).map_err(|error| match error {
+            CredentialError::AuthRequired => BackgroundReadError::AuthRequired,
+            other => BackgroundReadError::Other(format!("Failed to unwrap row key: {}", other)),
+        })?;
 
         let decrypted = decrypt_with_master_key(&row_key, encrypted_data)
             .map_err(|e| BackgroundReadError::Other(format!("Failed to decrypt payload: {}", e)));

--- a/src-tauri/src/storage/minilm_migration.rs
+++ b/src-tauri/src/storage/minilm_migration.rs
@@ -1,0 +1,929 @@
+//! Durable state and transactional page import for the MiniLM migration.
+
+use super::derived_index::{
+    derived_subject_is_active, encode_vector, validate_job_spec, MAX_METADATA_BYTES,
+};
+use super::policy::disk_totals_for_path;
+use super::{DerivedIndexJobSpec, DerivedIndexKind, StorageState};
+use rusqlite::{params, OptionalExtension, Transaction};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+const GIB: u64 = 1024 * 1024 * 1024;
+const MIGRATION_TRANSIENT_ALLOWANCE: u64 = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MinilmMigrationRunRecord {
+    pub run_id: String,
+    pub mode: String,
+    pub vector_space_revision: String,
+    pub status: String,
+    pub phase: String,
+    pub export_id: Option<String>,
+    pub export_cursor: u64,
+    pub chroma_total: u64,
+    pub chroma_processed: u64,
+    pub migrated: u64,
+    pub legacy_unverified: u64,
+    pub already_current: u64,
+    pub failed: u64,
+    pub discarded: u64,
+    pub unmappable: u64,
+    pub removed_extra: u64,
+    pub publish_current: u64,
+    pub publish_total: u64,
+    pub required_free_bytes: u64,
+    pub available_free_bytes: u64,
+    pub monitor_was_running: bool,
+    pub monitor_was_paused: bool,
+    pub last_error: Option<String>,
+    pub started_at: String,
+    pub heartbeat_at: String,
+    pub updated_at: String,
+    pub finished_at: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MinilmMigrationPageRow {
+    pub job: DerivedIndexJobSpec,
+    pub vector: Vec<f32>,
+    pub outcome: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MinilmMigrationPageCommit {
+    pub migrated: u64,
+    pub legacy_unverified: u64,
+    pub already_current: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MinilmMigrationDiskPreflight {
+    pub expected_rows: u64,
+    pub estimated_database_bytes: u64,
+    pub estimated_generation_bytes: u64,
+    pub estimated_snapshot_bytes: u64,
+    pub estimated_peak_bytes: u64,
+    pub required_free_bytes: u64,
+    pub available_free_bytes: u64,
+    pub sufficient: bool,
+}
+
+impl StorageState {
+    pub fn create_minilm_migration_run(
+        &self,
+        run: &MinilmMigrationRunRecord,
+    ) -> Result<(), String> {
+        validate_run_record(run)?;
+        let guard = self.get_connection_named("create_minilm_migration_run")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        conn.execute(
+            r#"
+            INSERT INTO minilm_migration_runs (
+                run_id, mode, vector_space_revision, status, phase,
+                export_id, export_cursor, chroma_total, chroma_processed,
+                migrated, legacy_unverified, already_current, failed, discarded,
+                unmappable, removed_extra, publish_current, publish_total,
+                required_free_bytes, available_free_bytes,
+                monitor_was_running, monitor_was_paused, last_error,
+                started_at, heartbeat_at, updated_at, finished_at
+            ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23,
+                ?24, ?25, ?26, ?27
+            )
+            "#,
+            run_params(run),
+        )
+        .map_err(|error| format!("Failed to create MiniLM migration run: {error}"))?;
+        Ok(())
+    }
+
+    pub fn update_minilm_migration_run(
+        &self,
+        run: &MinilmMigrationRunRecord,
+    ) -> Result<(), String> {
+        validate_run_record(run)?;
+        let guard = self.get_connection_named("update_minilm_migration_run")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        let changed = conn
+            .execute(
+                r#"
+                UPDATE minilm_migration_runs SET
+                    mode = ?2, vector_space_revision = ?3, status = ?4,
+                    phase = ?5, export_id = ?6, export_cursor = ?7,
+                    chroma_total = ?8, chroma_processed = ?9,
+                    migrated = ?10, legacy_unverified = ?11,
+                    already_current = ?12, failed = ?13, discarded = ?14,
+                    unmappable = ?15, removed_extra = ?16,
+                    publish_current = ?17, publish_total = ?18,
+                    required_free_bytes = ?19, available_free_bytes = ?20,
+                    monitor_was_running = ?21, monitor_was_paused = ?22,
+                    last_error = ?23, started_at = ?24, heartbeat_at = ?25,
+                    updated_at = ?26, finished_at = ?27
+                WHERE run_id = ?1
+                "#,
+                run_params(run),
+            )
+            .map_err(|error| format!("Failed to update MiniLM migration run: {error}"))?;
+        if changed == 0 {
+            return Err("MiniLM migration run no longer exists".to_string());
+        }
+        Ok(())
+    }
+
+    pub fn get_latest_minilm_migration_run(
+        &self,
+    ) -> Result<Option<MinilmMigrationRunRecord>, String> {
+        let guard = self.get_connection_named("get_latest_minilm_migration_run")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        conn.query_row(
+            &format!(
+                "{} ORDER BY datetime(updated_at) DESC, rowid DESC LIMIT 1",
+                minilm_run_select_sql()
+            ),
+            [],
+            map_minilm_run,
+        )
+        .optional()
+        .map_err(|error| format!("Failed to read latest MiniLM migration run: {error}"))?
+        .map(decode_minilm_run)
+        .transpose()
+    }
+
+    pub fn get_minilm_migration_run(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<MinilmMigrationRunRecord>, String> {
+        let guard = self.get_connection_named("get_minilm_migration_run")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        conn.query_row(
+            &format!("{} AND run_id = ?1", minilm_run_select_sql()),
+            [run_id],
+            map_minilm_run,
+        )
+        .optional()
+        .map_err(|error| format!("Failed to read MiniLM migration run: {error}"))?
+        .map(decode_minilm_run)
+        .transpose()
+    }
+
+    pub fn reset_minilm_migration_export(&self, run_id: &str) -> Result<(), String> {
+        let mut guard = self.get_connection_named("reset_minilm_migration_export")?;
+        let conn = guard.as_mut().ok_or("Database not initialized")?;
+        let tx = conn
+            .transaction()
+            .map_err(|error| format!("Failed to start MiniLM reset transaction: {error}"))?;
+        tx.execute(
+            "DELETE FROM minilm_migration_subjects WHERE run_id = ?1",
+            [run_id],
+        )
+        .map_err(|error| format!("Failed to clear MiniLM migration subjects: {error}"))?;
+        tx.execute(
+            r#"
+            UPDATE minilm_migration_runs
+               SET export_id = NULL, export_cursor = 0, chroma_total = 0,
+                   chroma_processed = 0, migrated = 0,
+                   legacy_unverified = 0, already_current = 0,
+                   unmappable = 0, failed = 0, last_error = NULL,
+                   heartbeat_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+             WHERE run_id = ?1
+            "#,
+            [run_id],
+        )
+        .map_err(|error| format!("Failed to reset MiniLM migration run: {error}"))?;
+        tx.commit()
+            .map_err(|error| format!("Failed to commit MiniLM reset transaction: {error}"))
+    }
+
+    pub fn commit_minilm_migration_page(
+        &self,
+        run_id: &str,
+        expected_cursor: u64,
+        next_cursor: u64,
+        rows: &[MinilmMigrationPageRow],
+    ) -> Result<MinilmMigrationPageCommit, String> {
+        if next_cursor < expected_cursor {
+            return Err("MiniLM migration cursor moved backwards".to_string());
+        }
+        for row in rows {
+            validate_job_spec(&row.job)?;
+            if row.job.index_kind != DerivedIndexKind::SemanticText {
+                return Err("MiniLM migration can only import semantic text rows".to_string());
+            }
+            validate_outcome(&row.outcome)?;
+            encode_vector(&row.vector)?;
+        }
+
+        let mut guard = self.get_connection_named("commit_minilm_migration_page")?;
+        let conn = guard.as_mut().ok_or("Database not initialized")?;
+        let tx = conn
+            .transaction()
+            .map_err(|error| format!("Failed to start MiniLM page transaction: {error}"))?;
+        let stored_cursor: i64 = tx
+            .query_row(
+                "SELECT export_cursor FROM minilm_migration_runs WHERE run_id = ?1",
+                [run_id],
+                |row| row.get(0),
+            )
+            .map_err(|error| format!("Failed to read MiniLM page cursor: {error}"))?;
+        let stored_cursor = u64::try_from(stored_cursor)
+            .map_err(|_| "Stored MiniLM migration cursor is invalid".to_string())?;
+        if stored_cursor != expected_cursor {
+            return Err(format!(
+                "MiniLM migration cursor mismatch: expected {expected_cursor}, stored {stored_cursor}"
+            ));
+        }
+
+        let mut result = MinilmMigrationPageCommit::default();
+        for row in rows {
+            if !derived_subject_is_active(&tx, row.job.index_kind, &row.job.subject_key)? {
+                return Err(format!(
+                    "Cannot import inactive MiniLM subject {}",
+                    row.job.subject_key
+                ));
+            }
+            let already_current = query_job_is_current(&tx, &row.job)?;
+            write_completed_embedding(&tx, row)?;
+            tx.execute(
+                r#"
+                INSERT INTO minilm_migration_subjects (
+                    run_id, subject_key, outcome, source_fingerprint, updated_at
+                ) VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP)
+                ON CONFLICT(run_id, subject_key) DO UPDATE SET
+                    outcome = excluded.outcome,
+                    source_fingerprint = excluded.source_fingerprint,
+                    updated_at = CURRENT_TIMESTAMP
+                "#,
+                params![
+                    run_id,
+                    row.job.subject_key,
+                    row.outcome,
+                    row.job.source_fingerprint,
+                ],
+            )
+            .map_err(|error| format!("Failed to record MiniLM migration subject: {error}"))?;
+
+            if row.outcome == "legacy_chroma_unverified" {
+                result.legacy_unverified = result.legacy_unverified.saturating_add(1);
+            } else if already_current {
+                result.already_current = result.already_current.saturating_add(1);
+            } else {
+                result.migrated = result.migrated.saturating_add(1);
+            }
+        }
+
+        let consumed = next_cursor.saturating_sub(expected_cursor);
+        tx.execute(
+            r#"
+            UPDATE minilm_migration_runs SET
+                export_cursor = ?2,
+                chroma_processed = chroma_processed + ?3,
+                migrated = migrated + ?4,
+                legacy_unverified = legacy_unverified + ?5,
+                already_current = already_current + ?6,
+                heartbeat_at = CURRENT_TIMESTAMP,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE run_id = ?1
+            "#,
+            params![
+                run_id,
+                i64::try_from(next_cursor).map_err(|_| "MiniLM cursor overflow")?,
+                i64::try_from(consumed).map_err(|_| "MiniLM page size overflow")?,
+                i64::try_from(result.migrated).map_err(|_| "MiniLM migrated count overflow")?,
+                i64::try_from(result.legacy_unverified)
+                    .map_err(|_| "MiniLM unverified count overflow")?,
+                i64::try_from(result.already_current)
+                    .map_err(|_| "MiniLM current count overflow")?,
+            ],
+        )
+        .map_err(|error| format!("Failed to advance MiniLM migration cursor: {error}"))?;
+        tx.commit()
+            .map_err(|error| format!("Failed to commit MiniLM page transaction: {error}"))?;
+        Ok(result)
+    }
+
+    pub fn record_minilm_migration_subject(
+        &self,
+        run_id: &str,
+        spec: &DerivedIndexJobSpec,
+        outcome: &str,
+    ) -> Result<(), String> {
+        validate_job_spec(spec)?;
+        validate_outcome(outcome)?;
+        let guard = self.get_connection_named("record_minilm_migration_subject")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        conn.execute(
+            r#"
+            INSERT INTO minilm_migration_subjects (
+                run_id, subject_key, outcome, source_fingerprint, updated_at
+            ) VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP)
+            ON CONFLICT(run_id, subject_key) DO UPDATE SET
+                outcome = excluded.outcome,
+                source_fingerprint = excluded.source_fingerprint,
+                updated_at = CURRENT_TIMESTAMP
+            "#,
+            params![run_id, spec.subject_key, outcome, spec.source_fingerprint],
+        )
+        .map_err(|error| format!("Failed to record MiniLM migration subject: {error}"))?;
+        Ok(())
+    }
+
+    pub fn list_minilm_migration_subject_ids(&self, run_id: &str) -> Result<HashSet<i64>, String> {
+        let guard = self.get_connection_named("list_minilm_migration_subject_ids")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        let mut statement = conn
+            .prepare("SELECT subject_key FROM minilm_migration_subjects WHERE run_id = ?1")
+            .map_err(|error| format!("Failed to prepare MiniLM subject query: {error}"))?;
+        let rows = statement
+            .query_map([run_id], |row| row.get::<_, String>(0))
+            .map_err(|error| format!("Failed to query MiniLM migration subjects: {error}"))?;
+        let mut ids = HashSet::new();
+        for row in rows {
+            let subject =
+                row.map_err(|error| format!("Failed to read MiniLM migration subject: {error}"))?;
+            if let Ok(id) = subject.parse::<i64>() {
+                if id > 0 && subject == id.to_string() {
+                    ids.insert(id);
+                }
+            }
+        }
+        Ok(ids)
+    }
+
+    pub fn record_minilm_migration_error(
+        &self,
+        run_id: &str,
+        subject_key: Option<&str>,
+        phase: &str,
+        code: &str,
+        error: &str,
+    ) -> Result<(), String> {
+        if phase.len() > MAX_METADATA_BYTES
+            || code.len() > MAX_METADATA_BYTES
+            || error.len() > MAX_METADATA_BYTES
+        {
+            return Err("MiniLM migration diagnostic exceeds storage limit".to_string());
+        }
+        let guard = self.get_connection_named("record_minilm_migration_error")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        conn.execute(
+            r#"
+            INSERT INTO minilm_migration_run_errors (
+                run_id, subject_key, phase, code, error
+            ) VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+            params![run_id, subject_key, phase, code, error],
+        )
+        .map_err(|db_error| format!("Failed to record MiniLM migration error: {db_error}"))?;
+        Ok(())
+    }
+
+    pub fn list_minilm_migration_errors(
+        &self,
+        run_id: &str,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Vec<serde_json::Value>, String> {
+        let guard = self.get_connection_named("list_minilm_migration_errors")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        let mut statement = conn
+            .prepare(
+                r#"
+                SELECT subject_key, phase, code, error, created_at
+                  FROM minilm_migration_run_errors
+                 WHERE run_id = ?1
+                 ORDER BY id
+                 LIMIT ?2 OFFSET ?3
+                "#,
+            )
+            .map_err(|error| format!("Failed to prepare MiniLM error query: {error}"))?;
+        let rows = statement
+            .query_map(params![run_id, limit.clamp(1, 500), offset], |row| {
+                Ok(serde_json::json!({
+                    "subject_key": row.get::<_, Option<String>>(0)?,
+                    "phase": row.get::<_, String>(1)?,
+                    "code": row.get::<_, String>(2)?,
+                    "error": row.get::<_, String>(3)?,
+                    "created_at": row.get::<_, String>(4)?,
+                }))
+            })
+            .map_err(|error| format!("Failed to query MiniLM migration errors: {error}"))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|error| format!("Failed to read MiniLM migration error: {error}"))
+    }
+
+    pub fn reconcile_minilm_migration_scope(&self, run_id: &str) -> Result<u64, String> {
+        let mut guard = self.get_connection_named("reconcile_minilm_migration_scope")?;
+        let conn = guard.as_mut().ok_or("Database not initialized")?;
+        let tx = conn
+            .transaction()
+            .map_err(|error| format!("Failed to start MiniLM reconcile transaction: {error}"))?;
+        let vectors = tx
+            .execute(
+                r#"
+                DELETE FROM derived_embeddings
+                 WHERE index_kind = 'semantic_text'
+                   AND subject_key NOT IN (
+                       SELECT subject_key FROM minilm_migration_subjects WHERE run_id = ?1
+                   )
+                "#,
+                [run_id],
+            )
+            .map_err(|error| format!("Failed to reconcile MiniLM embeddings: {error}"))?;
+        let jobs = tx
+            .execute(
+                r#"
+                DELETE FROM derived_index_jobs
+                 WHERE index_kind = 'semantic_text'
+                   AND subject_key NOT IN (
+                       SELECT subject_key FROM minilm_migration_subjects WHERE run_id = ?1
+                   )
+                "#,
+                [run_id],
+            )
+            .map_err(|error| format!("Failed to reconcile MiniLM jobs: {error}"))?;
+        let removed = u64::try_from(vectors.max(jobs))
+            .map_err(|_| "Invalid MiniLM reconcile count".to_string())?;
+        tx.execute(
+            r#"
+            UPDATE minilm_migration_runs
+               SET removed_extra = ?2, heartbeat_at = CURRENT_TIMESTAMP,
+                   updated_at = CURRENT_TIMESTAMP
+             WHERE run_id = ?1
+            "#,
+            params![
+                run_id,
+                i64::try_from(removed).map_err(|_| "MiniLM count overflow")?
+            ],
+        )
+        .map_err(|error| format!("Failed to record MiniLM reconcile count: {error}"))?;
+        tx.commit()
+            .map_err(|error| format!("Failed to commit MiniLM reconcile transaction: {error}"))?;
+        Ok(removed)
+    }
+
+    pub fn minilm_migration_disk_preflight(
+        &self,
+        expected_rows: u64,
+    ) -> Result<MinilmMigrationDiskPreflight, String> {
+        let data_dir = self
+            .data_dir
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone();
+        let (_, available_free_bytes) = disk_totals_for_path(&data_dir).ok_or_else(|| {
+            format!(
+                "Cannot determine free space for the CarbonPaper data directory ({})",
+                data_dir.display()
+            )
+        })?;
+        let estimated_database_bytes = expected_rows.saturating_mul(4 * 1024);
+        let estimated_generation_bytes = 256_u64.saturating_add(
+            expected_rows.saturating_mul((4 + 24 + 384 * std::mem::size_of::<f32>()) as u64),
+        );
+        let estimated_snapshot_bytes =
+            (1024 * 1024_u64).saturating_add(expected_rows.saturating_mul(24));
+        let estimated_peak_bytes = estimated_database_bytes
+            .saturating_add(estimated_generation_bytes)
+            .saturating_add(estimated_snapshot_bytes)
+            .saturating_add(MIGRATION_TRANSIENT_ALLOWANCE);
+        let required_free_bytes = estimated_peak_bytes
+            .saturating_add(estimated_peak_bytes / 4)
+            .saturating_add(GIB);
+        Ok(MinilmMigrationDiskPreflight {
+            expected_rows,
+            estimated_database_bytes,
+            estimated_generation_bytes,
+            estimated_snapshot_bytes,
+            estimated_peak_bytes,
+            required_free_bytes,
+            available_free_bytes,
+            sufficient: available_free_bytes >= required_free_bytes,
+        })
+    }
+
+    /// Sentinel row in `app_metadata` (same design as the auto-vacuum and
+    /// plaintext-backfill markers) recording that the automatic M2.4a copy is
+    /// settled for one vector-space revision, so startup does not re-trigger it.
+    fn minilm_auto_migration_sentinel_key(vector_space_revision: &str) -> String {
+        format!("minilm_auto_migration_done_{vector_space_revision}")
+    }
+
+    pub fn is_minilm_auto_migration_done(
+        &self,
+        vector_space_revision: &str,
+    ) -> Result<bool, String> {
+        let guard = self.get_connection_named("minilm_auto_migration_sentinel")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        conn.query_row(
+            "SELECT 1 FROM app_metadata WHERE key = ?1",
+            params![Self::minilm_auto_migration_sentinel_key(
+                vector_space_revision
+            )],
+            |_| Ok(true),
+        )
+        .optional()
+        .map(|found| found.unwrap_or(false))
+        .map_err(|error| format!("Failed to check MiniLM auto-migration sentinel: {error}"))
+    }
+
+    pub fn mark_minilm_auto_migration_done(
+        &self,
+        vector_space_revision: &str,
+    ) -> Result<(), String> {
+        let guard = self.get_connection_named("minilm_auto_migration_sentinel")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        conn.execute(
+            "INSERT OR REPLACE INTO app_metadata (key, value) VALUES (?1, '1')",
+            params![Self::minilm_auto_migration_sentinel_key(
+                vector_space_revision
+            )],
+        )
+        .map_err(|error| format!("Failed to write MiniLM auto-migration sentinel: {error}"))?;
+        Ok(())
+    }
+}
+
+fn query_job_is_current(tx: &Transaction<'_>, spec: &DerivedIndexJobSpec) -> Result<bool, String> {
+    tx.query_row(
+        r#"
+        SELECT EXISTS(
+            SELECT 1 FROM derived_index_jobs j
+            INNER JOIN derived_embeddings e
+              ON e.index_kind = j.index_kind AND e.subject_key = j.subject_key
+            WHERE j.index_kind = ?1 AND j.subject_key = ?2
+              AND j.status = 'completed'
+              AND j.model_id = ?3 AND j.model_revision = ?4
+              AND j.embedding_version = ?5 AND j.source_fingerprint = ?6
+              AND e.model_id = j.model_id AND e.model_revision = j.model_revision
+              AND e.embedding_version = j.embedding_version
+              AND e.source_fingerprint = j.source_fingerprint
+        )
+        "#,
+        params![
+            spec.index_kind.as_str(),
+            spec.subject_key,
+            spec.model_id,
+            spec.model_revision,
+            spec.embedding_version,
+            spec.source_fingerprint,
+        ],
+        |row| row.get(0),
+    )
+    .map_err(|error| format!("Failed to inspect current MiniLM row: {error}"))
+}
+
+fn write_completed_embedding(
+    tx: &Transaction<'_>,
+    row: &MinilmMigrationPageRow,
+) -> Result<(), String> {
+    let vector_blob = encode_vector(&row.vector)?;
+    let dimensions = i64::try_from(row.vector.len())
+        .map_err(|_| "MiniLM embedding dimensions exceed SQLite range".to_string())?;
+    tx.execute(
+        r#"
+        INSERT INTO derived_index_jobs (
+            index_kind, subject_key, status, error_code, error, attempts,
+            next_retry_at, lease_token, model_id, model_revision,
+            embedding_version, source_fingerprint, updated_at
+        ) VALUES (?1, ?2, 'completed', NULL, NULL, 0, NULL, NULL,
+                  ?3, ?4, ?5, ?6, CURRENT_TIMESTAMP)
+        ON CONFLICT(index_kind, subject_key) DO UPDATE SET
+            status = 'completed', error_code = NULL, error = NULL,
+            attempts = 0, next_retry_at = NULL, lease_token = NULL,
+            model_id = excluded.model_id,
+            model_revision = excluded.model_revision,
+            embedding_version = excluded.embedding_version,
+            source_fingerprint = excluded.source_fingerprint,
+            updated_at = CURRENT_TIMESTAMP
+        "#,
+        params![
+            row.job.index_kind.as_str(),
+            row.job.subject_key,
+            row.job.model_id,
+            row.job.model_revision,
+            row.job.embedding_version,
+            row.job.source_fingerprint,
+        ],
+    )
+    .map_err(|error| format!("Failed to write MiniLM migration ledger: {error}"))?;
+    tx.execute(
+        r#"
+        INSERT INTO derived_embeddings (
+            index_kind, subject_key, dimensions, vector_f32, model_id,
+            model_revision, embedding_version, source_fingerprint, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, CURRENT_TIMESTAMP)
+        ON CONFLICT(index_kind, subject_key) DO UPDATE SET
+            dimensions = excluded.dimensions,
+            vector_f32 = excluded.vector_f32,
+            model_id = excluded.model_id,
+            model_revision = excluded.model_revision,
+            embedding_version = excluded.embedding_version,
+            source_fingerprint = excluded.source_fingerprint,
+            updated_at = CURRENT_TIMESTAMP
+        "#,
+        params![
+            row.job.index_kind.as_str(),
+            row.job.subject_key,
+            dimensions,
+            vector_blob,
+            row.job.model_id,
+            row.job.model_revision,
+            row.job.embedding_version,
+            row.job.source_fingerprint,
+        ],
+    )
+    .map_err(|error| format!("Failed to write MiniLM migration embedding: {error}"))?;
+    Ok(())
+}
+
+fn validate_run_record(run: &MinilmMigrationRunRecord) -> Result<(), String> {
+    if run.run_id.trim().is_empty()
+        || run.mode.trim().is_empty()
+        || run.vector_space_revision.trim().is_empty()
+        || run.status.trim().is_empty()
+        || run.phase.trim().is_empty()
+    {
+        return Err("MiniLM migration run contains an empty required field".to_string());
+    }
+    Ok(())
+}
+
+fn validate_outcome(outcome: &str) -> Result<(), String> {
+    match outcome {
+        "migrated" | "already_current" | "legacy_chroma_unverified" => Ok(()),
+        _ => Err(format!(
+            "Unknown MiniLM migration subject outcome: {outcome}"
+        )),
+    }
+}
+
+type RawMinilmRun = (
+    String,
+    String,
+    String,
+    String,
+    String,
+    Option<String>,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    i64,
+    Option<String>,
+    String,
+    String,
+    String,
+    Option<String>,
+);
+
+fn minilm_run_select_sql() -> &'static str {
+    r#"
+    SELECT run_id, mode, vector_space_revision, status, phase,
+           export_id, export_cursor, chroma_total, chroma_processed,
+           migrated, legacy_unverified, already_current, failed, discarded,
+           unmappable, removed_extra, publish_current, publish_total,
+           required_free_bytes, available_free_bytes,
+           monitor_was_running, monitor_was_paused, last_error,
+           started_at, heartbeat_at, updated_at, finished_at
+      FROM minilm_migration_runs WHERE 1 = 1
+    "#
+}
+
+fn map_minilm_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawMinilmRun> {
+    Ok((
+        row.get(0)?,
+        row.get(1)?,
+        row.get(2)?,
+        row.get(3)?,
+        row.get(4)?,
+        row.get(5)?,
+        row.get(6)?,
+        row.get(7)?,
+        row.get(8)?,
+        row.get(9)?,
+        row.get(10)?,
+        row.get(11)?,
+        row.get(12)?,
+        row.get(13)?,
+        row.get(14)?,
+        row.get(15)?,
+        row.get(16)?,
+        row.get(17)?,
+        row.get(18)?,
+        row.get(19)?,
+        row.get(20)?,
+        row.get(21)?,
+        row.get(22)?,
+        row.get(23)?,
+        row.get(24)?,
+        row.get(25)?,
+        row.get(26)?,
+    ))
+}
+
+fn nonnegative(value: i64, name: &str) -> Result<u64, String> {
+    u64::try_from(value).map_err(|_| format!("Stored MiniLM {name} is invalid: {value}"))
+}
+
+fn decode_minilm_run(raw: RawMinilmRun) -> Result<MinilmMigrationRunRecord, String> {
+    Ok(MinilmMigrationRunRecord {
+        run_id: raw.0,
+        mode: raw.1,
+        vector_space_revision: raw.2,
+        status: raw.3,
+        phase: raw.4,
+        export_id: raw.5,
+        export_cursor: nonnegative(raw.6, "export cursor")?,
+        chroma_total: nonnegative(raw.7, "Chroma total")?,
+        chroma_processed: nonnegative(raw.8, "Chroma processed count")?,
+        migrated: nonnegative(raw.9, "migrated count")?,
+        legacy_unverified: nonnegative(raw.10, "legacy-unverified count")?,
+        already_current: nonnegative(raw.11, "already-current count")?,
+        failed: nonnegative(raw.12, "failed count")?,
+        discarded: nonnegative(raw.13, "discarded count")?,
+        unmappable: nonnegative(raw.14, "unmappable count")?,
+        removed_extra: nonnegative(raw.15, "removed-extra count")?,
+        publish_current: nonnegative(raw.16, "publish progress")?,
+        publish_total: nonnegative(raw.17, "publish total")?,
+        required_free_bytes: nonnegative(raw.18, "required free bytes")?,
+        available_free_bytes: nonnegative(raw.19, "available free bytes")?,
+        monitor_was_running: raw.20 != 0,
+        monitor_was_paused: raw.21 != 0,
+        last_error: raw.22,
+        started_at: raw.23,
+        heartbeat_at: raw.24,
+        updated_at: raw.25,
+        finished_at: raw.26,
+    })
+}
+
+fn run_params(
+    run: &MinilmMigrationRunRecord,
+) -> rusqlite::ParamsFromIter<Vec<rusqlite::types::Value>> {
+    use rusqlite::types::Value;
+    let values = vec![
+        Value::Text(run.run_id.clone()),
+        Value::Text(run.mode.clone()),
+        Value::Text(run.vector_space_revision.clone()),
+        Value::Text(run.status.clone()),
+        Value::Text(run.phase.clone()),
+        run.export_id
+            .clone()
+            .map(Value::Text)
+            .unwrap_or(Value::Null),
+        Value::Integer(run.export_cursor as i64),
+        Value::Integer(run.chroma_total as i64),
+        Value::Integer(run.chroma_processed as i64),
+        Value::Integer(run.migrated as i64),
+        Value::Integer(run.legacy_unverified as i64),
+        Value::Integer(run.already_current as i64),
+        Value::Integer(run.failed as i64),
+        Value::Integer(run.discarded as i64),
+        Value::Integer(run.unmappable as i64),
+        Value::Integer(run.removed_extra as i64),
+        Value::Integer(run.publish_current as i64),
+        Value::Integer(run.publish_total as i64),
+        Value::Integer(run.required_free_bytes as i64),
+        Value::Integer(run.available_free_bytes as i64),
+        Value::Integer(i64::from(run.monitor_was_running)),
+        Value::Integer(i64::from(run.monitor_was_paused)),
+        run.last_error
+            .clone()
+            .map(Value::Text)
+            .unwrap_or(Value::Null),
+        Value::Text(run.started_at.clone()),
+        Value::Text(run.heartbeat_at.clone()),
+        Value::Text(run.updated_at.clone()),
+        run.finished_at
+            .clone()
+            .map(Value::Text)
+            .unwrap_or(Value::Null),
+    ];
+    rusqlite::params_from_iter(values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credential_manager::CredentialManagerState;
+    use rusqlite::Connection;
+    use std::sync::Arc;
+
+    fn test_storage() -> StorageState {
+        let temp = tempfile::tempdir().expect("temp storage directory");
+        let path = temp.keep();
+        let credential = Arc::new(CredentialManagerState::new(path.clone()));
+        let storage = StorageState::new(path, credential);
+        let connection = Connection::open_in_memory().expect("in-memory database");
+        storage.init_tables(&connection).expect("initialize schema");
+        *storage.db.lock().unwrap_or_else(|error| error.into_inner()) = Some(connection);
+        storage
+    }
+
+    fn run_record() -> MinilmMigrationRunRecord {
+        MinilmMigrationRunRecord {
+            run_id: "run-1".to_string(),
+            mode: "copy_chroma_hot_layer".to_string(),
+            vector_space_revision: "revision-1".to_string(),
+            status: "running".to_string(),
+            phase: "copying_chroma".to_string(),
+            export_id: Some("export-1".to_string()),
+            export_cursor: 0,
+            chroma_total: 1,
+            chroma_processed: 0,
+            migrated: 0,
+            legacy_unverified: 0,
+            already_current: 0,
+            failed: 0,
+            discarded: 0,
+            unmappable: 0,
+            removed_extra: 0,
+            publish_current: 0,
+            publish_total: 0,
+            required_free_bytes: 0,
+            available_free_bytes: 0,
+            monitor_was_running: true,
+            monitor_was_paused: false,
+            last_error: None,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            heartbeat_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            finished_at: None,
+        }
+    }
+
+    #[test]
+    fn page_import_advances_cursor_with_vectors_in_one_transaction() {
+        let storage = test_storage();
+        {
+            let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+            guard
+                .as_ref()
+                .unwrap()
+                .execute(
+                    "INSERT INTO screenshots (id, image_path, image_hash) VALUES (7, 'x', 'h7')",
+                    [],
+                )
+                .unwrap();
+        }
+        storage.create_minilm_migration_run(&run_record()).unwrap();
+        let spec = DerivedIndexJobSpec {
+            index_kind: DerivedIndexKind::SemanticText,
+            subject_key: "7".to_string(),
+            model_id: "model".to_string(),
+            model_revision: "revision".to_string(),
+            embedding_version: 1,
+            source_fingerprint: "source".to_string(),
+        };
+        let committed = storage
+            .commit_minilm_migration_page(
+                "run-1",
+                0,
+                1,
+                &[MinilmMigrationPageRow {
+                    job: spec.clone(),
+                    vector: vec![0.25; 384],
+                    outcome: "migrated".to_string(),
+                }],
+            )
+            .unwrap();
+        assert_eq!(committed.migrated, 1);
+        let run = storage.get_minilm_migration_run("run-1").unwrap().unwrap();
+        assert_eq!(run.export_cursor, 1);
+        assert_eq!(run.migrated, 1);
+        assert!(storage
+            .get_query_visible_embedding(DerivedIndexKind::SemanticText, "7")
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn auto_migration_sentinel_round_trips_per_revision() {
+        let storage = test_storage();
+        assert!(!storage.is_minilm_auto_migration_done("revision-1").unwrap());
+        storage
+            .mark_minilm_auto_migration_done("revision-1")
+            .unwrap();
+        assert!(storage.is_minilm_auto_migration_done("revision-1").unwrap());
+        // A new vector-space revision must trigger its own migration.
+        assert!(!storage.is_minilm_auto_migration_done("revision-2").unwrap());
+        // Re-marking stays idempotent.
+        storage
+            .mark_minilm_auto_migration_done("revision-1")
+            .unwrap();
+        assert!(storage.is_minilm_auto_migration_done("revision-1").unwrap());
+    }
+}

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -9,6 +9,7 @@ mod derived_index;
 mod encryption;
 mod image_io;
 mod link_scoring;
+mod minilm_migration;
 pub mod migration;
 mod policy;
 mod process;
@@ -23,6 +24,8 @@ mod types;
 pub use derived_index::*;
 #[allow(unused_imports)]
 pub use image_io::{read_encrypted_image_as_base64, read_image_as_base64};
+#[allow(unused_imports)]
+pub use minilm_migration::*;
 pub use types::*;
 
 use crate::credential_manager::{

--- a/src-tauri/src/storage/policy.rs
+++ b/src-tauri/src/storage/policy.rs
@@ -69,8 +69,23 @@ fn parse_retention_cutoff(policy: &JsonValue) -> Option<String> {
     Some(cutoff.format("%Y-%m-%d %H:%M:%S").to_string())
 }
 
-fn disk_totals_for_path(path: &Path) -> Option<(u64, u64)> {
+/// On Windows `fs::canonicalize` returns `\\?\`-prefixed verbatim paths whose
+/// `Prefix` component never equals the plain `C:\` mount points sysinfo
+/// reports, so `starts_with` would match no disk at all. Strip the prefix.
+fn strip_windows_verbatim(path: std::path::PathBuf) -> std::path::PathBuf {
+    let text = path.as_os_str().to_string_lossy();
+    if let Some(stripped) = text.strip_prefix(r"\\?\UNC\") {
+        return std::path::PathBuf::from(format!(r"\\{stripped}"));
+    }
+    if let Some(stripped) = text.strip_prefix(r"\\?\") {
+        return std::path::PathBuf::from(stripped.to_string());
+    }
+    path
+}
+
+pub(super) fn disk_totals_for_path(path: &Path) -> Option<(u64, u64)> {
     let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let canonical = strip_windows_verbatim(canonical);
     let disks = Disks::new_with_refreshed_list();
 
     let mut matched: Option<(usize, u64, u64)> = None;
@@ -263,11 +278,46 @@ impl StorageState {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_retention_cutoff;
+    use super::{disk_totals_for_path, parse_retention_cutoff};
     use chrono::{Duration, NaiveDateTime, Utc};
     use serde_json::json;
+    use std::path::Path;
 
     const FORMAT: &str = "%Y-%m-%d %H:%M:%S";
+
+    #[test]
+    fn verbatim_prefixes_are_stripped_to_plain_forms() {
+        use super::strip_windows_verbatim;
+        use std::path::PathBuf;
+        assert_eq!(
+            strip_windows_verbatim(PathBuf::from(r"\\?\D:\projects\app")),
+            PathBuf::from(r"D:\projects\app")
+        );
+        assert_eq!(
+            strip_windows_verbatim(PathBuf::from(r"\\?\UNC\server\share\dir")),
+            PathBuf::from(r"\\server\share\dir")
+        );
+        assert_eq!(
+            strip_windows_verbatim(PathBuf::from(r"D:\already\plain")),
+            PathBuf::from(r"D:\already\plain")
+        );
+    }
+
+    #[test]
+    fn disk_totals_resolve_for_plain_and_verbatim_paths() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        assert!(
+            disk_totals_for_path(manifest_dir).is_some(),
+            "plain existing path must resolve to its disk"
+        );
+        // On Windows fs::canonicalize yields a \\?\-prefixed verbatim path;
+        // it must still match the plain mount points sysinfo reports.
+        let verbatim = std::fs::canonicalize(manifest_dir).expect("canonicalize manifest dir");
+        assert!(
+            disk_totals_for_path(&verbatim).is_some(),
+            "verbatim path {verbatim:?} must resolve to its disk"
+        );
+    }
 
     fn cutoff_for(period: &str) -> String {
         parse_retention_cutoff(&json!({ "retention_period": period }))

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -240,6 +240,66 @@ impl StorageState {
                 created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
 
+            -- Durable orchestration state for the foreground MiniLM migration.
+            -- The vector cache and sidecar remain rebuildable; these rows only
+            -- make a long-running upgrade resumable and diagnosable.
+            CREATE TABLE IF NOT EXISTS minilm_migration_runs (
+                run_id TEXT PRIMARY KEY,
+                mode TEXT NOT NULL,
+                vector_space_revision TEXT NOT NULL,
+                status TEXT NOT NULL,
+                phase TEXT NOT NULL,
+                export_id TEXT,
+                export_cursor INTEGER NOT NULL DEFAULT 0 CHECK (export_cursor >= 0),
+                chroma_total INTEGER NOT NULL DEFAULT 0 CHECK (chroma_total >= 0),
+                chroma_processed INTEGER NOT NULL DEFAULT 0 CHECK (chroma_processed >= 0),
+                migrated INTEGER NOT NULL DEFAULT 0 CHECK (migrated >= 0),
+                legacy_unverified INTEGER NOT NULL DEFAULT 0 CHECK (legacy_unverified >= 0),
+                already_current INTEGER NOT NULL DEFAULT 0 CHECK (already_current >= 0),
+                failed INTEGER NOT NULL DEFAULT 0 CHECK (failed >= 0),
+                discarded INTEGER NOT NULL DEFAULT 0 CHECK (discarded >= 0),
+                unmappable INTEGER NOT NULL DEFAULT 0 CHECK (unmappable >= 0),
+                removed_extra INTEGER NOT NULL DEFAULT 0 CHECK (removed_extra >= 0),
+                publish_current INTEGER NOT NULL DEFAULT 0 CHECK (publish_current >= 0),
+                publish_total INTEGER NOT NULL DEFAULT 0 CHECK (publish_total >= 0),
+                required_free_bytes INTEGER NOT NULL DEFAULT 0 CHECK (required_free_bytes >= 0),
+                available_free_bytes INTEGER NOT NULL DEFAULT 0 CHECK (available_free_bytes >= 0),
+                monitor_was_running INTEGER NOT NULL DEFAULT 0,
+                monitor_was_paused INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT,
+                started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                heartbeat_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                finished_at TEXT
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_minilm_migration_runs_updated
+                ON minilm_migration_runs(updated_at DESC);
+
+            CREATE TABLE IF NOT EXISTS minilm_migration_subjects (
+                run_id TEXT NOT NULL,
+                subject_key TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                source_fingerprint TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (run_id, subject_key),
+                FOREIGN KEY (run_id) REFERENCES minilm_migration_runs(run_id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS minilm_migration_run_errors (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id TEXT NOT NULL,
+                subject_key TEXT,
+                phase TEXT NOT NULL,
+                code TEXT NOT NULL,
+                error TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (run_id) REFERENCES minilm_migration_runs(run_id) ON DELETE CASCADE
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_minilm_migration_errors_run
+                ON minilm_migration_run_errors(run_id, id);
+
             DROP TRIGGER IF EXISTS derived_embeddings_epoch_after_insert;
             CREATE TRIGGER derived_embeddings_epoch_after_insert
             AFTER INSERT ON derived_embeddings

--- a/src-tauri/src/storage/screenshot.rs
+++ b/src-tauri/src/storage/screenshot.rs
@@ -1,8 +1,7 @@
 //! Screenshot CRUD operations (save, get, delete, commit, abort).
 
 use crate::credential_manager::{
-    decrypt_row_key_with_cng_silent, decrypt_with_master_key, encrypt_with_master_key,
-    CredentialError,
+    decrypt_with_master_key, encrypt_with_master_key, CngKeySession, CredentialError,
 };
 use chrono::{DateTime, Utc};
 use rand::RngCore;
@@ -57,6 +56,137 @@ impl EncryptedScreenshotSummaryRow {
             category: row.get(7)?,
         })
     }
+}
+
+/// Upper bound for CNG unwrap worker threads. The RSA work runs inside the
+/// key-isolation service, which stops scaling beyond a few concurrent
+/// callers, and background reads must not saturate every core.
+const CNG_UNWRAP_MAX_THREADS: usize = 8;
+
+fn open_cng_session() -> Result<CngKeySession, BackgroundReadError> {
+    CngKeySession::open_silent().map_err(|error| match error {
+        CredentialError::AuthRequired => BackgroundReadError::AuthRequired,
+        other => BackgroundReadError::Other(format!("Failed to open CNG session: {other}")),
+    })
+}
+
+/// Runs RPC-bound row-key unwrapping in parallel. Items are split into
+/// contiguous chunks; every worker thread opens its own [`CngKeySession`], so
+/// a batch pays the provider/key-open round-trip once per thread instead of
+/// once per row and no NCrypt handle receives concurrent calls. Input order
+/// is preserved. Any `AuthRequired` fails the whole batch with `AuthRequired`
+/// so callers keep their wait-for-unlock semantics.
+fn unwrap_batch_parallel<T, R, F>(items: Vec<T>, process: F) -> Result<Vec<R>, BackgroundReadError>
+where
+    T: Send,
+    R: Send,
+    F: Fn(&CngKeySession, T) -> Result<R, BackgroundReadError> + Sync,
+{
+    if items.is_empty() {
+        return Ok(Vec::new());
+    }
+    let threads = std::thread::available_parallelism()
+        .map(|value| value.get())
+        .unwrap_or(1)
+        .min(CNG_UNWRAP_MAX_THREADS)
+        .min(items.len())
+        .max(1);
+    if threads == 1 {
+        let session = open_cng_session()?;
+        return items
+            .into_iter()
+            .map(|item| process(&session, item))
+            .collect();
+    }
+
+    let chunk_size = items.len().div_ceil(threads);
+    let mut chunks: Vec<Vec<T>> = Vec::with_capacity(threads);
+    let mut remaining = items.into_iter();
+    loop {
+        let chunk: Vec<T> = remaining.by_ref().take(chunk_size).collect();
+        if chunk.is_empty() {
+            break;
+        }
+        chunks.push(chunk);
+    }
+
+    let results: Vec<Result<Vec<R>, BackgroundReadError>> = std::thread::scope(|scope| {
+        let handles: Vec<_> = chunks
+            .into_iter()
+            .map(|chunk| {
+                scope.spawn(|| {
+                    let session = open_cng_session()?;
+                    chunk
+                        .into_iter()
+                        .map(|item| process(&session, item))
+                        .collect()
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|handle| {
+                handle.join().unwrap_or_else(|_| {
+                    Err(BackgroundReadError::Other(
+                        "CNG unwrap worker panicked".to_string(),
+                    ))
+                })
+            })
+            .collect()
+    });
+
+    let mut merged = Vec::new();
+    let mut first_error: Option<BackgroundReadError> = None;
+    for result in results {
+        match result {
+            Ok(mut part) => merged.append(&mut part),
+            Err(BackgroundReadError::AuthRequired) => return Err(BackgroundReadError::AuthRequired),
+            Err(error) if first_error.is_none() => first_error = Some(error),
+            Err(_) => {}
+        }
+    }
+    match first_error {
+        Some(error) => Err(error),
+        None => Ok(merged),
+    }
+}
+
+/// Joins decrypted OCR box texts with single spaces per screenshot, skipping
+/// empty boxes, and stops decrypting a screenshot's remaining boxes once
+/// `min_chars` joined characters are collected. Rows of one screenshot must
+/// arrive contiguously in reading order; the produced string is then a join
+/// prefix of the full join, so its first `min_chars` characters match the
+/// full text exactly (the MiniLM source contract only consumes that prefix).
+fn assemble_ocr_text_prefixes<E>(
+    rows: Vec<(i64, Option<Vec<u8>>, Option<Vec<u8>>)>,
+    min_chars: usize,
+    mut decrypt: impl FnMut(&[u8], &[u8]) -> Result<String, E>,
+) -> Result<std::collections::HashMap<i64, String>, E> {
+    let mut texts: std::collections::HashMap<i64, Vec<String>> = std::collections::HashMap::new();
+    let mut joined_chars: std::collections::HashMap<i64, usize> = std::collections::HashMap::new();
+    for (screenshot_id, text_enc, key_enc) in rows {
+        if joined_chars
+            .get(&screenshot_id)
+            .is_some_and(|&count| count >= min_chars)
+        {
+            continue;
+        }
+        let (Some(data), Some(key)) = (text_enc.as_deref(), key_enc.as_deref()) else {
+            continue;
+        };
+        let text = decrypt(data, key)?;
+        if text.is_empty() {
+            continue;
+        }
+        let list = texts.entry(screenshot_id).or_default();
+        let count = joined_chars.entry(screenshot_id).or_insert(0);
+        *count += text.chars().count() + usize::from(!list.is_empty());
+        list.push(text);
+    }
+    Ok(texts
+        .into_iter()
+        .map(|(id, list)| (id, list.join(" ")))
+        .collect())
 }
 
 fn ocr_postprocess_retry_decision(current_attempts: i64) -> (&'static str, Option<i64>, i64) {
@@ -1469,9 +1599,12 @@ impl StorageState {
         Ok(raw_rows.into_iter().map(|raw| raw.into_record()).collect())
     }
 
-    fn decrypt_screenshot_summary_silent(
-        &self,
+    /// Decrypts one summary row with an injected row-key unwrap so batch
+    /// callers reuse a per-thread [`CngKeySession`] instead of paying a CNG
+    /// open/free round-trip per row.
+    fn decrypt_screenshot_summary_with_unwrap(
         row: EncryptedScreenshotSummaryRow,
+        unwrap_row_key: &dyn Fn(&[u8]) -> Result<Vec<u8>, CredentialError>,
     ) -> Result<BackgroundScreenshotSummary, BackgroundReadError> {
         let needs_row_key = row.window_title_enc.is_some() || row.process_name_enc.is_some();
         let mut row_key = if needs_row_key {
@@ -1481,15 +1614,13 @@ impl StorageState {
                     row.id
                 ))
             })?;
-            Some(
-                decrypt_row_key_with_cng_silent(encrypted_key).map_err(|error| match error {
-                    CredentialError::AuthRequired => BackgroundReadError::AuthRequired,
-                    other => BackgroundReadError::Other(format!(
-                        "Failed to unwrap screenshot summary key id={}: {}",
-                        row.id, other
-                    )),
-                })?,
-            )
+            Some(unwrap_row_key(encrypted_key).map_err(|error| match error {
+                CredentialError::AuthRequired => BackgroundReadError::AuthRequired,
+                other => BackgroundReadError::Other(format!(
+                    "Failed to unwrap screenshot summary key id={}: {}",
+                    row.id, other
+                )),
+            })?)
         } else {
             None
         };
@@ -1543,6 +1674,18 @@ impl StorageState {
             process_name: process_name_result?,
             timestamp: row.timestamp,
             category: row.category,
+        })
+    }
+
+    /// Decrypts summary rows in parallel with one CNG session per worker
+    /// thread, preserving input order.
+    fn decrypt_summaries_parallel(
+        raw_rows: Vec<EncryptedScreenshotSummaryRow>,
+    ) -> Result<Vec<BackgroundScreenshotSummary>, BackgroundReadError> {
+        unwrap_batch_parallel(raw_rows, |session, row| {
+            Self::decrypt_screenshot_summary_with_unwrap(row, &|ciphertext| {
+                session.unwrap_row_key(ciphertext)
+            })
         })
     }
 
@@ -1602,10 +1745,7 @@ impl StorageState {
             rows
         };
 
-        raw_rows
-            .into_iter()
-            .map(|row| self.decrypt_screenshot_summary_silent(row))
-            .collect()
+        Self::decrypt_summaries_parallel(raw_rows)
     }
 
     pub(crate) fn get_screenshot_summaries_by_time_range_paged_silent(
@@ -1667,10 +1807,7 @@ impl StorageState {
             rows
         };
 
-        raw_rows
-            .into_iter()
-            .map(|row| self.decrypt_screenshot_summary_silent(row))
-            .collect()
+        Self::decrypt_summaries_parallel(raw_rows)
     }
 
     pub fn get_screenshot_by_id(&self, id: i64) -> Result<Option<ScreenshotRecord>, String> {
@@ -1947,6 +2084,113 @@ impl StorageState {
             return Err(BackgroundReadError::AuthRequired);
         }
         self.get_ocr_results_by_screenshot_ids_with_mode(screenshot_ids, true)
+    }
+
+    /// Batch OCR text for MiniLM source fingerprints. Per screenshot only the
+    /// first `min_chars` joined characters are guaranteed — the MiniLM source
+    /// contract truncates OCR input to a fixed prefix — which lets the
+    /// decrypt loop skip the long tail of boxes: most screenshots reach the
+    /// budget within a few boxes instead of paying one RSA unwrap per box.
+    /// Screenshots are decrypted in parallel with per-thread CNG sessions.
+    /// Every requested id is present in the result (empty string when the
+    /// screenshot has no decryptable text), matching
+    /// [`Self::get_ocr_results_by_screenshot_ids_silent`].
+    pub(crate) fn get_ocr_text_prefixes_by_screenshot_ids_silent(
+        &self,
+        screenshot_ids: &[i64],
+        min_chars: usize,
+    ) -> Result<std::collections::HashMap<i64, String>, BackgroundReadError> {
+        if screenshot_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        if !self.is_session_valid() {
+            return Err(BackgroundReadError::AuthRequired);
+        }
+
+        // Phase 1: fetch the raw encrypted rows with a read-only connection.
+        let raw_rows = {
+            let conn = self
+                .open_read_connection_named("get_ocr_text_prefixes_by_screenshot_ids_silent")
+                .map_err(BackgroundReadError::Other)?;
+
+            let mut raw_rows: Vec<(i64, Option<Vec<u8>>, Option<Vec<u8>>)> = Vec::new();
+
+            // Process in chunks to avoid SQLite parameter limit (usually 999)
+            for chunk in screenshot_ids.chunks(500) {
+                let placeholders: Vec<&str> = chunk.iter().map(|_| "?").collect();
+                let sql = format!(
+                    "SELECT screenshot_id, text_enc, text_key_encrypted
+                     FROM ocr_results
+                     WHERE is_deleted = 0 AND screenshot_id IN ({})
+                     ORDER BY screenshot_id, box_y1, box_x1",
+                    placeholders.join(",")
+                );
+                let params: Vec<&dyn rusqlite::ToSql> =
+                    chunk.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
+
+                let mut stmt = conn.prepare(&sql).map_err(|e| {
+                    BackgroundReadError::Other(format!(
+                        "Failed to prepare OCR prefix query: {}",
+                        e
+                    ))
+                })?;
+
+                let rows = stmt
+                    .query_map(params.as_slice(), |row| {
+                        let screenshot_id: i64 = row.get(0)?;
+                        let text_enc: Option<Vec<u8>> = row.get(1)?;
+                        let text_key_enc: Option<Vec<u8>> = row.get(2)?;
+                        Ok((screenshot_id, text_enc, text_key_enc))
+                    })
+                    .map_err(|e| {
+                        BackgroundReadError::Other(format!(
+                            "Failed to execute OCR prefix query: {}",
+                            e
+                        ))
+                    })?;
+
+                for row in rows.filter_map(|r| r.ok()) {
+                    raw_rows.push(row);
+                }
+            }
+            raw_rows
+        };
+
+        // Phase 2: group boxes per screenshot. Each id lives in exactly one
+        // IN chunk and every chunk is ordered by screenshot_id, so the rows
+        // of one screenshot are contiguous and in reading order.
+        let mut groups: Vec<Vec<(i64, Option<Vec<u8>>, Option<Vec<u8>>)>> = Vec::new();
+        for row in raw_rows {
+            match groups.last_mut() {
+                Some(group) if group.last().map(|(id, _, _)| *id) == Some(row.0) => {
+                    group.push(row)
+                }
+                _ => groups.push(vec![row]),
+            }
+        }
+
+        // Phase 3: decrypt each screenshot's prefix in parallel.
+        let maps = unwrap_batch_parallel(groups, |session, group| {
+            assemble_ocr_text_prefixes(group, min_chars, |data, key| {
+                let bytes = Self::decrypt_payload_with_unwrap(data, key, &|ciphertext| {
+                    session.unwrap_row_key(ciphertext)
+                })?;
+                String::from_utf8(bytes).map_err(|error| {
+                    BackgroundReadError::Other(format!("Invalid OCR text encoding: {}", error))
+                })
+            })
+        })?;
+
+        let mut result: std::collections::HashMap<i64, String> = screenshot_ids
+            .iter()
+            .map(|&id| (id, String::new()))
+            .collect();
+        for map in maps {
+            for (id, text) in map {
+                result.insert(id, text);
+            }
+        }
+        Ok(result)
     }
 
     fn get_ocr_results_by_screenshot_ids_with_mode(
@@ -3033,6 +3277,10 @@ mod ocr_lifecycle_tests {
             Err(BackgroundReadError::AuthRequired)
         ));
         assert!(matches!(
+            storage.get_ocr_text_prefixes_by_screenshot_ids_silent(&[1], 200),
+            Err(BackgroundReadError::AuthRequired)
+        ));
+        assert!(matches!(
             storage.get_screenshot_summaries_by_ids_silent(&[1]),
             Err(BackgroundReadError::AuthRequired)
         ));
@@ -3045,6 +3293,57 @@ mod ocr_lifecycle_tests {
             ),
             Err(BackgroundReadError::AuthRequired)
         ));
+    }
+
+    #[test]
+    fn ocr_prefix_assembly_matches_full_join_and_skips_tail_boxes() {
+        let box_row = |id: i64, text: &str| (id, Some(text.as_bytes().to_vec()), Some(vec![0u8]));
+        let rows = vec![
+            box_row(1, "0123456789"),
+            (1, None, None), // legacy row without payload is skipped for free
+            box_row(1, ""),  // empty box costs one decrypt but adds no text
+            box_row(1, "abcdefghij"), // joined length reaches the 20-char budget here
+            box_row(1, "tail-never-needed"),
+            box_row(1, "tail-never-needed-2"),
+            box_row(2, "短文本"),
+            box_row(3, "这是一段刚好超过二十个字符预算的中文文本内容"),
+            box_row(3, "尾部"),
+            box_row(4, ""), // only-empty screenshot yields no map entry
+        ];
+        let full_join = |wanted: i64| -> String {
+            rows.iter()
+                .filter(|(id, data, _)| *id == wanted && data.is_some())
+                .filter_map(|(_, data, _)| String::from_utf8(data.clone().unwrap()).ok())
+                .filter(|text| !text.is_empty())
+                .collect::<Vec<_>>()
+                .join(" ")
+        };
+
+        let mut decrypts = 0usize;
+        let result = assemble_ocr_text_prefixes(rows.clone(), 20, |data, _key| {
+            decrypts += 1;
+            Ok::<String, BackgroundReadError>(String::from_utf8(data.to_vec()).unwrap())
+        })
+        .unwrap();
+
+        // The assembled text must agree with the full join on the consumed
+        // prefix — that is the exact fingerprint-equivalence contract.
+        for id in [1i64, 2, 3] {
+            let expected: String = full_join(id).chars().take(20).collect();
+            let got: String = result
+                .get(&id)
+                .cloned()
+                .unwrap_or_default()
+                .chars()
+                .take(20)
+                .collect();
+            assert_eq!(got, expected, "prefix mismatch for screenshot {id}");
+        }
+        // Screenshot 4 produced no text; the caller pre-fills empty strings.
+        assert!(!result.contains_key(&4));
+        // 9 decryptable boxes exist, but the two tails of screenshot 1 and
+        // the tail of screenshot 3 must be skipped once the budget is met.
+        assert_eq!(decrypts, 6);
     }
 
     #[test]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import { NotificationToast, NotificationPanel } from './components/Notifications
 import ErrorWindow from './components/ErrorWindow';
 import HmacMigrationDialog from './components/HmacMigrationDialog';
 import StartupVacuumDialog from './components/StartupVacuumDialog';
+import MinilmMigrationOverlay from './components/MinilmMigrationOverlay';
 import OcrModelRepairCard from './components/OcrModelRepairCard';
 import { deleteScreenshot, deleteRecordsByTimeRange } from './lib/monitor_api';
 import { UpdateModal } from './components/UpdateModal';
@@ -281,6 +282,10 @@ function App() {
         />
 
         <StartupVacuumDialog />
+
+        {/* Top-level, non-dismissable maintenance overlay: covers the whole
+            window (TopBar included) while the MiniLM migration runs. */}
+        <MinilmMigrationOverlay />
 
         {isAuthenticated && <HmacMigrationDialog />}
 

--- a/src/components/MinilmMigrationOverlay.jsx
+++ b/src/components/MinilmMigrationOverlay.jsx
@@ -1,0 +1,216 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Database, KeyRound, Loader2, ShieldAlert } from 'lucide-react';
+import { getMinilmRebuildStatus } from '../lib/task_api';
+import { requestAuth } from '../lib/auth_api';
+import { cn } from '../lib/utils';
+
+const ACTIVE_POLL_MS = 1000;
+const IDLE_POLL_MS = 3000;
+// Phases whose progress pair drives the bar and the ETA estimate.
+const PROGRESS_SOURCES = {
+  copying_chroma: ['chroma_processed', 'chroma_total'],
+  publishing_write: ['publish_current', 'publish_total'],
+  publishing_sync: ['publish_current', 'publish_total'],
+  publishing_verify: ['publish_current', 'publish_total'],
+};
+
+function formatEta(seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  if (seconds < 60) return `< 1 min`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `≈ ${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  return `≈ ${hours} h ${minutes % 60} min`;
+}
+
+/**
+ * Full-window, non-dismissable maintenance overlay for the sentinel-triggered
+ * MiniLM migration. The run cannot be cancelled: closing the app merely
+ * interrupts it, and it resumes on the next launch/unlock.
+ */
+export default function MinilmMigrationOverlay() {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState(null);
+  const [reauthenticating, setReauthenticating] = useState(false);
+  const samplesRef = useRef([]);
+
+  const poll = useCallback(async () => {
+    try {
+      const next = await getMinilmRebuildStatus();
+      setStatus(next);
+      const source = PROGRESS_SOURCES[next?.phase];
+      if (next?.running && source) {
+        const value = next[source[0]] ?? 0;
+        const samples = samplesRef.current;
+        const last = samples[samples.length - 1];
+        if (!last || last.value !== value) {
+          samples.push({ at: Date.now(), value, phase: next.phase });
+          if (samples.length > 30) samples.shift();
+        }
+      } else {
+        samplesRef.current = [];
+      }
+    } catch {
+      // Status polling must never break the overlay; keep the last snapshot.
+    }
+  }, []);
+
+  useEffect(() => {
+    let timer;
+    let cancelled = false;
+    const tick = async () => {
+      await poll();
+      if (cancelled) return;
+      timer = setTimeout(tick, status?.running ? ACTIVE_POLL_MS : IDLE_POLL_MS);
+    };
+    tick();
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [poll, status?.running]);
+
+  const visible = Boolean(status?.running);
+  if (!visible) return null;
+
+  const phase = status.phase || 'starting';
+  const source = PROGRESS_SOURCES[phase];
+  const current = source ? status[source[0]] ?? 0 : 0;
+  const total = source ? status[source[1]] ?? 0 : 0;
+  const percent = total > 0 ? Math.min(100, Math.round((current / total) * 100)) : null;
+
+  // ETA from the observed processing rate within the current phase only.
+  let eta = null;
+  const samples = samplesRef.current.filter((sample) => sample.phase === phase);
+  if (total > 0 && samples.length >= 2) {
+    const first = samples[0];
+    const last = samples[samples.length - 1];
+    const rate = (last.value - first.value) / Math.max(1, (last.at - first.at) / 1000);
+    if (rate > 0) eta = formatEta((total - current) / rate);
+  }
+
+  const waitingForAuth = phase === 'waiting_for_auth';
+  const isPublishSync = phase === 'publishing_sync';
+  const errorCount =
+    (status.failed ?? 0) + (status.unmappable ?? 0) + (status.discarded ?? 0);
+  const phaseText = t(`minilmMigration.phases.${phase}`, {
+    defaultValue: t('minilmMigration.phases.working'),
+  });
+
+  // This overlay covers AuthMask (z-50), so while the run is stuck in
+  // waiting_for_auth it must offer its own way to bring up Windows Hello;
+  // the backend worker polls the session and resumes on its own.
+  const handleReauthenticate = async () => {
+    setReauthenticating(true);
+    try {
+      await requestAuth();
+    } catch {
+      // Cancelled or failed: the button simply becomes usable again.
+    } finally {
+      setReauthenticating(false);
+    }
+  };
+
+  const HeaderIcon = waitingForAuth ? ShieldAlert : Database;
+
+  return (
+    <div className="absolute inset-0 z-[200] flex flex-col items-center justify-center bg-ide-bg/80 backdrop-blur-sm text-ide-muted">
+      <div className="w-full max-w-lg bg-ide-panel border border-ide-border rounded-xl p-6 shadow-2xl flex flex-col">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-1 shrink-0">
+          <div className="w-10 h-10 rounded-lg bg-ide-bg border border-ide-border flex items-center justify-center shrink-0">
+            <HeaderIcon
+              className={cn('w-5 h-5', waitingForAuth ? 'text-amber-400' : 'text-ide-accent')}
+            />
+          </div>
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold text-ide-text">
+              {t('minilmMigration.title')}
+            </h2>
+            <p className="text-xs text-ide-muted">
+              {t('minilmMigration.subtitle')}
+            </p>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="mt-4 space-y-3">
+          <div className="w-full space-y-1.5 pt-2">
+            <div className="flex justify-between text-xs">
+              <span className="text-ide-text font-medium">{phaseText}</span>
+              {percent !== null && (
+                <span className="text-ide-muted tabular-nums">
+                  {current.toLocaleString()} / {total.toLocaleString()} ({percent}%)
+                </span>
+              )}
+            </div>
+            <div className="w-full h-2 bg-ide-bg rounded-full overflow-hidden border border-ide-border">
+              <div
+                className={cn(
+                  'h-full bg-ide-accent rounded-full transition-all duration-300 ease-out',
+                  percent === null && 'w-1/3 animate-pulse'
+                )}
+                style={percent !== null ? { width: `${percent}%` } : undefined}
+              />
+            </div>
+            {eta && (
+              <p className="text-xs text-ide-muted">
+                {t('minilmMigration.eta', { eta })}
+              </p>
+            )}
+          </div>
+
+          {isPublishSync && (
+            <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
+              <p className="text-xs text-amber-400 leading-relaxed">
+                {t('minilmMigration.safeWrite')}
+              </p>
+            </div>
+          )}
+
+          {waitingForAuth && (
+            <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
+              <p className="text-xs text-amber-400 leading-relaxed">
+                {t('minilmMigration.waitingForAuth')}
+              </p>
+            </div>
+          )}
+
+          {(errorCount > 0 || status.last_error) && (
+            <div className="text-xs px-3 py-2 rounded bg-red-500/10 text-red-400 min-w-0">
+              {errorCount > 0 && (
+                <p>{t('minilmMigration.errorCount', { count: errorCount })}</p>
+              )}
+              {status.last_error && (
+                <p className="truncate" title={status.last_error}>{status.last_error}</p>
+              )}
+            </div>
+          )}
+
+          <p className="text-[11px] text-ide-muted">
+            {t('minilmMigration.blockedHint')}
+          </p>
+        </div>
+
+        {/* Actions */}
+        {waitingForAuth && (
+          <div className="mt-5 flex items-center justify-end gap-2 shrink-0">
+            <button
+              onClick={handleReauthenticate}
+              disabled={reauthenticating}
+              className="px-4 py-1.5 bg-ide-accent hover:bg-ide-accent/90 text-white rounded text-sm font-medium transition-colors disabled:opacity-50 flex items-center gap-1.5"
+            >
+              {reauthenticating ? (
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              ) : (
+                <KeyRound className="w-3.5 h-3.5" />
+              )}
+              {t('minilmMigration.reauth')}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/MinilmMigrationOverlay.test.jsx
+++ b/src/components/MinilmMigrationOverlay.test.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+vi.mock('../lib/task_api', () => ({
+  getMinilmRebuildStatus: vi.fn(),
+}));
+
+vi.mock('../lib/auth_api', () => ({
+  requestAuth: vi.fn(),
+}));
+
+import MinilmMigrationOverlay from './MinilmMigrationOverlay';
+import { getMinilmRebuildStatus } from '../lib/task_api';
+import { requestAuth } from '../lib/auth_api';
+
+const runningStatus = (overrides = {}) => ({
+  running: true,
+  run_id: 'run-a',
+  phase: 'copying_chroma',
+  mode: 'copy_chroma_hot_layer',
+  chroma_processed: 2,
+  chroma_total: 10,
+  failed: 0,
+  unmappable: 0,
+  discarded: 0,
+  last_error: null,
+  ...overrides,
+});
+
+// Advance the poll loop (setTimeout chain) and flush the async state updates.
+async function pollTick(ms = 0) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe('MinilmMigrationOverlay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('shows a non-dismissable overlay for an active run', async () => {
+    getMinilmRebuildStatus.mockResolvedValue(runningStatus());
+    render(<MinilmMigrationOverlay />);
+    await pollTick();
+
+    expect(screen.getByText('minilmMigration.title')).toBeInTheDocument();
+    expect(screen.getByText(/2\s*\/\s*10\s*\(20%\)/)).toBeInTheDocument();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('stays hidden when no migration is running', async () => {
+    getMinilmRebuildStatus.mockResolvedValue(
+      runningStatus({ running: false, phase: 'idle' })
+    );
+    render(<MinilmMigrationOverlay />);
+    await pollTick();
+
+    expect(screen.queryByText('minilmMigration.title')).toBeNull();
+  });
+
+  it('offers re-authentication while the run waits for Windows Hello', async () => {
+    getMinilmRebuildStatus.mockResolvedValue(
+      runningStatus({ phase: 'waiting_for_auth' })
+    );
+    render(<MinilmMigrationOverlay />);
+    await pollTick();
+
+    expect(screen.getByText('minilmMigration.waitingForAuth')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'minilmMigration.reauth' })
+    ).toBeEnabled();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'minilmMigration.reauth' }));
+    });
+    expect(requestAuth).toHaveBeenCalledOnce();
+  });
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1279,6 +1279,29 @@
       "trigger_ocr_model_repair_notification": "Test OCR Model Repair Notification"
     }
   },
+  "minilmMigration": {
+    "title": "Data migration in progress",
+    "subtitle": "Task vectors are being migrated to the local Rust index. The app is in maintenance mode while this runs.",
+    "eta": "Estimated time remaining: {{eta}} ",
+    "safeWrite": "Writing to disk. Please do not force-quit the app.",
+    "waitingForAuth": "Your session has expired. Complete Windows Hello authentication and the migration will continue automatically.",
+    "reauth": "Authenticate",
+    "errorCount": "{{count}} records could not be migrated. Details were written to the migration diagnostics.",
+    "blockedHint": "Other operations are unavailable during migration. If the app exits, migration resumes after the next launch and unlock.",
+    "phases": {
+      "starting": "Preparing…",
+      "preflight": "Checking disk space…",
+      "snapshotting_chroma": "Creating the vector snapshot…",
+      "copying_chroma": "Copying existing vectors…",
+      "reconciling": "Removing out-of-scope local vectors…",
+      "publishing_write": "Writing the index file…",
+      "publishing_sync": "Publishing the index…",
+      "publishing_verify": "Verifying the index file…",
+      "publishing_commit": "Committing the index…",
+      "waiting_for_auth": "Waiting for authentication…",
+      "working": "Working…"
+    }
+  },
   "securityAlert": {
     "title": "Monitor integrity compromised",
     "debug_title": "Security alert — debug trigger",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1279,6 +1279,29 @@
       "trigger_ocr_model_repair_notification": "测试 OCR 模型修复通知"
     }
   },
+  "minilmMigration": {
+    "title": "语义索引迁移中",
+    "subtitle": "正在进行数据库迁移。迁移期间应用处于维护模式。",
+    "eta": "预计剩余时间：{{eta}}",
+    "safeWrite": "正在写入磁盘，请勿强制关闭应用。",
+    "waitingForAuth": "会话已过期。请完成 Windows Hello 认证，迁移随后会自动继续。",
+    "reauth": "重新认证",
+    "errorCount": "有 {{count}} 条记录无法迁移，详情已写入迁移诊断。",
+    "blockedHint": "迁移期间其它操作暂不可用；若应用退出，将在下次启动并解锁后自动继续。",
+    "phases": {
+      "starting": "正在准备…",
+      "preflight": "正在检查磁盘空间…",
+      "snapshotting_chroma": "正在创建向量快照…",
+      "copying_chroma": "正在复制现有向量…",
+      "reconciling": "正在清理超出范围的本地向量…",
+      "publishing_write": "正在写入索引文件…",
+      "publishing_sync": "正在发布索引…",
+      "publishing_verify": "正在校验索引文件…",
+      "publishing_commit": "正在提交索引…",
+      "waiting_for_auth": "等待身份认证…",
+      "working": "正在处理…"
+    }
+  },
   "securityAlert": {
     "title": "监控完整性已被破坏",
     "debug_title": "安全告警 — 调试触发",

--- a/src/lib/task_api.js
+++ b/src/lib/task_api.js
@@ -137,6 +137,26 @@ export async function getClusteringStatus() {
 }
 
 /**
+ * Read progress for the active or most recently persisted MiniLM migration
+ * run. The migration itself is sentinel-triggered at startup and cannot be
+ * started or cancelled from the frontend; an interrupted run resumes on the
+ * next launch/unlock.
+ */
+export async function getMinilmRebuildStatus() {
+  return invoke('get_minilm_rebuild_status');
+}
+
+/** List in-memory + persisted diagnostics and failed/discarded ledger jobs. */
+export async function listMinilmRebuildErrors(offset = 0, limit = 100) {
+  return withAuth(() => invoke('list_minilm_rebuild_errors', { offset, limit }));
+}
+
+/** Whether the app is in global maintenance mode (blocking overlay shown). */
+export async function getMaintenanceStatus() {
+  return invoke('get_maintenance_status');
+}
+
+/**
  * Set the automatic clustering interval.
  * @param {'1d'|'1w'|'1m'|'6m'} interval
  */

--- a/src/lib/task_api.test.js
+++ b/src/lib/task_api.test.js
@@ -20,6 +20,9 @@ import {
   removeTaskScreenshot,
   runClustering,
   setClusteringInterval,
+  getMinilmRebuildStatus,
+  listMinilmRebuildErrors,
+  getMaintenanceStatus,
 } from './task_api';
 
 describe('task_api', () => {
@@ -102,6 +105,22 @@ describe('task_api', () => {
     expect(invoke).toHaveBeenNthCalledWith(2, 'monitor_set_clustering_interval', { interval: '1w' });
     expectWithAuth(1, { autoPrompt: false });
     expectWithAuth(2, { autoPrompt: true });
+  });
+
+  it('exposes read-only MiniLM migration status commands', async () => {
+    invoke.mockResolvedValue({ running: true });
+
+    await getMinilmRebuildStatus();
+    await listMinilmRebuildErrors(5, 25);
+    await getMaintenanceStatus();
+
+    expect(invoke).toHaveBeenNthCalledWith(1, 'get_minilm_rebuild_status');
+    expect(invoke).toHaveBeenNthCalledWith(2, 'list_minilm_rebuild_errors', {
+      offset: 5,
+      limit: 25,
+    });
+    expect(invoke).toHaveBeenNthCalledWith(3, 'get_maintenance_status');
+    expectWithAuth(1);
   });
 
   it('calls smart cluster summary commands with expected payloads', async () => {


### PR DESCRIPTION
## Summary

Milestone 2.4a: copy the Chroma `task_vectors` hot-layer collection into the
Rust-derived embedding cache so the two stores become behaviorally equivalent,
without running any inference. The copy is a mandatory, sentinel-triggered,
resumable one-time job — not a manual or cancellable command.

- **Sentinel-triggered & resumable.** For each vector-space revision, the
  absence of `app_metadata.minilm_auto_migration_done_<revision>` starts one
  full-scope copy at startup. The worker waits for Windows Hello unlock before
  reading encrypted OCR inputs. A crash, exit, or transient failure leaves the
  sentinel unset; the next launch/unlock resumes from the durable cursor and the
  persisted Chroma snapshot. Legacy manual/time-bounded run records are never
  resumed or allowed to settle the sentinel.
- **Global maintenance mode.** The whole run executes under a process-global
  flag: a non-dismissable full-window overlay, `MAINTENANCE_IN_PROGRESS`
  rejection at the MCP and reverse-IPC boundaries (with a small
  session/crypto/status/dual-write allowlist), gated monitor
  start/stop/pause/resume, and a paused retention/delete-queue loop. Capture is
  paused for the duration and the prior monitor running/paused state is restored
  exactly. Closing the app is the only interruption.
- **Async ID snapshot.** The full hot-layer ID snapshot is built by an internal
  Python protocol (`start_task_vectors_export` → status polling → exact-id pages
  → `finish_task_vectors_export`), persisted with an atomically renamed manifest
  under `data/migrations/minilm/<export_id>/`, and bounded by a 10-minute logical
  build deadline plus 24 h idle / 7 d hard / 1 h `.tmp` TTLs.
- **Compact page transport.** Pages carry vectors as one little-endian float32
  blob in Base64 (`embeddings_f32_le_b64`, ~256 KB per 128-row page) instead of
  tens of thousands of JSON floats.
- **Durable, transactional ledgers.** `minilm_migration_runs` /
  `minilm_migration_subjects` / `minilm_migration_run_errors`; each page commits
  ledger rows, embeddings, counters, and the export cursor in one transaction, so
  a crash either retries an uncommitted page or continues after it.
- **Strict validation & rehydration.** Rust accepts only canonical positive
  screenshot ids and finite, non-zero 384-dimensional vectors (zero vectors are
  quarantined, never imported), maps them to active SQLite screenshots, and
  rehydrates process/title/category/OCR from SQLite. Orphan ids, corrupt vectors,
  and rows that disappear after the snapshot are persisted diagnostics that yield
  `completed_with_errors`.
- **Reconcile + deletion mirroring.** After a full-scope copy, Rust
  `semantic_text` rows outside the snapshot scope are deleted, and Python's
  hot-layer expiry mirrors deletions to Rust through reverse IPC with a persisted
  retry queue, so the Rust collection tracks — rather than outgrows — the Chroma
  hot layer.
- **Disk preflight & publish phases.** A preflight (`estimated peak × 1.25 + 1
  GiB`, with a 64 MiB transient allowance) rejects the run before any vector
  write; generation publication runs on a blocking worker with progress phases
  `publishing_sync` / `publishing_verify` / `publishing_commit`.
