### PR TITLE
m2: MiniLM semantic shadow comparison + shadow-scaffolding retirement rule

### DIFF
--- a/docs/python-removal-roadmap.md
+++ b/docs/python-removal-roadmap.md
@@ -66,6 +66,7 @@ Unchanged except where the audit forces a correction.
 - A Rust replacement is not complete merely because it can load the same ONNX file. Before default cutover it must pass the Python-oracle behavior contract for preprocessing/tokenization, pooling/normalization, response shape, filtering/pagination, ranking quality, lifecycle, and rollback.
 - **Corrected flag rule:** prefer shipping a Rust replacement behind a config flag, then default, then remove the Python fallback a release later. Where a replacement ships default without a flag (as OCR did), it **must** still expose an observable fallback/degrade path and a diagnostic. Track any skipped flag as debt rather than pretending it exists.
 - Heavy ML must use the existing idle policy or an explicit manual-run path. No background model load/inference should surprise a foreground app.
+- **Migration diagnostics are development scaffolding, not product surface.** Shadow comparison toggles, parity probes, and their sample tables exist only to prove one cutover gate. Once that gate is proven and the capability is cut over, they must be removed from the default build before the capability ships in a production (non-beta) release. Shipping one to end users is a defect, not a harmless extra: it exposes a meaningless switch, keeps a second inference path alive on a user's machine, and invites bug reports about numbers no user can act on. Whatever must survive for the "observable fallback" rule is a minimal read-only status field on an existing status command, never a dev panel.
 - Delete infrastructure only after the previous release ran without needing it by default.
 - Model downloads must be explicit, pinned by expected files and hashes where practical, and described as local ML assets.
 - Do not port a Python feature just because it exists. If it is low value, hard to explain, or expensive to maintain, demote or remove it.
@@ -274,7 +275,7 @@ Recommended sequence:
 
 1. MiniLM Rust inference parity.
 2. MiniLM derived-cache/index dual-write and migration. **Done in M2.4.**
-3. Rust semantic shadow queries compared locally with Chroma; Python remains authoritative.
+3. Rust semantic shadow queries compared locally with Chroma; Python remains authoritative. **Harness done 2026-07-27** — passive per-query shadow, an active built-in query corpus, and a document-encoder re-encode probe, reported through the telemetry-free `get_semantic_shadow_report`. The whole surface is temporary by construction; see the retirement block below.
 4. Cut over semantic-text retrieval and Smart Cluster calibration prefilter; keep rollback.
 5. Reranker parity and shadow scoring; cut over calibration only after score/order gates pass. The Python Smart Cluster worker may temporarily call the Rust reranker, but its Python fallback remains until Milestone 3.
 6. CLIP vector export/migration.
@@ -282,8 +283,51 @@ Recommended sequence:
 8. Rust CLIP text-query shadow mode, then cut over `search_nl` and MCP capability reporting.
 9. Implement BGE in the shared Rust runtime and run it in shadow mode, but do not remove Python BGE inference until classification itself has a Rust path or a deliberately supported Rust inference bridge. The classification consumer remains a Milestone 5 completion item.
 
+Step-3 measurement (2026-07-27, 256-query and 256-document samples): query-encoder
+maximum absolute error 6.0e-7; Overlap@10 p50 100%, p05 50%; top-1 agreement
+90.7%; document re-encode cosine p50 0.9917 / p05 0.9868 / min 0.9796. Retrieval
+divergence is dominated by Rust returning documents the Chroma ANN path does not
+surface — the Rust side is an exact scan over the same hot layer, so a strict
+superset of recall is expected and was accepted as a difference in retrieval
+method rather than a Rust defect. Recorded honestly: this clears the query-encoder
+numeric gate but not the literal "top-10 overlap ≥ 99% / top-1 effectively
+unchanged" or the ≥0.99999 cosine wording below, which were written assuming two
+implementations of the *same* retrieval method. The step-4 cutover therefore keeps
+the `python` fallback and should re-check ranking on the reranked end-to-end path
+(step 5), where the bi-encoder recall difference is re-scored anyway.
+
 - Use enum backends, not ambiguous booleans: `semantic_runtime = python|rust_shadow|rust`, `semantic_index = chroma|dual|rust`, `clip_runtime = python|rust_shadow|rust`, `clip_index = chroma|dual|rust`. Invalid or unavailable Rust configurations fall back observably for one release, with a local diagnostic explaining why.
 - Preserve and explicitly test search response schemas, filters, offsets, limits, thresholds, MCP tool availability, and frontend labels. OCR keyword, MiniLM semantic text, CLIP visual/NL image search, and Smart Cluster assignment remain separately labeled; their scores are not compared across models.
+
+##### Shadow-scaffolding retirement — release-blocking, not optional cleanup
+
+Every `rust_shadow` harness in this milestone is a development instrument with a
+scheduled death. It proves one gate, and then it goes. A production (non-beta)
+release must not contain the shadow toggle or its probes for a capability that
+has already cut over. Enforce this per capability, at the cutover PR, rather
+than as an end-of-milestone sweep — an unowned diagnostic panel never gets
+deleted later.
+
+MiniLM instance of the rule. Shadow-only, delete with (or immediately after)
+the step-4 cutover:
+
+- `semantic_shadow.rs` — `spawn_shadow_sample`, `run_semantic_shadow_probe`, `run_semantic_doc_encoder_probe`, the built-in probe corpus, and the single-flight guards; the `spawn_shadow_sample` call site in `monitor.rs::monitor_nl_cluster_query`; the three Tauri commands registered in `lib.rs`.
+- `storage/semantic_shadow.rs` and the `semantic_shadow_samples` / `semantic_doc_encoder_runs` tables plus their in-place column upgrades in `storage/schema.rs`. Dropping these tables loses no user data — they hold query hashes and parity/latency numbers only, never query text or screenshot content.
+- `SemanticShadowCard` in `settings/advanced/InferenceCards.jsx`, its wiring in `AdvancedSection.jsx`, and the report/probe state in `useAdvancedSectionController.js`.
+- `minilm_migration::minilm_sources_for_ids`, whose only caller is the document-encoder probe.
+- The `rust_shadow` value of `semantic_runtime` once nothing can enter that mode.
+
+Explicitly **not** shadow scaffolding — this code is the production read path and stays:
+
+- `derived_index::semantic_text_topk`, `ScoredSubject`, `count_query_visible_embeddings`.
+- `storage/semantic_cache.rs` (the resident vector matrix), its `StorageState` fields, the idle-eviction ticker in `lib.rs`, and the cache resets in `storage/schema.rs`.
+- The `semantic_runtime` / `semantic_index` enums themselves, minus the retired value: they remain the observable rollback switch required above.
+
+What may survive the cutover is the *fallback* diagnostic the enum rule demands
+— which backend is active and why a Rust configuration was refused — and it
+survives as a field on an existing status command, not as a settings card with
+percentiles in it. Apply the same shape to the reranker, CLIP, and BGE shadows
+when their turn comes.
 
 Release gate:
 
@@ -295,6 +339,7 @@ Release gate:
 - Embedding migration/rebuild is interruptible/resumable; session lock/unlock, process crash, partial ANN generation, model upgrade, rollback to the previous release, and deletion are tested without screenshot loss or silent vector loss.
 - Background semantic work cannot trigger a model load during fullscreen/game activity. User-initiated search remains available with a deadline. OCR p95 latency and reliability show no material regression from semantic work; search p95 latency and peak memory stay within an explicitly recorded budget.
 - The Python fallback remains available for one released version after each capability becomes Rust-default.
+- **No shadow/probe development surface for an already-cut-over capability ships in a production build.** The retirement list above is executed, not deferred: the settings card, the probe commands, and the sample tables are gone, and the only remaining backend diagnostic is the read-only fallback status the enum rule requires. A beta may ship the harness; a production release may not.
 
 Depends on: Milestone 1 semantics/decisions landed and reviewed, including the approximate-count caveats above.
 
@@ -446,6 +491,15 @@ Do not delete a Python component until its Rust replacement has shipped as defau
 - Python classification/PII dependencies — only after Milestone 5 is stable.
 - Python installer/venv/pyz/reverse IPC — only after Milestone 6 proves fresh install and upgrade without Python.
 
+Migration scaffolding runs on the opposite clock. It is not a Python component
+waiting for a replacement; it is temporary instrumentation that must be removed
+as soon as the gate it proves is signed off, and at the latest before the
+capability's first production release:
+
+- MiniLM shadow toggle, query/document probes, `semantic_shadow_samples` / `semantic_doc_encoder_runs`, and the settings card — delete with the M2.5 step-4 cutover. Full artifact list in the retirement block under M2.5.
+- Reranker, CLIP, and BGE shadow harnesses — same rule at their own cutovers.
+- The `rust_shadow` enum values — delete once no capability can still enter shadow mode.
+
 ## Branching And Release Discipline
 
 - Keep this roadmap inside the `carbonPaper` repository (for example `docs/python-removal-roadmap.md`) before treating milestone status as branch/PR truth. The current parent-directory `roadmap.md` is outside the repository and cannot be reviewed or versioned with implementation branches.
@@ -459,6 +513,16 @@ Do not delete a Python component until its Rust replacement has shipped as defau
 
 ## Immediate Next Step
 
-Continue with M2.5 MiniLM shadow queries: compare Rust semantic retrieval locally against Chroma using the migrated generation and bounded delta path, record score/order parity and latency, and keep Python/Chroma authoritative until the release gate and rollback checks pass. The coverage denominator for that gate is the set of valid, mappable vectors in the Chroma hot-layer snapshot, not all SQLite screenshots. Then cut over MiniLM semantic retrieval independently before beginning the separate CLIP vector migration/cutover sequence.
+M2.5 step 3 is done: the shadow harness (passive per-query comparison, active
+query corpus, document re-encode probe) landed on `m2/minilm-shadow-cutover`
+together with the resident-vector read path, and its parity/latency numbers are
+recorded above. Next is step 4 — cut over semantic-text retrieval and the Smart
+Cluster calibration prefilter to `semantic_index = rust`, keeping the `python`
+enum value as the one-release observable rollback. That same PR must delete the
+shadow scaffolding per the retirement block; the harness has now served its
+purpose and must not reach a production build. The coverage denominator for the
+gate is the set of valid, mappable vectors in the Chroma hot-layer snapshot, not
+all SQLite screenshots. Only then begin the separate CLIP vector
+migration/cutover sequence.
 
 No Rust backend becomes authoritative until its Python behavior contract, dual-write/migration, shadow-query, lifecycle, performance, and rollback gates pass. The first recommended cutover is MiniLM semantic retrieval; CLIP follows only after both legacy-vector migration and new-capture Rust image indexing work. Chroma remains for Milestone 4 task clustering, and Python BGE remains for Milestone 5 classification. Until subject-level Rust ledgers exist, the internal count-level CLIP comparison is only a migration baseline, not a product health judgment.

--- a/monitor/monitor/clustering_commands.py
+++ b/monitor/monitor/clustering_commands.py
@@ -23,6 +23,7 @@ HANDLED_CLUSTERING_COMMANDS = {
     "export_task_vectors_page",
     "finish_task_vectors_export",
     "upsert_task_vectors",
+    "get_task_vectors_count",
 }
 
 
@@ -92,6 +93,17 @@ def handle_clustering_command(
                 if k != "clusters"
             } if last else None,
         }
+
+    if cmd == "get_task_vectors_count":
+        service_error = _requires_service(manager=manager)
+        if service_error:
+            return service_error
+        try:
+            count = int(manager.hot_collection.count())
+            return {"status": "success", "count": count}
+        except Exception as e:
+            logger.warning("get_task_vectors_count failed: %s", e)
+            return {"error": str(e)}
 
     if cmd == "set_clustering_interval":
         service_error = _requires_service(scheduler=scheduler)

--- a/scripts/security-guards.cjs
+++ b/scripts/security-guards.cjs
@@ -176,6 +176,9 @@ const COMMAND_TIERS = {
   'semantic_runtime::restart_ml_semantic_worker': 'runtime_public',
   'minilm_migration::get_minilm_rebuild_status': 'public',
   'minilm_migration::list_minilm_rebuild_errors': 'session_required',
+  'semantic_shadow::get_semantic_shadow_report': 'public',
+  'semantic_shadow::run_semantic_shadow_probe': 'session_required',
+  'semantic_shadow::run_semantic_doc_encoder_probe': 'session_required',
   'maintenance::get_maintenance_status': 'public',
 };
 

--- a/src-tauri/src/commands/utility.rs
+++ b/src-tauri/src/commands/utility.rs
@@ -144,6 +144,10 @@ pub fn get_advanced_config() -> Result<serde_json::Value, String> {
         registry_config::get_bool("clustering_allow_full_low_memory").unwrap_or(false);
     let network_enabled = registry_config::get_bool("network_enabled").unwrap_or(true);
     let use_onnx = registry_config::get_bool("use_onnx").unwrap_or(true);
+    // M2.5 per-capability backend selection. Enums, not booleans, because
+    // inference runtime and index ownership cut over at different times.
+    let semantic_runtime = crate::semantic_shadow::semantic_runtime_backend();
+    let semantic_index = crate::semantic_shadow::semantic_index_backend();
 
     Ok(serde_json::json!({
         "cpu_limit_enabled": cpu_limit_enabled,
@@ -160,6 +164,8 @@ pub fn get_advanced_config() -> Result<serde_json::Value, String> {
         "clustering_allow_full_low_memory": clustering_allow_full_low_memory,
         "network_enabled": network_enabled,
         "use_onnx": use_onnx,
+        "semantic_runtime": semantic_runtime,
+        "semantic_index": semantic_index,
     }))
 }
 
@@ -227,6 +233,18 @@ pub fn set_advanced_config(
     }
     if let Some(v) = config.get("use_onnx").and_then(|v| v.as_bool()) {
         registry_config::set_bool("use_onnx", v)?;
+    }
+    // M2.5 backend selection. Unknown enum values are ignored so the runtime
+    // keeps observably falling back to the previous default.
+    if let Some(v) = config.get("semantic_runtime").and_then(|v| v.as_str()) {
+        if ["python", "rust_shadow", "rust"].contains(&v) {
+            registry_config::set_string("semantic_runtime", v)?;
+        }
+    }
+    if let Some(v) = config.get("semantic_index").and_then(|v| v.as_str()) {
+        if ["chroma", "dual", "rust"].contains(&v) {
+            registry_config::set_string("semantic_index", v)?;
+        }
     }
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,6 +38,7 @@ mod script_integrity;
 mod semantic_models;
 #[allow(dead_code)]
 mod semantic_runtime;
+mod semantic_shadow;
 mod sensitive_filter;
 mod storage;
 mod updater;
@@ -957,6 +958,22 @@ pub fn run() {
                         tauri::async_runtime::spawn(async move {
                             ml_runtime::run_postprocess_retry_loop(app_handle_postprocess).await;
                         });
+
+                        // The resident MiniLM matrix only earns its ~14 MiB
+                        // while the user is running NL cluster queries; release
+                        // it once they stop. The frontend does not report when
+                        // the view closes, so this polls instead of subscribing.
+                        let storage_cache = storage.inner().clone();
+                        tauri::async_runtime::spawn(async move {
+                            let mut ticker =
+                                tokio::time::interval(std::time::Duration::from_secs(60));
+                            loop {
+                                ticker.tick().await;
+                                storage_cache.evict_semantic_vector_cache_if_idle(
+                                    storage::SEMANTIC_CACHE_IDLE_TTL,
+                                );
+                            }
+                        });
                     }
                 } else {
                     tracing::error!("Storage initialization deferred: public key unavailable");
@@ -1107,6 +1124,9 @@ pub fn run() {
             semantic_runtime::restart_ml_semantic_worker,
             minilm_migration::get_minilm_rebuild_status,
             minilm_migration::list_minilm_rebuild_errors,
+            semantic_shadow::get_semantic_shadow_report,
+            semantic_shadow::run_semantic_shadow_probe,
+            semantic_shadow::run_semantic_doc_encoder_probe,
             maintenance::get_maintenance_status,
             monitor::monitor_remove_local_anchors_by_process,
             // 安全告警调试触发（设置 → 高级 → 调试）

--- a/src-tauri/src/minilm_migration.rs
+++ b/src-tauri/src/minilm_migration.rs
@@ -1263,6 +1263,34 @@ pub(crate) fn import_minilm_vector_from_python(
     Ok(ensured)
 }
 
+/// Reconstruct the MiniLM task text and its fingerprint for a batch of
+/// screenshot ids, using the exact migration/dual-write contract
+/// (`build_minilm_task_text` + `minilm_source_fingerprint`). Ids that map to no
+/// active screenshot are simply absent from the returned map. Used by the M2.5
+/// document-encoder shadow probe to re-encode migrated documents with the Rust
+/// runtime and compare against the stored Python doc vectors.
+pub(crate) fn minilm_sources_for_ids(
+    storage: &StorageState,
+    ids: &[i64],
+) -> Result<HashMap<i64, (String, String)>, String> {
+    if ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let summaries = storage
+        .get_screenshot_summaries_by_ids_silent(ids)
+        .map_err(background_error)?;
+    let ocr = storage
+        .get_ocr_text_prefixes_by_screenshot_ids_silent(ids, MINILM_OCR_SNIPPET_CHARS)
+        .map_err(background_error)?;
+    let mut out = HashMap::with_capacity(summaries.len());
+    for row in source_rows(summaries, &ocr) {
+        if let Ok(id) = row.spec.subject_key.parse::<i64>() {
+            out.insert(id, (row.text, row.spec.source_fingerprint));
+        }
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -727,6 +727,7 @@ pub async fn monitor_get_task_clusters(
 
 #[tauri::command]
 pub async fn monitor_nl_cluster_query(
+    app: tauri::AppHandle,
     credential_state: State<'_, Arc<crate::credential_manager::CredentialManagerState>>,
     state: State<'_, MonitorState>,
     query: String,
@@ -734,18 +735,34 @@ pub async fn monitor_nl_cluster_query(
     enable_rerank: Option<bool>,
     rerank_variant: Option<String>,
 ) -> Result<Value, String> {
-    authenticated_monitor_command(
+    let enable_rerank = enable_rerank.unwrap_or(false);
+    let started = std::time::Instant::now();
+    let response = authenticated_monitor_command(
         &credential_state,
         &state,
         serde_json::json!({
             "command": "nl_cluster_query",
-            "query": query,
+            "query": query.clone(),
             "n_results": n_results.unwrap_or(30).min(200),
-            "enable_rerank": enable_rerank.unwrap_or(false),
+            "enable_rerank": enable_rerank,
             "rerank_variant": rerank_variant.unwrap_or_else(|| "q4f16".to_string()),
         }),
     )
-    .await
+    .await?;
+    let python_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+    // Passive M2.5 shadow comparison. Runs only when semantic_runtime is
+    // rust_shadow; never alters the authoritative Python/Chroma response.
+    if response.get("status").and_then(|value| value.as_str()) == Some("success") {
+        crate::semantic_shadow::spawn_shadow_sample(
+            app,
+            query,
+            enable_rerank,
+            response.clone(),
+            python_ms,
+        );
+    }
+    Ok(response)
 }
 
 #[tauri::command]

--- a/src-tauri/src/semantic_shadow.rs
+++ b/src-tauri/src/semantic_shadow.rs
@@ -1,0 +1,1181 @@
+//! M2.5 step 3 — MiniLM Rust semantic shadow queries.
+//!
+//! Two ways to generate samples, both comparing the authoritative Chroma/Python
+//! `nl_cluster_query` (MiniLM over `task_vectors`) against the equivalent Rust
+//! exact-scan retrieval over the migrated derived store:
+//!
+//! 1. Passive: when `semantic_runtime = rust_shadow`, every live NL cluster
+//!    query is shadowed in the background (`spawn_shadow_sample`).
+//! 2. Active: `run_semantic_shadow_probe` drives a built-in (or caller-supplied)
+//!    query corpus on demand, so parity can be measured without depending on the
+//!    user manually searching the demo NL surface.
+//!
+//! Neither path ever changes user-visible search behavior; Python/Chroma stays
+//! authoritative throughout the shadow phase. Samples feed the telemetry-free
+//! `get_semantic_shadow_report` diagnostic used to prove the release gate before
+//! any cutover.
+
+use crate::credential_manager::CredentialManagerState;
+use crate::ml_protocol::MlSemanticModel;
+use crate::monitor::{authenticated_monitor_command, MonitorState};
+use crate::registry_config;
+use crate::semantic_runtime::SemanticRuntimeState;
+use crate::storage::{
+    DerivedEmbeddingRecord, DerivedIndexKind, ScoredSubject, SemanticDocEncoderRun,
+    SemanticShadowSample, StorageState,
+};
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Manager};
+
+/// User-initiated search is foreground work: deadline-bound, not idle-gated.
+const SHADOW_EMBED_TIMEOUT: Duration = Duration::from_secs(5);
+/// Overlap is reported over the top-N (Rust-vs-Python) for a stable headline
+/// metric that matches the release gate's "top-10 overlap".
+const OVERLAP_WINDOW: usize = 10;
+/// Candidates fetched per probe query. Matches the frontend NL default so the
+/// probe exercises the same over-fetch/threshold path as a real query.
+const PROBE_N_RESULTS: u32 = 30;
+const MAX_PROBE_QUERIES: usize = 256;
+const MAX_QUERY_CHARS: usize = 512;
+
+/// Default document-encoder sample size when the caller does not specify one.
+const DEFAULT_DOC_SAMPLE_SIZE: u32 = 256;
+/// Hard cap on a single document-encoder probe run.
+const MAX_DOC_SAMPLE_SIZE: u32 = 4_096;
+/// Worker round-trip batch size for document re-encoding. The semantic protocol
+/// bounds a single embed request to 32 texts.
+const DOC_ENCODE_BATCH: usize = 32;
+/// Document re-encoding is an explicit batch diagnostic, not a foreground search,
+/// so it gets a larger per-batch deadline than a single interactive query.
+const DOC_EMBED_TIMEOUT: Duration = Duration::from_secs(30);
+
+const RUNTIME_BACKENDS: &[&str] = &["python", "rust_shadow", "rust"];
+const INDEX_BACKENDS: &[&str] = &["chroma", "dual", "rust"];
+
+/// Built-in, non-sensitive probe corpus. Generic screenshot-content queries in
+/// Chinese and English so the harness works on any user's data without needing
+/// them to type anything sensitive. Deliberately broad (dozens of everyday
+/// domains) so p05/p95 over the corpus are not dominated by a handful of
+/// queries; `sample_count` in the report makes the effective N explicit.
+const DEFAULT_PROBE_QUERIES: &[&str] = &[
+    "代码 编辑器 开发",
+    "会议 日程 安排",
+    "浏览器 网页 搜索",
+    "聊天 消息 对话",
+    "文档 报告 写作",
+    "视频 播放 观看",
+    "购物 订单 支付",
+    "设置 配置 选项",
+    "邮件 收件箱",
+    "终端 命令行",
+    "代码审查 拉取请求",
+    "版本控制 提交记录",
+    "错误 报错 堆栈跟踪",
+    "数据库 查询 表",
+    "接口 文档 调试",
+    "日志 监控 告警",
+    "表格 数据 统计",
+    "幻灯片 演示 汇报",
+    "笔记 待办 清单",
+    "日历 提醒 事项",
+    "地图 导航 路线",
+    "天气 预报 温度",
+    "音乐 歌单 播放器",
+    "照片 相册 图片编辑",
+    "翻译 词典 语言",
+    "新闻 资讯 头条",
+    "社交 动态 评论",
+    "论坛 帖子 回复",
+    "云盘 文件 同步",
+    "下载 上传 进度",
+    "安装 更新 卸载",
+    "登录 注册 密码",
+    "个人资料 账户 头像",
+    "通知 消息中心",
+    "搜索结果 筛选 排序",
+    "支付 账单 发票",
+    "银行 转账 余额",
+    "股票 基金 行情",
+    "机票 酒店 预订",
+    "外卖 餐厅 菜单",
+    "快递 物流 追踪",
+    "视频会议 屏幕共享",
+    "白板 思维导图",
+    "设计 原型 界面",
+    "表单 提交 校验",
+    "游戏 关卡 成就",
+    "直播 弹幕 打赏",
+    "健身 步数 运动记录",
+    "医疗 挂号 报告单",
+    "课程 学习 作业",
+    "招聘 简历 面试",
+    "合同 协议 条款",
+    "报销 审批 流程",
+    "客服 工单 反馈",
+    "invoice and billing",
+    "meeting notes",
+    "pull request review",
+    "error stack trace",
+    "database query editor",
+    "api documentation",
+    "spreadsheet data table",
+    "presentation slides",
+    "todo list and tasks",
+    "calendar reminder",
+    "map directions route",
+    "weather forecast",
+    "music playlist player",
+    "photo gallery editor",
+    "email inbox thread",
+    "terminal command output",
+    "settings and preferences",
+    "login and password reset",
+    "shopping cart checkout",
+    "flight and hotel booking",
+    "file upload progress",
+    "video call screen share",
+    "chat conversation history",
+    "dashboard charts metrics",
+    "search filters and sorting",
+    "notification center",
+    "source control commit log",
+    "unit test results",
+    "cloud storage sync",
+    "job application resume",
+    "bank transfer balance",
+    "stock market quotes",
+    "food delivery order",
+    "package tracking status",
+    "online course lecture",
+    "design prototype mockup",
+];
+
+/// Single-flight guard so a double-click cannot launch two overlapping probes.
+static PROBE_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Selected semantic inference backend. Invalid/unset values fall back to
+/// `python` observably (the shadow simply does not run).
+pub fn semantic_runtime_backend() -> String {
+    normalize_enum(
+        registry_config::get_string("semantic_runtime"),
+        RUNTIME_BACKENDS,
+        "python",
+    )
+}
+
+/// Selected semantic index ownership backend. Reserved for the step-4 cutover;
+/// read here so the setting round-trips through the diagnostics UI today.
+pub fn semantic_index_backend() -> String {
+    normalize_enum(
+        registry_config::get_string("semantic_index"),
+        INDEX_BACKENDS,
+        "chroma",
+    )
+}
+
+fn normalize_enum(value: Option<String>, allowed: &[&str], default: &str) -> String {
+    match value {
+        Some(value) if allowed.contains(&value.as_str()) => value,
+        _ => default.to_string(),
+    }
+}
+
+/// Run one synchronous storage closure off the async runtime.
+///
+/// Every storage call in this module takes the process-wide, non-reentrant
+/// database mutex, and several are O(N) scans or per-row CNG decryptions.
+/// Awaiting one on a tokio worker parks that worker for the whole lock wait —
+/// and the probe issues hundreds of them back-to-back while live capture holds
+/// the same lock, which starves the runtime the reverse-IPC bridge shares.
+async fn blocking_storage<T, F>(storage: &Arc<StorageState>, work: F) -> Result<T, String>
+where
+    F: FnOnce(&StorageState) -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    let storage = storage.clone();
+    tokio::task::spawn_blocking(move || work(&storage))
+        .await
+        .map_err(|error| format!("storage task failed: {error}"))?
+}
+
+/// Persist one sample off the async runtime and hand it back to the caller.
+async fn record_sample(
+    storage: &Arc<StorageState>,
+    sample: SemanticShadowSample,
+) -> Result<SemanticShadowSample, String> {
+    let recorded = sample.clone();
+    blocking_storage(storage, move |storage| {
+        storage.record_semantic_shadow_sample(&sample)
+    })
+    .await?;
+    Ok(recorded)
+}
+
+/// Query-visible Rust vector count, or 0 when the store cannot answer.
+async fn rust_visible_count(storage: &Arc<StorageState>) -> u64 {
+    blocking_storage(storage, |storage| {
+        Ok(storage
+            .count_query_visible_embeddings(DerivedIndexKind::SemanticText)
+            .unwrap_or(0))
+    })
+    .await
+    .unwrap_or(0)
+}
+
+/// Spawn a best-effort passive shadow comparison for one already-served NL
+/// query. Returns immediately; the comparison runs on a background task and
+/// never affects the caller's response.
+pub fn spawn_shadow_sample(
+    app: AppHandle,
+    query: String,
+    enable_rerank: bool,
+    python_response: serde_json::Value,
+    python_ms: f64,
+) {
+    // The Rust path is bi-encoder retrieval; reranker parity is M2.5 step 5.
+    // Comparing against a reranked Python response would measure the reranker,
+    // not retrieval, so skip those queries entirely.
+    if enable_rerank {
+        return;
+    }
+    if semantic_runtime_backend() != "rust_shadow" {
+        return;
+    }
+    // A migration is rewriting the derived store; a shadow read would race it.
+    if crate::maintenance::is_active() {
+        return;
+    }
+    if query.trim().is_empty() {
+        return;
+    }
+    tauri::async_runtime::spawn(async move {
+        let storage = app.state::<Arc<StorageState>>().inner().clone();
+        let semantic = app.state::<Arc<SemanticRuntimeState>>().inner().clone();
+        let chroma_scope = resolve_chroma_scope(&app, &storage).await;
+        if let Err(error) = evaluate_and_record(
+            &app,
+            &storage,
+            &semantic,
+            query.trim(),
+            &python_response,
+            python_ms,
+            chroma_scope,
+            false,
+        )
+        .await
+        {
+            tracing::debug!("[SEMANTIC:SHADOW] passive sample skipped: {error}");
+        }
+    });
+}
+
+/// Compare one query's Python ranking against the Rust exact-scan retrieval and
+/// record a sample. Always records: when the comparison cannot be made it
+/// records a `note` sample instead, which the aggregate excludes rather than
+/// scoring as a zero-overlap divergence. Returns the recorded sample.
+async fn evaluate_and_record(
+    app: &AppHandle,
+    storage: &Arc<StorageState>,
+    semantic: &Arc<SemanticRuntimeState>,
+    query: &str,
+    python_response: &serde_json::Value,
+    python_ms: f64,
+    chroma_scope: Option<u64>,
+    cold_start: bool,
+) -> Result<SemanticShadowSample, String> {
+    let query_hash = hash_query(query);
+    let python_results = parse_python_results(python_response);
+    let rust_visible = rust_visible_count(storage).await;
+
+    // Python answered `success` with no ranking at all. `query_by_text` returns
+    // an empty list for an absent collection, a zero-count collection, and any
+    // internal Chroma exception it swallows — none of which is a measurement.
+    // Comparing against it would yield overlap=0 / top1=false, identical to a
+    // real divergence, so record it as a note sample and stop. Otherwise one
+    // click on the probe before the MiniLM index exists writes ~90 phantom
+    // zero-overlap rows that hold the gate numbers down for several runs.
+    if python_results.is_empty() {
+        let sample = note_sample(
+            &query_hash,
+            0,
+            python_ms,
+            0.0,
+            rust_visible,
+            chroma_scope,
+            cold_start,
+            "python_empty_results: Chroma returned no ranking to compare against",
+        );
+        return record_sample(storage, sample).await;
+    }
+
+    // Embed the query with the Rust MiniLM runtime (CPU-only, foreground).
+    let embed_started = Instant::now();
+    let embedding = semantic
+        .embed_text(
+            app.clone(),
+            MlSemanticModel::MinilmL12,
+            vec![query.to_string()],
+            SHADOW_EMBED_TIMEOUT,
+            false,
+        )
+        .await;
+    let embed_ms = elapsed_ms(embed_started);
+    let embedding = match embedding {
+        Ok(embedding) => embedding,
+        Err(error) => {
+            let sample = note_sample(
+                &query_hash,
+                python_results.len(),
+                python_ms,
+                embed_ms,
+                rust_visible,
+                chroma_scope,
+                cold_start,
+                &format!("embed_failed: {error}"),
+            );
+            return record_sample(storage, sample).await;
+        }
+    };
+    let query_vec = embedding
+        .vectors
+        .into_iter()
+        .next()
+        .ok_or("semantic worker returned no embedding")?;
+
+    // Exact-scan retrieval over the query-visible derived store, followed by the
+    // per-id classification lookups. Both are synchronous SQLite work under the
+    // global storage mutex, so they share one blocking thread instead of hopping
+    // back onto the async runtime between them.
+    let k = python_results.len().max(1);
+    let python_count = python_results.len();
+    let scan_storage = storage.clone();
+    let scan_vec = query_vec;
+    let scan_results = python_results;
+    let (rust_count, scan_ms, metrics) = tokio::task::spawn_blocking(move || {
+        let scan_started = Instant::now();
+        let rust_top = scan_storage.semantic_text_topk(&scan_vec, k)?;
+        let scan_ms = elapsed_ms(scan_started);
+        let metrics = compute_metrics(&scan_results, &rust_top, &scan_vec, &scan_storage);
+        Ok::<_, String>((rust_top.len() as u32, scan_ms, metrics))
+    })
+    .await
+    .map_err(|error| format!("shadow scan task failed: {error}"))??;
+
+    // A classification lookup that errored leaves this row's divergence
+    // breakdown incomplete, so mark it and let the aggregate skip it.
+    let note = (metrics.lookup_failed > 0).then(|| {
+        format!(
+            "classification_lookup_failed: {} of {} top-K lookups errored",
+            metrics.lookup_failed,
+            OVERLAP_WINDOW.min(python_count)
+        )
+    });
+
+    let sample = SemanticShadowSample {
+        query_hash,
+        k: k as u32,
+        python_count: python_count as u32,
+        rust_count,
+        shared: metrics.shared,
+        top1_agreement: metrics.top1_agreement,
+        overlap_k: metrics.overlap,
+        max_abs_err: metrics.max_abs_err,
+        mean_abs_err: metrics.mean_abs_err,
+        embed_ms,
+        scan_ms,
+        python_ms,
+        rust_visible,
+        chroma_scope,
+        only_in_chroma: metrics.only_in_chroma,
+        in_both_diff_rank: metrics.in_both_diff_rank,
+        only_in_rust: metrics.only_in_rust,
+        cold_start,
+        note,
+    };
+    record_sample(storage, sample).await
+}
+
+struct ShadowMetrics {
+    shared: u32,
+    top1_agreement: bool,
+    overlap: f32,
+    max_abs_err: Option<f32>,
+    mean_abs_err: Option<f32>,
+    only_in_chroma: u32,
+    in_both_diff_rank: u32,
+    only_in_rust: u32,
+    /// Top-K ids whose local lookup returned an error instead of a definite
+    /// present/absent answer. Deliberately never folded into `only_in_chroma`.
+    lookup_failed: u32,
+}
+
+fn compute_metrics(
+    python_results: &[(i64, Option<f32>)],
+    rust_top: &[ScoredSubject],
+    query_vec: &[f32],
+    storage: &StorageState,
+) -> ShadowMetrics {
+    let window = OVERLAP_WINDOW.min(python_results.len()).max(1);
+    let python_ids: Vec<i64> = python_results.iter().map(|(id, _)| *id).collect();
+    let rust_ids: Vec<i64> = rust_top
+        .iter()
+        .filter_map(|scored| scored.subject_key.parse::<i64>().ok())
+        .collect();
+
+    let python_window: HashSet<i64> = python_ids.iter().take(window).copied().collect();
+    let rust_window: HashSet<i64> = rust_ids.iter().take(window).copied().collect();
+    let shared = python_window.intersection(&rust_window).count();
+    let overlap = shared as f32 / window as f32;
+    let top1_agreement = matches!(
+        (python_ids.first(), rust_ids.first()),
+        (Some(a), Some(b)) if a == b
+    );
+
+    // One local lookup per Python-top id does double duty: it classifies the
+    // disagreement AND supplies the stored vector for the cosine-error check.
+    // Cosine error isolates the query-encoder difference (stored doc vectors
+    // are the migrated Python copies). The classification is the decisive
+    // signal: a Python-top id absent from the Rust store means Rust is missing
+    // a document Chroma serves (real divergence); a Python-top id present in
+    // Rust but ranked out is ranking/approximation, not missing data.
+    let mut abs_errors: Vec<f32> = Vec::new();
+    let mut only_in_chroma = 0u32;
+    let mut in_both_diff_rank = 0u32;
+    let mut lookup_failed = 0u32;
+    for (id, python_sim) in python_results.iter().take(window) {
+        let stored = match storage
+            .get_query_visible_embedding(DerivedIndexKind::SemanticText, &id.to_string())
+        {
+            Ok(stored) => stored,
+            Err(error) => {
+                // A read error means "unknown", not "absent". Folding it into
+                // `only_in_chroma` would report a transient storage fault as the
+                // one metric that means "Rust is missing data Chroma serves" —
+                // the most alarming number on the cutover gate.
+                tracing::debug!(
+                    "[SEMANTIC:SHADOW] top-K classification lookup failed for {id}: {error}"
+                );
+                lookup_failed += 1;
+                continue;
+            }
+        };
+        if !rust_window.contains(id) {
+            match &stored {
+                Some(_) => in_both_diff_rank += 1,
+                None => only_in_chroma += 1,
+            }
+        }
+        if let (Some(python_sim), Some(record)) = (python_sim.as_ref(), stored.as_ref()) {
+            if record.vector.len() == query_vec.len() {
+                let rust_sim: f32 = query_vec
+                    .iter()
+                    .zip(&record.vector)
+                    .map(|(x, y)| x * y)
+                    .sum();
+                abs_errors.push((rust_sim - *python_sim).abs());
+            }
+        }
+    }
+    let only_in_rust = rust_ids
+        .iter()
+        .take(window)
+        .filter(|id| !python_window.contains(id))
+        .count() as u32;
+
+    let max_abs_err = abs_errors
+        .iter()
+        .copied()
+        .fold(None, |acc: Option<f32>, value| {
+            Some(acc.map_or(value, |current| current.max(value)))
+        });
+    let mean_abs_err = if abs_errors.is_empty() {
+        None
+    } else {
+        Some(abs_errors.iter().sum::<f32>() / abs_errors.len() as f32)
+    };
+
+    ShadowMetrics {
+        shared: shared as u32,
+        top1_agreement,
+        overlap,
+        max_abs_err,
+        mean_abs_err,
+        only_in_chroma,
+        in_both_diff_rank,
+        only_in_rust,
+        lookup_failed,
+    }
+}
+
+/// The comparison denominator per the roadmap gate is the set of valid,
+/// mappable vectors in the migrated Chroma snapshot. This is only a fallback
+/// for when the live count is unavailable — it is a historical migration-time
+/// value, not the current hot-layer size.
+async fn mappable_chroma_scope(storage: &Arc<StorageState>) -> Option<u64> {
+    blocking_storage(storage, |storage| {
+        Ok(storage.get_latest_minilm_migration_run().ok().flatten())
+    })
+    .await
+    .ok()
+    .flatten()
+    .map(|run| run.migrated + run.legacy_unverified)
+}
+
+/// Live count of the Chroma `task_vectors` hot layer, so coverage compares
+/// live-Rust against live-Chroma. Best-effort: `None` if the monitor is down.
+async fn live_chroma_task_vectors_count(app: &AppHandle) -> Option<u64> {
+    let credential = app.state::<Arc<CredentialManagerState>>();
+    let monitor = app.state::<MonitorState>();
+    let response = authenticated_monitor_command(
+        &credential,
+        &monitor,
+        serde_json::json!({ "command": "get_task_vectors_count" }),
+    )
+    .await
+    .ok()?;
+    if response.get("status").and_then(|value| value.as_str()) != Some("success") {
+        return None;
+    }
+    response.get("count").and_then(serde_json::Value::as_u64)
+}
+
+/// Resolve the coverage denominator: the live Chroma hot-layer count when the
+/// monitor answers, otherwise the historical migration-snapshot fallback.
+async fn resolve_chroma_scope(app: &AppHandle, storage: &Arc<StorageState>) -> Option<u64> {
+    match live_chroma_task_vectors_count(app).await {
+        Some(count) => Some(count),
+        None => mappable_chroma_scope(storage).await,
+    }
+}
+
+fn parse_python_results(response: &serde_json::Value) -> Vec<(i64, Option<f32>)> {
+    let Some(results) = response.get("results").and_then(|value| value.as_array()) else {
+        return Vec::new();
+    };
+    let mut parsed = Vec::with_capacity(results.len());
+    let mut seen = HashMap::new();
+    for entry in results {
+        let Some(id) = entry
+            .get("screenshot_id")
+            .and_then(serde_json::Value::as_i64)
+            .filter(|id| *id > 0)
+        else {
+            continue;
+        };
+        // Chroma can only return each id once, but guard against duplicates so
+        // the overlap denominator stays honest.
+        if seen.insert(id, ()).is_some() {
+            continue;
+        }
+        let similarity = entry
+            .get("similarity")
+            .and_then(serde_json::Value::as_f64)
+            .map(|value| value as f32);
+        parsed.push((id, similarity));
+    }
+    parsed
+}
+
+#[allow(clippy::too_many_arguments)]
+fn note_sample(
+    query_hash: &str,
+    python_count: usize,
+    python_ms: f64,
+    embed_ms: f64,
+    rust_visible: u64,
+    chroma_scope: Option<u64>,
+    cold_start: bool,
+    note: &str,
+) -> SemanticShadowSample {
+    SemanticShadowSample {
+        query_hash: query_hash.to_string(),
+        k: 0,
+        python_count: python_count as u32,
+        rust_count: 0,
+        shared: 0,
+        top1_agreement: false,
+        overlap_k: 0.0,
+        max_abs_err: None,
+        mean_abs_err: None,
+        embed_ms,
+        scan_ms: 0.0,
+        python_ms,
+        rust_visible,
+        chroma_scope,
+        only_in_chroma: 0,
+        in_both_diff_rank: 0,
+        only_in_rust: 0,
+        cold_start,
+        note: Some(note.to_string()),
+    }
+}
+
+fn hash_query(query: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(query.as_bytes());
+    format!("{:x}", digest.finalize())
+}
+
+fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1000.0
+}
+
+/// Authoritatively query the Python MiniLM NL surface for the probe. Reranking
+/// is off so the comparison stays at the bi-encoder retrieval layer.
+async fn probe_python_query(
+    app: &AppHandle,
+    query: &str,
+) -> Result<(serde_json::Value, f64), String> {
+    let credential = app.state::<Arc<CredentialManagerState>>();
+    let monitor = app.state::<MonitorState>();
+    let started = Instant::now();
+    let response = authenticated_monitor_command(
+        &credential,
+        &monitor,
+        serde_json::json!({
+            "command": "nl_cluster_query",
+            "query": query,
+            "n_results": PROBE_N_RESULTS,
+            "enable_rerank": false,
+            "rerank_variant": "q4f16",
+        }),
+    )
+    .await?;
+    let python_ms = elapsed_ms(started);
+    match response.get("status").and_then(|value| value.as_str()) {
+        Some("success") => Ok((response, python_ms)),
+        _ => Err(response
+            .get("error")
+            .and_then(|value| value.as_str())
+            .unwrap_or("nl_cluster_query did not return success")
+            .to_string()),
+    }
+}
+
+fn resolve_probe_queries(queries: Option<Vec<String>>) -> Vec<String> {
+    let raw = match queries {
+        Some(queries) if !queries.is_empty() => queries,
+        _ => DEFAULT_PROBE_QUERIES
+            .iter()
+            .map(|query| query.to_string())
+            .collect(),
+    };
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for query in raw {
+        let trimmed = query.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let capped: String = trimmed.chars().take(MAX_QUERY_CHARS).collect();
+        if seen.insert(capped.clone()) {
+            out.push(capped);
+            if out.len() >= MAX_PROBE_QUERIES {
+                break;
+            }
+        }
+    }
+    out
+}
+
+async fn run_probe_inner(
+    app: AppHandle,
+    queries: Option<Vec<String>>,
+) -> Result<serde_json::Value, String> {
+    let queries = resolve_probe_queries(queries);
+    if queries.is_empty() {
+        return Err("No valid probe queries were provided".to_string());
+    }
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+    let semantic = app.state::<Arc<SemanticRuntimeState>>().inner().clone();
+    // The live hot-layer size is stable across one probe run; fetch it once so
+    // coverage is live-Rust vs live-Chroma without an IPC per query.
+    let chroma_scope = resolve_chroma_scope(&app, &storage).await;
+
+    let mut recorded = 0u32;
+    let mut full_samples = 0u32;
+    let mut note_samples = 0u32;
+    let mut python_failures = 0u32;
+
+    for (index, query) in queries.iter().enumerate() {
+        // The first probe sample bears the ONNX session-init cost; flag it so
+        // the report can exclude it from steady-state latency percentiles.
+        let cold_start = index == 0;
+        match probe_python_query(&app, query).await {
+            Ok((response, python_ms)) => {
+                match evaluate_and_record(
+                    &app,
+                    &storage,
+                    &semantic,
+                    query,
+                    &response,
+                    python_ms,
+                    chroma_scope,
+                    cold_start,
+                )
+                .await
+                {
+                    Ok(sample) => {
+                        recorded += 1;
+                        if sample.note.is_some() {
+                            note_samples += 1;
+                        } else {
+                            full_samples += 1;
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            "[SEMANTIC:SHADOW] probe evaluate failed for one query: {error}"
+                        );
+                    }
+                }
+            }
+            Err(error) => {
+                python_failures += 1;
+                let sample = note_sample(
+                    &hash_query(query),
+                    0,
+                    0.0,
+                    0.0,
+                    rust_visible_count(&storage).await,
+                    chroma_scope,
+                    cold_start,
+                    &format!("python_query_failed: {error}"),
+                );
+                if record_sample(&storage, sample).await.is_ok() {
+                    recorded += 1;
+                    note_samples += 1;
+                }
+            }
+        }
+    }
+
+    Ok(serde_json::json!({
+        "queries": queries.len(),
+        "recorded": recorded,
+        "full_samples": full_samples,
+        "note_samples": note_samples,
+        "python_failures": python_failures,
+        "report": report_value(&storage).await?,
+    }))
+}
+
+async fn report_value(storage: &Arc<StorageState>) -> Result<serde_json::Value, String> {
+    let report = blocking_storage(storage, |storage| {
+        storage.get_semantic_shadow_report(500)
+    })
+    .await?;
+    let mut value = serde_json::to_value(&report).map_err(|error| error.to_string())?;
+    if let serde_json::Value::Object(map) = &mut value {
+        map.insert(
+            "semantic_runtime".to_string(),
+            serde_json::Value::String(semantic_runtime_backend()),
+        );
+        map.insert(
+            "semantic_index".to_string(),
+            serde_json::Value::String(semantic_index_backend()),
+        );
+    }
+    Ok(value)
+}
+
+/// Async on purpose: a non-async Tauri command runs on the main thread, and this
+/// one scans up to 500 sample rows plus a doc-run lookup under the global
+/// storage mutex. The settings page calls it on every mount, so a sync version
+/// froze the UI thread whenever a capture write held that lock.
+#[tauri::command]
+pub async fn get_semantic_shadow_report(
+    storage: tauri::State<'_, Arc<StorageState>>,
+    _window: Option<u32>,
+) -> Result<serde_json::Value, String> {
+    let storage = storage.inner().clone();
+    report_value(&storage).await
+}
+
+/// Run the active shadow probe over a built-in (or caller-supplied) query
+/// corpus. This is an explicit, foreground diagnostic: it runs regardless of the
+/// `semantic_runtime` setting so parity can be measured before enabling the
+/// passive shadow, but it is still rejected during maintenance.
+#[tauri::command]
+pub async fn run_semantic_shadow_probe(
+    app: AppHandle,
+    credential_state: tauri::State<'_, Arc<CredentialManagerState>>,
+    queries: Option<Vec<String>>,
+) -> Result<serde_json::Value, String> {
+    crate::commands::check_auth_required(&credential_state)?;
+    if crate::maintenance::is_active() {
+        return Err(crate::maintenance::MAINTENANCE_IN_PROGRESS.to_string());
+    }
+    if PROBE_RUNNING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err("A semantic shadow probe is already running".to_string());
+    }
+    let result = run_probe_inner(app, queries).await;
+    PROBE_RUNNING.store(false, Ordering::SeqCst);
+    result
+}
+
+/// Single-flight guard for the document-encoder probe.
+static DOC_PROBE_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Run the active document-encoder parity probe. This fills the half of the
+/// chain the per-query shadow cannot: it re-encodes a sample of the migrated
+/// documents with the Rust MiniLM runtime (`build_minilm_task_text` + Rust
+/// encoder) and compares each against the stored Python document vector. The
+/// per-query samples, by contrast, reuse the stored Python doc vectors and so
+/// only exercise the query encoder. Foreground, auth-gated, rejected during
+/// maintenance.
+#[tauri::command]
+pub async fn run_semantic_doc_encoder_probe(
+    app: AppHandle,
+    credential_state: tauri::State<'_, Arc<CredentialManagerState>>,
+    sample_size: Option<u32>,
+) -> Result<serde_json::Value, String> {
+    crate::commands::check_auth_required(&credential_state)?;
+    if crate::maintenance::is_active() {
+        return Err(crate::maintenance::MAINTENANCE_IN_PROGRESS.to_string());
+    }
+    if DOC_PROBE_RUNNING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err("A document-encoder probe is already running".to_string());
+    }
+    let result = run_doc_encoder_probe_inner(app, sample_size).await;
+    DOC_PROBE_RUNNING.store(false, Ordering::SeqCst);
+    result
+}
+
+async fn run_doc_encoder_probe_inner(
+    app: AppHandle,
+    sample_size: Option<u32>,
+) -> Result<serde_json::Value, String> {
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+    let semantic = app.state::<Arc<SemanticRuntimeState>>().inner().clone();
+    let requested = sample_size
+        .unwrap_or(DEFAULT_DOC_SAMPLE_SIZE)
+        .clamp(1, MAX_DOC_SAMPLE_SIZE) as usize;
+
+    // Draw an unbiased sample of the migrated (query-visible) MiniLM vectors off
+    // the async runtime — the reservoir scan is synchronous SQLite work.
+    let sample_storage = storage.clone();
+    let sampled =
+        tokio::task::spawn_blocking(move || sample_visible_embeddings(&sample_storage, requested))
+            .await
+            .map_err(|error| format!("doc-encoder sampling task failed: {error}"))??;
+
+    if sampled.is_empty() {
+        let run = SemanticDocEncoderRun {
+            requested: requested as u64,
+            note: Some("no query-visible MiniLM vectors to compare".to_string()),
+            ..Default::default()
+        };
+        blocking_storage(&storage, move |storage| storage.record_doc_encoder_run(&run)).await?;
+        return Ok(serde_json::json!({
+            "doc_encoder": blocking_storage(&storage, |storage| storage
+                .get_latest_doc_encoder_run())
+            .await?,
+            "report": report_value(&storage).await?,
+        }));
+    }
+
+    let drawn = sampled.len() as u64;
+    let mut cosines: Vec<f32> = Vec::with_capacity(sampled.len());
+    let mut source_changed = 0u64;
+    let mut missing_text = 0u64;
+    let mut cold_start_ms: Option<f64> = None;
+    let mut steady_ms_total = 0f64;
+    let mut steady_docs = 0u64;
+    let mut first_batch = true;
+
+    for chunk in sampled.chunks(DOC_ENCODE_BATCH) {
+        let ids: Vec<i64> = chunk
+            .iter()
+            .filter_map(|record| record.job.subject_key.parse::<i64>().ok())
+            .collect();
+        // Reconstruct the exact migration-contract task text for this batch.
+        // Per batch this reads SQLite, unwraps a CNG-protected key and decrypts
+        // every row, so it belongs off the async runtime like the scan does.
+        let sources_ids = ids.clone();
+        let sources =
+            blocking_storage(&storage, move |storage| {
+                crate::minilm_migration::minilm_sources_for_ids(storage, &sources_ids)
+            })
+            .await?;
+
+        let mut batch_texts: Vec<String> = Vec::with_capacity(chunk.len());
+        let mut batch_python: Vec<Vec<f32>> = Vec::with_capacity(chunk.len());
+        for record in chunk {
+            let Ok(id) = record.job.subject_key.parse::<i64>() else {
+                missing_text += 1;
+                continue;
+            };
+            match sources.get(&id) {
+                Some((text, fingerprint)) if !text.is_empty() => {
+                    // Only compare when the current SQLite text still hashes to
+                    // the stored fingerprint; otherwise the stored Python vector
+                    // and a fresh Rust encode would describe different text.
+                    if *fingerprint == record.job.source_fingerprint {
+                        batch_texts.push(text.clone());
+                        batch_python.push(record.vector.clone());
+                    } else {
+                        source_changed += 1;
+                    }
+                }
+                _ => missing_text += 1,
+            }
+        }
+        if batch_texts.is_empty() {
+            continue;
+        }
+
+        let batch_len = batch_texts.len();
+        let started = Instant::now();
+        let embedded = semantic
+            .embed_text(
+                app.clone(),
+                MlSemanticModel::MinilmL12,
+                batch_texts,
+                DOC_EMBED_TIMEOUT,
+                false,
+            )
+            .await?;
+        let batch_ms = elapsed_ms(started);
+
+        for (rust_vec, python_vec) in embedded.vectors.iter().zip(batch_python.iter()) {
+            if let Some(similarity) = cosine(rust_vec, python_vec) {
+                cosines.push(similarity);
+            }
+        }
+        // The first batch bears the ONNX session-init cost; report it as the
+        // cold figure and amortize only the remaining batches into steady state.
+        if first_batch {
+            cold_start_ms = Some(batch_ms);
+            first_batch = false;
+        } else {
+            steady_ms_total += batch_ms;
+            steady_docs += batch_len as u64;
+        }
+    }
+
+    cosines.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let doc_sample_count = cosines.len() as u64;
+    let cos_min = cosines.first().copied();
+    let cos_max = cosines.last().copied();
+    let cos_mean = if cosines.is_empty() {
+        None
+    } else {
+        Some(cosines.iter().sum::<f32>() / cosines.len() as f32)
+    };
+    let steady_ms_per_doc = if steady_docs > 0 {
+        Some(steady_ms_total / steady_docs as f64)
+    } else {
+        None
+    };
+    let note = (doc_sample_count == 0)
+        .then(|| "all sampled documents were skipped (source changed or empty)".to_string());
+
+    let run = SemanticDocEncoderRun {
+        created_at: String::new(),
+        doc_sample_count,
+        requested: drawn,
+        source_changed,
+        missing_text,
+        cos_min,
+        cos_p05: sorted_percentile_f32(&cosines, 0.05),
+        cos_p50: sorted_percentile_f32(&cosines, 0.50),
+        cos_mean,
+        cos_max,
+        max_abs_err: cos_min.map(|value| 1.0 - value),
+        cold_start_ms,
+        steady_ms_per_doc,
+        note,
+    };
+    blocking_storage(&storage, move |storage| storage.record_doc_encoder_run(&run)).await?;
+
+    Ok(serde_json::json!({
+        "doc_encoder": blocking_storage(&storage, |storage| storage.get_latest_doc_encoder_run())
+            .await?,
+        "report": report_value(&storage).await?,
+    }))
+}
+
+/// Reservoir-sample (Algorithm R) up to `sample_size` query-visible semantic
+/// embeddings so a probe draws an unbiased spread across the whole migrated hot
+/// layer instead of just the lowest screenshot ids.
+fn sample_visible_embeddings(
+    storage: &StorageState,
+    sample_size: usize,
+) -> Result<Vec<DerivedEmbeddingRecord>, String> {
+    use rand::Rng;
+    const PAGE: u32 = 2_000;
+    let mut reservoir: Vec<DerivedEmbeddingRecord> = Vec::with_capacity(sample_size.min(4_096));
+    let mut rng = rand::thread_rng();
+    let mut seen = 0usize;
+    let mut offset = 0u32;
+    loop {
+        let page =
+            storage.list_query_visible_embeddings(DerivedIndexKind::SemanticText, offset, PAGE)?;
+        let page_len = page.len();
+        for record in page {
+            if reservoir.len() < sample_size {
+                reservoir.push(record);
+            } else {
+                let index = rng.gen_range(0..=seen);
+                if index < sample_size {
+                    reservoir[index] = record;
+                }
+            }
+            seen += 1;
+        }
+        if (page_len as u32) < PAGE {
+            break;
+        }
+        offset = offset
+            .checked_add(PAGE)
+            .ok_or("doc-encoder sampling offset overflow")?;
+    }
+    Ok(reservoir)
+}
+
+/// True cosine similarity with f64 accumulation. Both MiniLM outputs are
+/// L2-normalized, so this equals their dot product, but normalizing here keeps
+/// the metric unambiguous regardless of stored-vector scale.
+fn cosine(a: &[f32], b: &[f32]) -> Option<f32> {
+    if a.is_empty() || a.len() != b.len() {
+        return None;
+    }
+    let mut dot = 0f64;
+    let mut norm_a = 0f64;
+    let mut norm_b = 0f64;
+    for (x, y) in a.iter().zip(b) {
+        dot += f64::from(*x) * f64::from(*y);
+        norm_a += f64::from(*x) * f64::from(*x);
+        norm_b += f64::from(*y) * f64::from(*y);
+    }
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom <= f64::EPSILON {
+        return None;
+    }
+    Some((dot / denom).clamp(-1.0, 1.0) as f32)
+}
+
+/// Nearest-rank percentile over an already-ascending-sorted slice. `q` in [0,1].
+fn sorted_percentile_f32(sorted: &[f32], q: f64) -> Option<f32> {
+    if sorted.is_empty() {
+        return None;
+    }
+    let rank = (q * (sorted.len() as f64 - 1.0)).round() as usize;
+    sorted.get(rank.min(sorted.len() - 1)).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scored(id: &str, score: f32) -> ScoredSubject {
+        ScoredSubject {
+            subject_key: id.to_string(),
+            score,
+        }
+    }
+
+    #[test]
+    fn enum_normalization_rejects_unknown_values() {
+        assert_eq!(normalize_enum(None, RUNTIME_BACKENDS, "python"), "python");
+        assert_eq!(
+            normalize_enum(Some("rust_shadow".to_string()), RUNTIME_BACKENDS, "python"),
+            "rust_shadow"
+        );
+        assert_eq!(
+            normalize_enum(Some("nonsense".to_string()), RUNTIME_BACKENDS, "python"),
+            "python"
+        );
+    }
+
+    #[test]
+    fn parses_ranked_ids_and_similarities() {
+        let response = serde_json::json!({
+            "status": "success",
+            "results": [
+                {"screenshot_id": 7, "similarity": 0.9},
+                {"screenshot_id": 3, "similarity": null},
+                {"screenshot_id": 0, "similarity": 0.5},
+                {"screenshot_id": 7, "similarity": 0.9}
+            ]
+        });
+        let parsed = parse_python_results(&response);
+        assert_eq!(parsed, vec![(7, Some(0.9)), (3, None)]);
+    }
+
+    #[test]
+    fn overlap_and_top1_are_computed_over_the_window() {
+        let python: Vec<(i64, Option<f32>)> = vec![(1, None), (2, None), (3, None)];
+        let rust = vec![scored("1", 0.99), scored("2", 0.98), scored("9", 0.10)];
+        let window = OVERLAP_WINDOW.min(python.len());
+        let py: HashSet<i64> = python.iter().map(|(id, _)| *id).take(window).collect();
+        let ru: HashSet<i64> = rust
+            .iter()
+            .filter_map(|s| s.subject_key.parse::<i64>().ok())
+            .take(window)
+            .collect();
+        assert_eq!(py.intersection(&ru).count(), 2);
+    }
+
+    #[test]
+    fn resolve_probe_queries_uses_defaults_and_dedupes() {
+        let defaulted = resolve_probe_queries(None);
+        assert_eq!(defaulted.len(), DEFAULT_PROBE_QUERIES.len());
+
+        let custom = resolve_probe_queries(Some(vec![
+            "  hello  ".to_string(),
+            "hello".to_string(),
+            "   ".to_string(),
+            "world".to_string(),
+        ]));
+        assert_eq!(custom, vec!["hello".to_string(), "world".to_string()]);
+
+        // Empty vec falls back to defaults, not an empty run.
+        assert_eq!(resolve_probe_queries(Some(vec![])).len(), DEFAULT_PROBE_QUERIES.len());
+    }
+
+    #[test]
+    fn default_corpus_is_deduped_and_within_cap() {
+        // The expanded corpus must have no accidental duplicates and stay under
+        // the per-run cap so `resolve_probe_queries` runs all of it.
+        let resolved = resolve_probe_queries(None);
+        assert_eq!(resolved.len(), DEFAULT_PROBE_QUERIES.len());
+        assert!(DEFAULT_PROBE_QUERIES.len() <= MAX_PROBE_QUERIES);
+        // A materially larger corpus than the original 12 so p05/p95 are less
+        // noise-dominated; the exact count can grow, but not shrink below this.
+        assert!(DEFAULT_PROBE_QUERIES.len() >= 64);
+    }
+
+    #[test]
+    fn cosine_matches_dot_product_for_normalized_vectors() {
+        // Identical direction → 1.0; orthogonal → 0.0; opposite → -1.0.
+        assert!((cosine(&[1.0, 0.0], &[1.0, 0.0]).unwrap() - 1.0).abs() < 1e-6);
+        assert!(cosine(&[1.0, 0.0], &[0.0, 1.0]).unwrap().abs() < 1e-6);
+        assert!((cosine(&[1.0, 0.0], &[-1.0, 0.0]).unwrap() + 1.0).abs() < 1e-6);
+        // Scale-invariant: cosine ignores magnitude.
+        assert!((cosine(&[3.0, 0.0], &[0.5, 0.0]).unwrap() - 1.0).abs() < 1e-6);
+        // Degenerate inputs are rejected rather than producing NaN.
+        assert!(cosine(&[0.0, 0.0], &[1.0, 0.0]).is_none());
+        assert!(cosine(&[1.0], &[1.0, 0.0]).is_none());
+    }
+
+    #[test]
+    fn sorted_percentile_uses_nearest_rank() {
+        let sorted = [0.90_f32, 0.95, 0.98, 0.99, 1.00];
+        assert_eq!(sorted_percentile_f32(&sorted, 0.0), Some(0.90));
+        assert_eq!(sorted_percentile_f32(&sorted, 0.5), Some(0.98));
+        assert_eq!(sorted_percentile_f32(&sorted, 0.05), Some(0.90));
+        assert_eq!(sorted_percentile_f32(&[], 0.5), None);
+    }
+}

--- a/src-tauri/src/storage/derived_index.rs
+++ b/src-tauri/src/storage/derived_index.rs
@@ -101,6 +101,14 @@ pub struct DerivedEmbeddingRecord {
     pub updated_at: String,
 }
 
+/// One scored subject from an exact-scan semantic retrieval. `score` is cosine
+/// similarity (dot product of L2-normalized vectors).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScoredSubject {
+    pub subject_key: String,
+    pub score: f32,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DerivedIndexJobRecord {
     pub spec: DerivedIndexJobSpec,
@@ -569,6 +577,13 @@ impl StorageState {
             .map_err(|_| "Derived embedding dimensions exceed SQLite range".to_string())?;
         let mut guard = self.get_connection_named("commit_derived_embedding")?;
         let conn = guard.as_mut().ok_or("Database not initialized")?;
+        // Sampled before the write so the resident cache can tell "I was
+        // current and this is my delta" from "I already missed something".
+        let epoch_before = if write.job.index_kind == DerivedIndexKind::SemanticText {
+            Some(read_derived_data_epoch(conn, DerivedIndexKind::SemanticText)?)
+        } else {
+            None
+        };
         let tx = conn
             .transaction()
             .map_err(|error| format!("Failed to start derived embedding transaction: {error}"))?;
@@ -633,6 +648,19 @@ impl StorageState {
         .map_err(|error| format!("Failed to write derived embedding: {error}"))?;
         tx.commit()
             .map_err(|error| format!("Failed to commit derived embedding: {error}"))?;
+        if let Some(epoch_before) = epoch_before {
+            // The triggers in this transaction advanced the epoch. Read it back
+            // on the connection already held and fold the row into the resident
+            // matrix, so continuous dual-write capture does not invalidate the
+            // whole cache every few seconds.
+            let epoch_after = read_derived_data_epoch(conn, DerivedIndexKind::SemanticText)?;
+            self.note_semantic_cache_write(
+                &write.job.subject_key,
+                &write.vector,
+                epoch_before,
+                epoch_after,
+            );
+        }
         Ok(())
     }
 
@@ -679,6 +707,49 @@ impl StorageState {
                 .and_then(|row| decode_embedding_row(index_kind, row))
         })
         .collect()
+    }
+
+    /// Count query-visible embeddings for one index kind. Used as the Rust
+    /// coverage numerator for the M2.5 shadow-query diagnostics.
+    pub fn count_query_visible_embeddings(
+        &self,
+        index_kind: DerivedIndexKind,
+    ) -> Result<u64, String> {
+        let guard = self.get_connection_named("count_query_visible_embeddings")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        let count: i64 = conn
+            .query_row(
+                &visible_embedding_aggregate_sql(),
+                [index_kind.as_str()],
+                |row| row.get(0),
+            )
+            .map_err(|error| format!("Failed to count query-visible embeddings: {error}"))?;
+        u64::try_from(count).map_err(|_| "Invalid query-visible embedding count".to_string())
+    }
+
+    /// Exact-scan cosine top-K over the query-visible `semantic_text`
+    /// embeddings. Stored and query vectors are both L2-normalized, so cosine
+    /// similarity equals the dot product. This is the M2.5 shadow-query read
+    /// path: SQLite remains authoritative and the `.cpdvec` ANN sidecar is not
+    /// consulted until a performance gate requires it. The scan is bounded by
+    /// the ~30-day MiniLM hot layer that M2.4 migrated.
+    ///
+    /// Scoring runs against the resident matrix rather than re-reading the
+    /// store per query — see `semantic_cache` for the freshness and lifetime
+    /// rules. The result is identical to a fresh SQL scan; only the summation
+    /// order of the dot product differs, which can reorder exact ties.
+    pub fn semantic_text_topk(
+        &self,
+        query: &[f32],
+        k: usize,
+    ) -> Result<Vec<ScoredSubject>, String> {
+        if query.is_empty() {
+            return Err("Semantic query vector must not be empty".to_string());
+        }
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+        self.semantic_topk_resident(query, k)
     }
 
     pub fn get_derived_index_job(
@@ -843,6 +914,11 @@ impl StorageState {
         validate_required_text("subject_key", subject_key, MAX_SUBJECT_KEY_BYTES)?;
         let mut guard = self.get_connection_named("delete_derived_index_subject")?;
         let conn = guard.as_mut().ok_or("Database not initialized")?;
+        let epoch_before = if index_kind == DerivedIndexKind::SemanticText {
+            Some(read_derived_data_epoch(conn, DerivedIndexKind::SemanticText)?)
+        } else {
+            None
+        };
         let tx = conn
             .transaction()
             .map_err(|error| format!("Failed to start derived deletion transaction: {error}"))?;
@@ -860,6 +936,10 @@ impl StorageState {
             .map_err(|error| format!("Failed to delete derived index job: {error}"))?;
         tx.commit()
             .map_err(|error| format!("Failed to commit derived deletion: {error}"))?;
+        if let Some(epoch_before) = epoch_before {
+            let epoch_after = read_derived_data_epoch(conn, DerivedIndexKind::SemanticText)?;
+            self.note_semantic_cache_removal(subject_key, epoch_before, epoch_after);
+        }
         Ok(vectors > 0 || jobs > 0)
     }
 
@@ -1384,41 +1464,69 @@ pub(super) fn derived_subject_is_active(
     .map_err(|error| format!("Failed to validate derived index subject: {error}"))
 }
 
+/// The query-visible content epoch. The `derived_index_state` triggers advance
+/// it on every mutation that can change the visible join, which makes it the
+/// authority the resident vector cache checks itself against.
+pub(super) fn read_derived_data_epoch(
+    conn: &rusqlite::Connection,
+    index_kind: DerivedIndexKind,
+) -> Result<i64, String> {
+    conn.query_row(
+        "SELECT COALESCE((SELECT data_epoch FROM derived_index_state WHERE index_kind = ?1), 0)",
+        [index_kind.as_str()],
+        |row| row.get(0),
+    )
+    .map_err(|error| format!("Failed to read derived index epoch: {error}"))
+}
+
+/// Single definition of "query-visible": a completed ledger row whose model
+/// contract and fingerprint still match the stored vector. Every projection
+/// below shares it so the resident cache cannot drift from the SQL readers.
+const VISIBLE_EMBEDDING_SOURCE: &str = r#"
+        FROM derived_embeddings e
+        INNER JOIN derived_index_jobs j
+          ON j.index_kind = e.index_kind AND j.subject_key = e.subject_key
+        WHERE e.index_kind = ?1 AND j.status = 'completed'
+          AND j.model_id = e.model_id
+          AND j.model_revision = e.model_revision
+          AND j.embedding_version = e.embedding_version
+          AND j.source_fingerprint = e.source_fingerprint
+"#;
+
 fn visible_embedding_sql(predicate: &str, suffix: &str) -> String {
     format!(
         r#"
         SELECT e.subject_key, e.dimensions, e.vector_f32, e.model_id,
                e.model_revision, e.embedding_version, e.source_fingerprint,
                e.updated_at
-        FROM derived_embeddings e
-        INNER JOIN derived_index_jobs j
-          ON j.index_kind = e.index_kind AND j.subject_key = e.subject_key
-        WHERE e.index_kind = ?1 AND j.status = 'completed'
-          AND j.model_id = e.model_id
-          AND j.model_revision = e.model_revision
-          AND j.embedding_version = e.embedding_version
-          AND j.source_fingerprint = e.source_fingerprint
+        {VISIBLE_EMBEDDING_SOURCE}
           {predicate} {suffix}
         "#
     )
 }
 
+/// Column-minimal projection for the resident cache load. The scan needs only
+/// an identity and the vector; the four text columns the full projection
+/// carries are decoded and thrown away once per row.
+pub(super) fn visible_embedding_scan_sql() -> String {
+    format!(
+        r#"
+        SELECT e.subject_key, e.dimensions, e.vector_f32
+        {VISIBLE_EMBEDDING_SOURCE}
+        "#
+    )
+}
+
 fn visible_embedding_aggregate_sql() -> String {
-    r#"
+    format!(
+        r#"
         SELECT COUNT(*), MIN(e.dimensions), MAX(e.dimensions),
                MIN(e.model_id), MAX(e.model_id),
                MIN(e.model_revision), MAX(e.model_revision),
                MIN(e.embedding_version), MAX(e.embedding_version)
-        FROM derived_embeddings e
-        INNER JOIN derived_index_jobs j
-          ON j.index_kind = e.index_kind AND j.subject_key = e.subject_key
-        WHERE e.index_kind = ?1 AND j.status = 'completed'
-          AND j.model_id = e.model_id
-          AND j.model_revision = e.model_revision
-          AND j.embedding_version = e.embedding_version
-          AND j.source_fingerprint = e.source_fingerprint
-    "#
-    .to_string()
+        {VISIBLE_EMBEDDING_SOURCE}
+        "#
+    )
 }
 
 fn decode_snapshot_metadata(
@@ -1619,7 +1727,7 @@ pub(super) fn encode_vector(vector: &[f32]) -> Result<Vec<u8>, String> {
     Ok(bytes)
 }
 
-fn decode_vector(bytes: &[u8], dimensions: usize) -> Result<Vec<f32>, String> {
+pub(super) fn decode_vector(bytes: &[u8], dimensions: usize) -> Result<Vec<f32>, String> {
     let expected = dimensions
         .checked_mul(std::mem::size_of::<f32>())
         .ok_or_else(|| "Stored embedding byte length overflow".to_string())?;
@@ -2765,5 +2873,166 @@ mod tests {
         assert!(storage
             .publish_derived_index_generation(DerivedIndexKind::SemanticText)
             .is_err());
+    }
+
+    #[test]
+    fn semantic_text_topk_ranks_visible_rows_by_cosine() {
+        let (_temp, storage) = test_storage();
+        // Three L2-normalized 2-D vectors at increasing angle from the query.
+        commit_vector(&storage, job(DerivedIndexKind::SemanticText, "1"), vec![1.0, 0.0])
+            .unwrap();
+        commit_vector(
+            &storage,
+            job(DerivedIndexKind::SemanticText, "2"),
+            vec![0.8, 0.6],
+        )
+        .unwrap();
+        commit_vector(&storage, job(DerivedIndexKind::SemanticText, "3"), vec![0.0, 1.0])
+            .unwrap();
+
+        // A pending rebuild must hide its row from retrieval.
+        let hidden = job(DerivedIndexKind::SemanticText, "4");
+        ensure_active_subject(&storage, &hidden);
+        storage.upsert_derived_index_job(&hidden).unwrap();
+
+        let query = vec![1.0f32, 0.0];
+        let ranked = storage.semantic_text_topk(&query, 2).unwrap();
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].subject_key, "1");
+        assert_eq!(ranked[1].subject_key, "2");
+        assert!((ranked[0].score - 1.0).abs() < 1e-6);
+        assert!(ranked[0].score >= ranked[1].score);
+
+        // The pending subject (id 4) never appears; only completed rows scan.
+        assert_eq!(storage.semantic_text_topk(&query, 10).unwrap().len(), 3);
+        assert_eq!(
+            storage
+                .count_query_visible_embeddings(DerivedIndexKind::SemanticText)
+                .unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn semantic_text_topk_rejects_empty_query_and_zero_k() {
+        let (_temp, storage) = test_storage();
+        assert!(storage.semantic_text_topk(&[], 5).is_err());
+        assert!(storage.semantic_text_topk(&[1.0, 0.0], 0).unwrap().is_empty());
+    }
+
+    fn data_epoch(storage: &StorageState) -> i64 {
+        let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+        read_derived_data_epoch(guard.as_ref().unwrap(), DerivedIndexKind::SemanticText).unwrap()
+    }
+
+    const VECTOR_BYTES: usize = std::mem::size_of::<f32>();
+
+    #[test]
+    fn resident_cache_absorbs_write_path_updates() {
+        let (_temp, storage) = test_storage();
+        commit_vector(&storage, job(DerivedIndexKind::SemanticText, "1"), vec![1.0, 0.0]).unwrap();
+        let query = vec![1.0f32, 0.0];
+        // The first query loads the matrix; nothing is resident before it.
+        assert_eq!(storage.semantic_vector_cache_bytes(), 0);
+        assert_eq!(storage.semantic_text_topk(&query, 5).unwrap().len(), 1);
+        assert_eq!(storage.semantic_vector_cache_bytes(), 2 * VECTOR_BYTES);
+
+        // A dual-write landing while the cache is resident must be visible to
+        // the next query without a reload.
+        commit_vector(
+            &storage,
+            job(DerivedIndexKind::SemanticText, "2"),
+            vec![0.8, 0.6],
+        )
+        .unwrap();
+        let ranked = storage.semantic_text_topk(&query, 5).unwrap();
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].subject_key, "1");
+        assert_eq!(ranked[1].subject_key, "2");
+        assert_eq!(storage.semantic_vector_cache_bytes(), 4 * VECTOR_BYTES);
+
+        // Re-encoding an existing subject replaces its row in place.
+        commit_vector(
+            &storage,
+            job(DerivedIndexKind::SemanticText, "2"),
+            vec![0.0, 1.0],
+        )
+        .unwrap();
+        let ranked = storage.semantic_text_topk(&[0.0, 1.0], 1).unwrap();
+        assert_eq!(ranked[0].subject_key, "2");
+        assert!((ranked[0].score - 1.0).abs() < 1e-6);
+        assert_eq!(storage.semantic_vector_cache_bytes(), 4 * VECTOR_BYTES);
+    }
+
+    #[test]
+    fn resident_cache_does_not_survive_a_trigger_driven_delete() {
+        let (_temp, storage) = test_storage();
+        for (key, vector) in [("1", vec![1.0, 0.0]), ("2", vec![0.9, 0.1])] {
+            commit_vector(&storage, job(DerivedIndexKind::SemanticText, key), vector).unwrap();
+        }
+        let query = vec![1.0f32, 0.0];
+        assert_eq!(storage.semantic_text_topk(&query, 5).unwrap().len(), 2);
+
+        // Soft-deleting the screenshot removes the embedding from inside
+        // SQLite, which the write-path hooks cannot observe.
+        let before = data_epoch(&storage);
+        {
+            let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+            guard
+                .as_ref()
+                .unwrap()
+                .execute("UPDATE screenshots SET is_deleted = 1 WHERE id = 1", [])
+                .unwrap();
+        }
+        // The nested epoch trigger is what makes the resident matrix notice.
+        // If this ever stops holding, the visibility re-check below is the only
+        // thing standing between the cache and a deleted screenshot.
+        assert!(data_epoch(&storage) > before);
+
+        let ranked = storage.semantic_text_topk(&query, 5).unwrap();
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].subject_key, "2");
+        assert_eq!(storage.semantic_vector_cache_bytes(), 2 * VECTOR_BYTES);
+    }
+
+    #[test]
+    fn resident_cache_drops_a_subject_deleted_through_the_api() {
+        let (_temp, storage) = test_storage();
+        for (key, vector) in [("1", vec![1.0, 0.0]), ("2", vec![0.9, 0.1])] {
+            commit_vector(&storage, job(DerivedIndexKind::SemanticText, key), vector).unwrap();
+        }
+        let query = vec![1.0f32, 0.0];
+        assert_eq!(storage.semantic_text_topk(&query, 5).unwrap().len(), 2);
+
+        assert!(storage
+            .delete_derived_index_subject(DerivedIndexKind::SemanticText, "1")
+            .unwrap());
+        let ranked = storage.semantic_text_topk(&query, 5).unwrap();
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].subject_key, "2");
+        assert_eq!(storage.semantic_vector_cache_bytes(), 2 * VECTOR_BYTES);
+    }
+
+    #[test]
+    fn idle_eviction_releases_the_resident_matrix() {
+        let (_temp, storage) = test_storage();
+        commit_vector(&storage, job(DerivedIndexKind::SemanticText, "1"), vec![1.0, 0.0]).unwrap();
+        // Nothing resident yet, so there is nothing to evict.
+        assert!(!storage.evict_semantic_vector_cache_if_idle(std::time::Duration::ZERO));
+
+        assert_eq!(storage.semantic_text_topk(&[1.0, 0.0], 1).unwrap().len(), 1);
+        assert!(storage.semantic_vector_cache_bytes() > 0);
+        // A live TTL keeps a just-used cache.
+        assert!(!storage
+            .evict_semantic_vector_cache_if_idle(super::super::SEMANTIC_CACHE_IDLE_TTL));
+        assert!(storage.semantic_vector_cache_bytes() > 0);
+
+        assert!(storage.evict_semantic_vector_cache_if_idle(std::time::Duration::ZERO));
+        assert_eq!(storage.semantic_vector_cache_bytes(), 0);
+        assert!(!storage.evict_semantic_vector_cache_if_idle(std::time::Duration::ZERO));
+
+        // The next query reloads transparently.
+        assert_eq!(storage.semantic_text_topk(&[1.0, 0.0], 1).unwrap().len(), 1);
+        assert!(storage.semantic_vector_cache_bytes() > 0);
     }
 }

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -16,6 +16,8 @@ mod process;
 mod schema;
 mod screenshot;
 mod search;
+mod semantic_cache;
+mod semantic_shadow;
 pub mod smart_cluster;
 pub mod task;
 mod types;
@@ -26,6 +28,9 @@ pub use derived_index::*;
 pub use image_io::{read_encrypted_image_as_base64, read_image_as_base64};
 #[allow(unused_imports)]
 pub use minilm_migration::*;
+#[allow(unused_imports)]
+pub use semantic_cache::SEMANTIC_CACHE_IDLE_TTL;
+pub use semantic_shadow::*;
 pub use types::*;
 
 use crate::credential_manager::{
@@ -36,7 +41,7 @@ use rusqlite::{Connection, OpenFlags};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
 /// Error returned by background-only reads of encrypted screenshot content.
 /// `AuthRequired` is intentionally distinct so callers can defer work without
@@ -87,6 +92,12 @@ pub struct StorageState {
     /// Serializes derived-index sidecar publication without participating in
     /// the data-directory/database lock ordering.
     derived_generation_publish_lock: Mutex<()>,
+    /// Resident `semantic_text` vectors for the exact-scan read path. Loaded on
+    /// first query, kept current by the write path, released when idle.
+    /// Lock order: always acquired after the database mutex, never before.
+    semantic_vector_cache: RwLock<Option<semantic_cache::SemanticVectorCache>>,
+    /// Unix millis of the last resident-cache use; 0 when nothing is cached.
+    semantic_cache_used_at: AtomicU64,
 }
 
 struct NamedConnectionGuard<'a> {
@@ -138,6 +149,8 @@ impl StorageState {
             thumbnail_warmup_done: AtomicBool::new(false),
             startup_vacuum_in_progress: AtomicBool::new(false),
             derived_generation_publish_lock: Mutex::new(()),
+            semantic_vector_cache: RwLock::new(None),
+            semantic_cache_used_at: AtomicU64::new(0),
         }
     }
 

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -18,6 +18,9 @@ impl StorageState {
         if *initialized {
             return Ok(());
         }
+        // Belt-and-braces against a stale resident matrix from a previous
+        // connection; `shutdown` already clears it on the normal path.
+        self.reset_semantic_vector_cache();
 
         // Create directories
         let data_dir = self
@@ -103,6 +106,10 @@ impl StorageState {
     /// Shut down storage: close database connection.
     pub fn shutdown(&self) -> Result<(), String> {
         self.lazy_indexer_shutdown.store(true, Ordering::SeqCst);
+        // The resident semantic matrix belongs to the connection being closed.
+        // Its freshness epoch is per-database, so carrying it into whatever
+        // connection comes next can silently score against the old file.
+        self.reset_semantic_vector_cache();
         let mut db_guard = self.db.lock().map_err(|e| format!("lock error: {}", e))?;
         if db_guard.is_some() {
             *db_guard = None;
@@ -542,6 +549,62 @@ impl StorageState {
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
 
+            -- M2.5 shadow-query diagnostics: local, telemetry-free parity and
+            -- latency samples comparing Rust semantic retrieval against the
+            -- authoritative Chroma/Python nl_cluster_query. Only a query hash is
+            -- stored, never the query text. Bounded retention is enforced on insert.
+            CREATE TABLE IF NOT EXISTS semantic_shadow_samples (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                query_hash TEXT NOT NULL,
+                k INTEGER NOT NULL,
+                python_count INTEGER NOT NULL,
+                rust_count INTEGER NOT NULL,
+                shared INTEGER NOT NULL,
+                top1_agreement INTEGER NOT NULL,
+                overlap_k REAL NOT NULL,
+                max_abs_err REAL,
+                mean_abs_err REAL,
+                embed_ms REAL NOT NULL,
+                scan_ms REAL NOT NULL,
+                python_ms REAL NOT NULL,
+                rust_visible INTEGER NOT NULL,
+                chroma_scope INTEGER,
+                only_in_chroma INTEGER NOT NULL DEFAULT 0,
+                in_both_diff_rank INTEGER NOT NULL DEFAULT 0,
+                only_in_rust INTEGER NOT NULL DEFAULT 0,
+                note TEXT
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_semantic_shadow_samples_created
+                ON semantic_shadow_samples(id DESC);
+
+            -- M2.5 doc-encoder parity: one summary row per Rust-vs-Python
+            -- document-encoder probe run. Complements the per-query samples
+            -- above by measuring the OTHER half of the chain: Rust re-encoding
+            -- the migrated documents (build_minilm_task_text + Rust MiniLM) vs
+            -- the stored Python doc vectors. Only aggregate cosine/latency
+            -- stats are stored, never document text. Bounded retention on insert.
+            CREATE TABLE IF NOT EXISTS semantic_doc_encoder_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                doc_sample_count INTEGER NOT NULL,
+                requested INTEGER NOT NULL,
+                source_changed INTEGER NOT NULL DEFAULT 0,
+                missing_text INTEGER NOT NULL DEFAULT 0,
+                cos_min REAL,
+                cos_p05 REAL,
+                cos_p50 REAL,
+                cos_mean REAL,
+                cos_max REAL,
+                cold_start_ms REAL,
+                steady_ms_per_doc REAL,
+                note TEXT
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_semantic_doc_encoder_runs_created
+                ON semantic_doc_encoder_runs(id DESC);
+
             -- Enable foreign key constraints
             PRAGMA foreign_keys = ON;
 
@@ -778,6 +841,36 @@ impl StorageState {
             "INTEGER",
         )?;
         Self::add_column_if_missing(conn, "derived_index_jobs", "lease_token", "TEXT")?;
+
+        // M2.5 shadow-query non-overlap classification (added after the table
+        // first shipped, so upgrade existing diagnostic tables in place).
+        Self::add_column_if_missing(
+            conn,
+            "semantic_shadow_samples",
+            "only_in_chroma",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "semantic_shadow_samples",
+            "in_both_diff_rank",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "semantic_shadow_samples",
+            "only_in_rust",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
+        // Cold-start marker: the first probe sample bears the ONNX session
+        // init cost, so steady-state latency percentiles exclude it and it is
+        // reported separately (added after the table first shipped).
+        Self::add_column_if_missing(
+            conn,
+            "semantic_shadow_samples",
+            "cold_start",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
 
         Self::create_table_if_missing(
             conn,

--- a/src-tauri/src/storage/screenshot.rs
+++ b/src-tauri/src/storage/screenshot.rs
@@ -151,10 +151,28 @@ where
     }
 }
 
+/// Builds the batched OCR prefix query for `placeholder_count` screenshot ids.
+/// `ORDER BY screenshot_id, id` is load-bearing: `id` is the insertion rowid,
+/// and the boxes of one screenshot are inserted in a single transaction in the
+/// exact order the OCR engine emitted them — the same order their texts were
+/// joined into the MiniLM source string. Ordering by geometry instead would
+/// reshuffle boxes that share a visual line (`box_y1` jitters by a few pixels)
+/// and rebuild text that no longer matches the stored vector.
+fn ocr_text_prefix_query(placeholder_count: usize) -> String {
+    let placeholders = vec!["?"; placeholder_count].join(",");
+    format!(
+        "SELECT screenshot_id, text_enc, text_key_encrypted
+         FROM ocr_results
+         WHERE is_deleted = 0 AND screenshot_id IN ({})
+         ORDER BY screenshot_id, id",
+        placeholders
+    )
+}
+
 /// Joins decrypted OCR box texts with single spaces per screenshot, skipping
 /// empty boxes, and stops decrypting a screenshot's remaining boxes once
 /// `min_chars` joined characters are collected. Rows of one screenshot must
-/// arrive contiguously in reading order; the produced string is then a join
+/// arrive contiguously in insertion order; the produced string is then a join
 /// prefix of the full join, so its first `min_chars` characters match the
 /// full text exactly (the MiniLM source contract only consumes that prefix).
 fn assemble_ocr_text_prefixes<E>(
@@ -2092,6 +2110,8 @@ impl StorageState {
     /// decrypt loop skip the long tail of boxes: most screenshots reach the
     /// budget within a few boxes instead of paying one RSA unwrap per box.
     /// Screenshots are decrypted in parallel with per-thread CNG sessions.
+    /// The prefix replays the boxes in insertion order so it reproduces the
+    /// text that was actually embedded; see [`ocr_text_prefix_query`].
     /// Every requested id is present in the result (empty string when the
     /// screenshot has no decryptable text), matching
     /// [`Self::get_ocr_results_by_screenshot_ids_silent`].
@@ -2117,14 +2137,7 @@ impl StorageState {
 
             // Process in chunks to avoid SQLite parameter limit (usually 999)
             for chunk in screenshot_ids.chunks(500) {
-                let placeholders: Vec<&str> = chunk.iter().map(|_| "?").collect();
-                let sql = format!(
-                    "SELECT screenshot_id, text_enc, text_key_encrypted
-                     FROM ocr_results
-                     WHERE is_deleted = 0 AND screenshot_id IN ({})
-                     ORDER BY screenshot_id, box_y1, box_x1",
-                    placeholders.join(",")
-                );
+                let sql = ocr_text_prefix_query(chunk.len());
                 let params: Vec<&dyn rusqlite::ToSql> =
                     chunk.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
 
@@ -2158,7 +2171,9 @@ impl StorageState {
 
         // Phase 2: group boxes per screenshot. Each id lives in exactly one
         // IN chunk and every chunk is ordered by screenshot_id, so the rows
-        // of one screenshot are contiguous and in reading order.
+        // of one screenshot are contiguous and in insertion order — the exact
+        // order the OCR engine emitted the boxes, which is the order their
+        // texts were joined into the embedded MiniLM source string.
         let mut groups: Vec<Vec<(i64, Option<Vec<u8>>, Option<Vec<u8>>)>> = Vec::new();
         for row in raw_rows {
             match groups.last_mut() {
@@ -3293,6 +3308,52 @@ mod ocr_lifecycle_tests {
             ),
             Err(BackgroundReadError::AuthRequired)
         ));
+    }
+
+    #[test]
+    fn ocr_text_prefix_query_replays_insertion_order() {
+        let connection = Connection::open_in_memory().expect("in-memory database");
+        connection
+            .execute_batch(
+                "CREATE TABLE ocr_results (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    screenshot_id INTEGER NOT NULL,
+                    text_enc BLOB,
+                    text_key_encrypted BLOB,
+                    box_x1 REAL, box_y1 REAL,
+                    is_deleted INTEGER NOT NULL DEFAULT 0
+                 );
+                 -- Rows are listed in OCR engine order, which is the order the
+                 -- boxes were embedded. Geometry disagrees on purpose: the last
+                 -- box of screenshot 7 sits highest on screen, and the first two
+                 -- share a visual line whose box_y1 jitters by one pixel.
+                 INSERT INTO ocr_results
+                    (screenshot_id, text_enc, text_key_encrypted, box_x1, box_y1, is_deleted)
+                 VALUES
+                    (7, X'01', X'00', 900.0, 41.0, 0),
+                    (7, X'02', X'00', 120.0, 40.0, 0),
+                    (7, X'03', X'00', 300.0, 10.0, 0),
+                    (7, X'04', X'00',  10.0,  9.0, 1),
+                    (8, X'05', X'00',  50.0, 99.0, 0);",
+            )
+            .expect("OCR ordering fixture");
+
+        let sql = ocr_text_prefix_query(2);
+        let mut stmt = connection.prepare(&sql).expect("prefix query");
+        let rows: Vec<(i64, u8)> = stmt
+            .query_map(params![7i64, 8i64], |row| {
+                let screenshot_id: i64 = row.get(0)?;
+                let text_enc: Vec<u8> = row.get(1)?;
+                Ok((screenshot_id, text_enc[0]))
+            })
+            .expect("execute prefix query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("read prefix rows");
+
+        // Insertion order — ordering by `box_y1, box_x1` would hand back 3, 2, 1
+        // for screenshot 7 and rebuild text the vector was never encoded from.
+        // The soft-deleted box 4 stays out regardless of order.
+        assert_eq!(rows, vec![(7, 1u8), (7, 2u8), (7, 3u8), (8, 5u8)]);
     }
 
     #[test]

--- a/src-tauri/src/storage/semantic_cache.rs
+++ b/src-tauri/src/storage/semantic_cache.rs
@@ -1,0 +1,555 @@
+//! Resident vector cache for the `semantic_text` derived index.
+//!
+//! The exact-scan read path re-materialized every vector out of the encrypted
+//! store on each query. Measured on a ~9.5k-row hot layer that costs ~425 ms
+//! per query, of which the dot products themselves are under a millisecond —
+//! the rest is b-tree traversal, page decryption and per-row allocation. The
+//! whole matrix is ~14 MiB, so it is held resident while the user is querying
+//! and released once they stop: NL cluster search is an explicit submit-and-read
+//! interaction, not a keystroke-driven one, so most of the time nobody is
+//! searching and the memory is pure waste.
+//!
+//! Freshness rests on `derived_index_state.data_epoch`: every trigger that can
+//! change the query-visible set advances it (see `schema.rs`). The write path
+//! updates resident rows in place and records the new epoch, so a capture that
+//! dual-writes a vector every few seconds does not force a reload. Anything the
+//! write path cannot observe — notably the screenshot soft-delete trigger, which
+//! deletes embedding rows from inside SQLite — surfaces as an epoch mismatch and
+//! reloads.
+//!
+//! Lock order is always the database mutex before the cache lock. Scoring never
+//! touches SQLite, and the cache guard is dropped before the visibility
+//! re-check takes the database mutex, which is not reentrant.
+
+use super::derived_index::{
+    decode_vector, read_derived_data_epoch, visible_embedding_scan_sql, DerivedIndexKind,
+    ScoredSubject,
+};
+use super::StorageState;
+use rusqlite::params;
+use std::cmp::Ordering as CmpOrdering;
+use std::collections::HashMap;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// Candidates scored past `k`, so a subject deleted in the window between the
+/// epoch read and the scan can be dropped without a second retrieval pass.
+const VISIBILITY_MARGIN: usize = 16;
+
+/// Idle window after which the resident matrix is released. One NL cluster
+/// session is a burst of a few queries; five minutes outlives the burst without
+/// holding the memory for the hours until the next one.
+pub const SEMANTIC_CACHE_IDLE_TTL: Duration = Duration::from_secs(300);
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1000.0
+}
+
+/// Four independent accumulators: f32 addition is not associative, so a single
+/// accumulator forces the compiler to keep the loop scalar.
+fn dot_product_wide(query: &[f32], row: &[f32]) -> f32 {
+    let mut acc = [0.0f32; 4];
+    let mut query_chunks = query.chunks_exact(4);
+    let mut row_chunks = row.chunks_exact(4);
+    for (q, r) in query_chunks.by_ref().zip(row_chunks.by_ref()) {
+        acc[0] += q[0] * r[0];
+        acc[1] += q[1] * r[1];
+        acc[2] += q[2] * r[2];
+        acc[3] += q[3] * r[3];
+    }
+    let mut total = acc[0] + acc[1] + acc[2] + acc[3];
+    for (q, r) in query_chunks
+        .remainder()
+        .iter()
+        .zip(row_chunks.remainder().iter())
+    {
+        total += q * r;
+    }
+    total
+}
+
+/// Row-major matrix of query-visible vectors plus the epoch it reflects.
+pub(super) struct SemanticVectorCache {
+    dimensions: usize,
+    matrix: Vec<f32>,
+    subjects: Vec<String>,
+    positions: HashMap<String, usize>,
+    epoch: i64,
+}
+
+impl SemanticVectorCache {
+    fn new(epoch: i64) -> Self {
+        Self {
+            dimensions: 0,
+            matrix: Vec::new(),
+            subjects: Vec::new(),
+            positions: HashMap::new(),
+            epoch,
+        }
+    }
+
+    pub(super) fn rows(&self) -> usize {
+        self.subjects.len()
+    }
+
+    pub(super) fn resident_bytes(&self) -> usize {
+        self.matrix.len() * std::mem::size_of::<f32>()
+    }
+
+    /// Appends a loaded row. Returns false when the row does not match the
+    /// cache's dimension contract, which the caller reports and skips.
+    fn push(&mut self, subject_key: String, vector: Vec<f32>) -> bool {
+        if self.subjects.is_empty() {
+            self.dimensions = vector.len();
+        }
+        if vector.len() != self.dimensions || vector.is_empty() {
+            return false;
+        }
+        let index = self.subjects.len();
+        self.matrix.extend_from_slice(&vector);
+        self.positions.insert(subject_key.clone(), index);
+        self.subjects.push(subject_key);
+        true
+    }
+
+    /// In-place update from the write path. Returns false when the vector does
+    /// not fit the resident contract, which invalidates the cache instead.
+    fn upsert(&mut self, subject_key: &str, vector: &[f32]) -> bool {
+        if self.subjects.is_empty() && self.dimensions == 0 {
+            self.dimensions = vector.len();
+        }
+        if vector.is_empty() || vector.len() != self.dimensions {
+            return false;
+        }
+        match self.positions.get(subject_key).copied() {
+            Some(index) => {
+                let start = index * self.dimensions;
+                self.matrix[start..start + self.dimensions].copy_from_slice(vector);
+            }
+            None => {
+                let index = self.subjects.len();
+                self.matrix.extend_from_slice(vector);
+                self.positions.insert(subject_key.to_string(), index);
+                self.subjects.push(subject_key.to_string());
+            }
+        }
+        true
+    }
+
+    /// Removes a subject by moving the final row into the hole, keeping the
+    /// matrix contiguous for scanning.
+    fn remove(&mut self, subject_key: &str) {
+        let Some(index) = self.positions.remove(subject_key) else {
+            return;
+        };
+        let last = self.subjects.len() - 1;
+        if index != last {
+            let dimensions = self.dimensions;
+            let (head, tail) = self.matrix.split_at_mut(last * dimensions);
+            head[index * dimensions..(index + 1) * dimensions].copy_from_slice(&tail[..dimensions]);
+            let moved = self.subjects[last].clone();
+            self.positions.insert(moved, index);
+        }
+        self.subjects.swap_remove(index);
+        self.matrix.truncate(last * self.dimensions);
+    }
+
+    /// Scores every resident row and returns the best `want`, highest first.
+    fn top_candidates(&self, query: &[f32], want: usize) -> Vec<ScoredSubject> {
+        if want == 0 || self.subjects.is_empty() || query.len() != self.dimensions {
+            return Vec::new();
+        }
+        let mut scored: Vec<(f32, u32)> = self
+            .matrix
+            .chunks_exact(self.dimensions)
+            .enumerate()
+            .map(|(index, row)| (dot_product_wide(query, row), index as u32))
+            .collect();
+        let descending = |a: &(f32, u32), b: &(f32, u32)| {
+            b.0.partial_cmp(&a.0).unwrap_or(CmpOrdering::Equal)
+        };
+        let take = want.min(scored.len());
+        // Only the surviving candidates need ordering; the rest stay unsorted.
+        scored.select_nth_unstable_by(take - 1, descending);
+        scored.truncate(take);
+        scored.sort_unstable_by(descending);
+        scored
+            .into_iter()
+            .map(|(score, index)| ScoredSubject {
+                subject_key: self.subjects[index as usize].clone(),
+                score,
+            })
+            .collect()
+    }
+}
+
+impl StorageState {
+    /// Cosine top-K over the resident matrix, loading it on first use.
+    pub(super) fn semantic_topk_resident(
+        &self,
+        query: &[f32],
+        k: usize,
+    ) -> Result<Vec<ScoredSubject>, String> {
+        let started = Instant::now();
+        let current_epoch = {
+            let guard = self.get_connection_named("semantic_cache_epoch")?;
+            let conn = guard.as_ref().ok_or("Database not initialized")?;
+            read_derived_data_epoch(conn, DerivedIndexKind::SemanticText)?
+        };
+        let epoch_ms = elapsed_ms(started);
+
+        let want = k.saturating_add(VISIBILITY_MARGIN);
+        let mut candidates = {
+            let guard = self
+                .semantic_vector_cache
+                .read()
+                .unwrap_or_else(|error| error.into_inner());
+            match guard.as_ref() {
+                Some(cache) if cache.epoch == current_epoch => Some(cache.top_candidates(query, want)),
+                _ => None,
+            }
+        };
+
+        let reloaded = candidates.is_none();
+        if candidates.is_none() {
+            let loaded = self.load_semantic_vector_cache()?;
+            let top = loaded.top_candidates(query, want);
+            let mut guard = self
+                .semantic_vector_cache
+                .write()
+                .unwrap_or_else(|error| error.into_inner());
+            *guard = Some(loaded);
+            candidates = Some(top);
+        }
+        self.semantic_cache_used_at.store(now_ms(), Ordering::Relaxed);
+        let score_ms = elapsed_ms(started) - epoch_ms;
+
+        let candidates = candidates.unwrap_or_default();
+        if candidates.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // The epoch check already covers deletions, because the soft-delete
+        // trigger's `DELETE FROM derived_embeddings` fires the epoch trigger in
+        // turn. Re-checking the survivors anyway keeps "never surface a deleted
+        // screenshot" from depending on nested-trigger semantics. The statement
+        // is cached: re-parsing it per candidate dominated the whole query in an
+        // unoptimized dev build, where the bundled SQLCipher is also built -O0.
+        let candidate_count = candidates.len();
+        let visible = {
+            let guard = self.get_connection_named("semantic_cache_visibility")?;
+            let conn = guard.as_ref().ok_or("Database not initialized")?;
+            let mut statement = conn
+                .prepare_cached(
+                    "SELECT EXISTS(SELECT 1 FROM screenshots WHERE id = ?1 AND is_deleted = 0)",
+                )
+                .map_err(|error| format!("Failed to prepare visibility re-check: {error}"))?;
+            let mut visible = Vec::with_capacity(k);
+            for candidate in candidates {
+                if visible.len() == k {
+                    break;
+                }
+                let screenshot_id = candidate.subject_key.parse::<i64>().map_err(|error| {
+                    format!(
+                        "Invalid semantic derived subject key '{}': {error}",
+                        candidate.subject_key
+                    )
+                })?;
+                let active: bool = statement
+                    .query_row([screenshot_id], |row| row.get(0))
+                    .map_err(|error| format!("Failed to re-check derived subject: {error}"))?;
+                if active {
+                    visible.push(candidate);
+                }
+            }
+            visible
+        };
+        tracing::debug!(
+            "[SEMANTIC] topk k={k} epoch={epoch_ms:.1}ms score={score_ms:.1}ms visibility={:.1}ms reloaded={reloaded} candidates={candidate_count} returned={}",
+            elapsed_ms(started) - epoch_ms - score_ms,
+            visible.len()
+        );
+        Ok(visible)
+    }
+
+    /// Reads the epoch and every visible row under one connection guard, so the
+    /// matrix and the epoch it is tagged with cannot straddle a write.
+    fn load_semantic_vector_cache(&self) -> Result<SemanticVectorCache, String> {
+        let guard = self.get_connection_named("load_semantic_vector_cache")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        let epoch = read_derived_data_epoch(conn, DerivedIndexKind::SemanticText)?;
+        let mut cache = SemanticVectorCache::new(epoch);
+        let mut statement = conn
+            .prepare(&visible_embedding_scan_sql())
+            .map_err(|error| format!("Failed to prepare resident vector scan: {error}"))?;
+        let mut rows = statement
+            .query(params![DerivedIndexKind::SemanticText.as_str()])
+            .map_err(|error| format!("Failed to scan resident vectors: {error}"))?;
+        let mut skipped = 0u64;
+        while let Some(row) = rows
+            .next()
+            .map_err(|error| format!("Failed to read resident vector row: {error}"))?
+        {
+            let subject_key: String = row
+                .get(0)
+                .map_err(|error| format!("Failed to read resident subject key: {error}"))?;
+            let dimensions: i64 = row
+                .get(1)
+                .map_err(|error| format!("Failed to read resident dimensions: {error}"))?;
+            let blob: Vec<u8> = row
+                .get(2)
+                .map_err(|error| format!("Failed to read resident vector blob: {error}"))?;
+            let dimensions = usize::try_from(dimensions)
+                .map_err(|_| "Invalid resident vector dimensions".to_string())?;
+            let vector = decode_vector(&blob, dimensions)?;
+            if !cache.push(subject_key, vector) {
+                skipped += 1;
+            }
+        }
+        if skipped > 0 {
+            // A mixed-dimension store cannot happen under one model contract;
+            // report it rather than silently ranking a partial corpus.
+            tracing::warn!(
+                "[SEMANTIC] resident cache skipped {skipped} row(s) with a foreign dimension"
+            );
+        }
+        tracing::debug!(
+            "[SEMANTIC] resident cache loaded {} rows ({} KiB) at epoch {}",
+            cache.rows(),
+            cache.resident_bytes() / 1024,
+            cache.epoch
+        );
+        Ok(cache)
+    }
+
+    /// Write-path hook: keeps the resident rows current so continuous capture
+    /// does not invalidate the whole matrix every few seconds. Called with the
+    /// database mutex held; must never re-enter a storage method that locks it.
+    ///
+    /// The delta is applied only when the cache was current *before* this write
+    /// (`epoch_before`). A cache that already missed an unobservable mutation —
+    /// the screenshot soft-delete trigger, say — must not be stamped with the
+    /// new epoch, or it would claim freshness while still holding a row SQLite
+    /// has dropped.
+    pub(super) fn note_semantic_cache_write(
+        &self,
+        subject_key: &str,
+        vector: &[f32],
+        epoch_before: i64,
+        epoch_after: i64,
+    ) {
+        let mut guard = self
+            .semantic_vector_cache
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        let Some(cache) = guard.as_mut() else {
+            return;
+        };
+        if cache.epoch != epoch_before {
+            // Already behind: let the next query reload rather than stack a
+            // delta on a matrix of unknown content.
+            return;
+        }
+        if epoch_after == epoch_before {
+            // The visible-set triggers did not fire, so this write did not
+            // become query-visible. Adding it would put a row in the matrix
+            // that a SQL reader would not return.
+            return;
+        }
+        if cache.upsert(subject_key, vector) {
+            cache.epoch = epoch_after;
+        } else {
+            // Foreign dimension: drop the cache rather than serve a matrix that
+            // no longer matches the store.
+            *guard = None;
+        }
+    }
+
+    /// Write-path hook for explicit subject deletion. Same staleness rule as
+    /// [`Self::note_semantic_cache_write`].
+    pub(super) fn note_semantic_cache_removal(
+        &self,
+        subject_key: &str,
+        epoch_before: i64,
+        epoch_after: i64,
+    ) {
+        let mut guard = self
+            .semantic_vector_cache
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        let Some(cache) = guard.as_mut() else {
+            return;
+        };
+        if cache.epoch != epoch_before || epoch_after == epoch_before {
+            return;
+        }
+        cache.remove(subject_key);
+        cache.epoch = epoch_after;
+    }
+
+    /// Drops the resident matrix unconditionally.
+    ///
+    /// Required whenever the underlying database connection is swapped: the
+    /// freshness check compares `cache.epoch` against `derived_index_state`'s
+    /// counter, and that counter is per-database. After a backup import points
+    /// this same `StorageState` at a different file, an unreset cache whose
+    /// epoch happens to match the new database's counter would score queries
+    /// against the *old* database's vectors — the id-based visibility re-check
+    /// cannot catch it, because ids that exist in both files pass.
+    pub(super) fn reset_semantic_vector_cache(&self) {
+        *self
+            .semantic_vector_cache
+            .write()
+            .unwrap_or_else(|error| error.into_inner()) = None;
+        self.semantic_cache_used_at.store(0, Ordering::Relaxed);
+    }
+
+    /// Releases the matrix when no query has touched it for `ttl`.
+    pub fn evict_semantic_vector_cache_if_idle(&self, ttl: Duration) -> bool {
+        let used_at = self.semantic_cache_used_at.load(Ordering::Relaxed);
+        if used_at == 0 {
+            return false;
+        }
+        if now_ms().saturating_sub(used_at) < ttl.as_millis() as u64 {
+            return false;
+        }
+        let mut guard = self
+            .semantic_vector_cache
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        let Some(cache) = guard.as_ref() else {
+            self.semantic_cache_used_at.store(0, Ordering::Relaxed);
+            return false;
+        };
+        tracing::debug!(
+            "[SEMANTIC] releasing {} KiB resident vector cache after {:?} idle",
+            cache.resident_bytes() / 1024,
+            ttl
+        );
+        *guard = None;
+        self.semantic_cache_used_at.store(0, Ordering::Relaxed);
+        true
+    }
+
+    /// Diagnostics: resident vector bytes, zero when nothing is cached.
+    pub fn semantic_vector_cache_bytes(&self) -> usize {
+        self.semantic_vector_cache
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .as_ref()
+            .map(SemanticVectorCache::resident_bytes)
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cache_of(rows: &[(&str, Vec<f32>)]) -> SemanticVectorCache {
+        let mut cache = SemanticVectorCache::new(1);
+        for (key, vector) in rows {
+            assert!(cache.push((*key).to_string(), vector.clone()));
+        }
+        cache
+    }
+
+    #[test]
+    fn wide_dot_product_matches_the_scalar_definition() {
+        let query: Vec<f32> = (0..384).map(|i| (i as f32) * 0.001).collect();
+        let row: Vec<f32> = (0..384).map(|i| ((384 - i) as f32) * 0.002).collect();
+        let scalar: f32 = query.iter().zip(&row).map(|(a, b)| a * b).sum();
+        let wide = dot_product_wide(&query, &row);
+        assert!((scalar - wide).abs() < 1e-3, "scalar {scalar} vs wide {wide}");
+    }
+
+    #[test]
+    fn wide_dot_product_handles_a_non_multiple_of_four() {
+        let query = vec![1.0f32, 2.0, 3.0, 4.0, 5.0];
+        let row = vec![2.0f32, 2.0, 2.0, 2.0, 2.0];
+        assert!((dot_product_wide(&query, &row) - 30.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn top_candidates_rank_by_descending_score() {
+        let cache = cache_of(&[
+            ("1", vec![1.0, 0.0]),
+            ("2", vec![0.8, 0.6]),
+            ("3", vec![0.0, 1.0]),
+        ]);
+        let ranked = cache.top_candidates(&[1.0, 0.0], 2);
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].subject_key, "1");
+        assert_eq!(ranked[1].subject_key, "2");
+        assert!(ranked[0].score >= ranked[1].score);
+    }
+
+    #[test]
+    fn top_candidates_reject_a_foreign_query_dimension() {
+        let cache = cache_of(&[("1", vec![1.0, 0.0])]);
+        assert!(cache.top_candidates(&[1.0, 0.0, 0.0], 5).is_empty());
+    }
+
+    #[test]
+    fn upsert_replaces_in_place_and_appends_new_subjects() {
+        let mut cache = cache_of(&[("1", vec![1.0, 0.0])]);
+        assert!(cache.upsert("1", &[0.0, 1.0]));
+        assert!(cache.upsert("2", &[1.0, 0.0]));
+        assert_eq!(cache.rows(), 2);
+        let ranked = cache.top_candidates(&[0.0, 1.0], 1);
+        assert_eq!(ranked[0].subject_key, "1");
+        assert!((ranked[0].score - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn remove_keeps_the_matrix_and_positions_consistent() {
+        let mut cache = cache_of(&[
+            ("1", vec![1.0, 0.0]),
+            ("2", vec![0.0, 1.0]),
+            ("3", vec![0.6, 0.8]),
+        ]);
+        cache.remove("1");
+        assert_eq!(cache.rows(), 2);
+        assert_eq!(cache.matrix.len(), 4);
+        // "3" was moved into the hole; its vector must still score as itself.
+        let ranked = cache.top_candidates(&[0.6, 0.8], 2);
+        assert_eq!(ranked[0].subject_key, "3");
+        assert!((ranked[0].score - 1.0).abs() < 1e-6);
+        cache.remove("missing");
+        assert_eq!(cache.rows(), 2);
+    }
+
+    #[test]
+    #[ignore = "measurement, not an assertion; run with --release"]
+    fn bench_scoring_a_hot_layer_sized_matrix() {
+        let (rows, dimensions) = (9558usize, 384usize);
+        let mut cache = SemanticVectorCache::new(1);
+        for row in 0..rows {
+            let vector: Vec<f32> = (0..dimensions)
+                .map(|i| (((row * 31 + i * 7) % 1000) as f32) / 1000.0)
+                .collect();
+            assert!(cache.push(row.to_string(), vector));
+        }
+        let query: Vec<f32> = (0..dimensions)
+            .map(|i| ((i % 997) as f32) / 997.0)
+            .collect();
+        let _ = cache.top_candidates(&query, 26);
+        let runs = 20;
+        let started = std::time::Instant::now();
+        for _ in 0..runs {
+            assert_eq!(cache.top_candidates(&query, 26).len(), 26);
+        }
+        let per_query = started.elapsed().as_secs_f64() * 1000.0 / runs as f64;
+        println!(
+            "top_candidates over {rows}x{dimensions}: {per_query:.3} ms/query, {} KiB resident",
+            cache.resident_bytes() / 1024
+        );
+    }
+}

--- a/src-tauri/src/storage/semantic_shadow.rs
+++ b/src-tauri/src/storage/semantic_shadow.rs
@@ -1,0 +1,656 @@
+//! First-party persistence for MiniLM Rust-vs-Chroma shadow-query samples.
+//!
+//! M2.5 step 3 records local, telemetry-free parity and latency samples so the
+//! shadow phase can prove the release gate (top-10 overlap, top-1 stability,
+//! cosine error, latency budget) before any cutover. Only a query hash is
+//! persisted; the query text never touches this table.
+
+use super::StorageState;
+use rusqlite::{params, OptionalExtension};
+use serde::Serialize;
+
+/// One shadow comparison between the authoritative Chroma/Python retrieval and
+/// the Rust exact-scan retrieval for the same query.
+#[derive(Debug, Clone)]
+pub struct SemanticShadowSample {
+    pub query_hash: String,
+    pub k: u32,
+    pub python_count: u32,
+    pub rust_count: u32,
+    pub shared: u32,
+    pub top1_agreement: bool,
+    pub overlap_k: f32,
+    pub max_abs_err: Option<f32>,
+    pub mean_abs_err: Option<f32>,
+    pub embed_ms: f64,
+    pub scan_ms: f64,
+    pub python_ms: f64,
+    pub rust_visible: u64,
+    pub chroma_scope: Option<u64>,
+    /// Python-top ids absent from the Rust store entirely (Rust under-covers).
+    pub only_in_chroma: u32,
+    /// Python-top ids present in the Rust store but ranked outside Rust top-K.
+    pub in_both_diff_rank: u32,
+    /// Rust-top ids not present in the Python top-K.
+    pub only_in_rust: u32,
+    /// True for the first probe sample, which bears the ONNX session-init cost.
+    /// Steady-state latency percentiles exclude cold-start samples.
+    pub cold_start: bool,
+    pub note: Option<String>,
+}
+
+/// Aggregated view over the most recent shadow samples for the diagnostics UI.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct SemanticShadowReport {
+    pub window: u32,
+    /// Comparable samples: the N behind every parity and latency statistic
+    /// below. Rows carrying a `note` are excluded — see `note_sample_count`.
+    pub sample_count: u64,
+    /// Rows in the window that could not be compared (embed failure, Python
+    /// failure, empty Chroma ranking, incomplete classification). They store
+    /// `overlap_k = 0` / `top1 = false` as filler, not as a measurement, so
+    /// counting them would let one run against an unavailable index bury the
+    /// gate numbers for hundreds of subsequent real samples.
+    pub note_sample_count: u64,
+    /// Total rows examined in the window (`sample_count + note_sample_count`).
+    pub window_row_count: u64,
+    /// Samples that count toward steady-state latency (cold-start excluded).
+    pub steady_sample_count: u64,
+    /// What this report actually measures. The Rust path is bi-encoder
+    /// retrieval only; the reranker is disabled, so these numbers do NOT
+    /// represent the final online ranking (reranker parity is M2.5 step 5).
+    pub retrieval_scope: String,
+    pub top1_agreement_rate: Option<f32>,
+    pub overlap_mean: Option<f32>,
+    pub overlap_p50: Option<f32>,
+    pub overlap_p05: Option<f32>,
+    pub max_abs_err: Option<f32>,
+    pub mean_abs_err: Option<f32>,
+    pub python_ms_p50: Option<f64>,
+    pub python_ms_p95: Option<f64>,
+    /// Total Rust latency (embed + scan), steady-state only.
+    pub rust_ms_p50: Option<f64>,
+    pub rust_ms_p95: Option<f64>,
+    /// Rust latency split so the O(N) exact scan is visible apart from encode.
+    pub rust_embed_ms_p50: Option<f64>,
+    pub rust_embed_ms_p95: Option<f64>,
+    pub rust_scan_ms_p50: Option<f64>,
+    pub rust_scan_ms_p95: Option<f64>,
+    /// Latest cold-start sample's total Rust latency (embed + scan). This is the
+    /// first-query cost including ONNX session init; it is excluded from the
+    /// percentiles above so a single cold outlier cannot inflate p95.
+    pub rust_cold_start_ms: Option<f64>,
+    pub rust_visible_latest: Option<u64>,
+    pub chroma_scope_latest: Option<u64>,
+    /// Summed over the window: the decisive breakdown of top-K disagreement.
+    /// A high `only_in_chroma_total` means Rust is missing documents Chroma
+    /// serves (real divergence); disagreement concentrated in
+    /// `in_both_diff_rank_total` is ranking/approximation, not missing data.
+    pub only_in_chroma_total: u64,
+    pub in_both_diff_rank_total: u64,
+    pub only_in_rust_total: u64,
+    pub last_note: Option<String>,
+    /// Latest document-encoder parity run: Rust re-encoding the migrated docs
+    /// vs the stored Python doc vectors. `None` until a doc probe has run.
+    pub doc_encoder: Option<SemanticDocEncoderRun>,
+}
+
+/// Summary of one document-encoder parity run. Measures the half of the chain
+/// the per-query samples cannot: `rust_encode(build_minilm_task_text(...))`
+/// against the stored Python document vector, over a sample of migrated docs.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct SemanticDocEncoderRun {
+    pub created_at: String,
+    /// Documents actually re-encoded and compared.
+    pub doc_sample_count: u64,
+    /// Documents requested for the sample (before skips).
+    pub requested: u64,
+    /// Skipped: current SQLite text no longer matches the stored fingerprint
+    /// (OCR/title changed since migration), so the stored vector and a fresh
+    /// Rust encode would not describe the same text.
+    pub source_changed: u64,
+    /// Skipped: no active screenshot / empty reconstructed text.
+    pub missing_text: u64,
+    pub cos_min: Option<f32>,
+    pub cos_p05: Option<f32>,
+    pub cos_p50: Option<f32>,
+    pub cos_mean: Option<f32>,
+    pub cos_max: Option<f32>,
+    /// Worst-case cosine distance (1 - cos_min): the document-side analogue of
+    /// the query-side `max_abs_err`.
+    pub max_abs_err: Option<f32>,
+    /// First (cold) encode batch total ms, including ONNX session init.
+    pub cold_start_ms: Option<f64>,
+    /// Amortized steady-state per-document encode ms (cold batch excluded).
+    pub steady_ms_per_doc: Option<f64>,
+    /// Free-text note, e.g. why a run compared zero documents.
+    pub note: Option<String>,
+}
+
+/// Cap on retained samples so the diagnostic table cannot grow without bound.
+const MAX_RETAINED_SAMPLES: u32 = 5_000;
+
+/// Cap on retained document-encoder run summaries.
+const MAX_RETAINED_DOC_RUNS: i64 = 100;
+
+/// Fixed label describing what the shadow report measures. Surfaced verbatim so
+/// the UI cannot present bi-encoder retrieval parity as end-to-end parity.
+pub const RETRIEVAL_SCOPE_BI_ENCODER: &str = "bi_encoder_only";
+
+impl StorageState {
+    pub fn record_semantic_shadow_sample(
+        &self,
+        sample: &SemanticShadowSample,
+    ) -> Result<(), String> {
+        let guard = self.get_connection_named("record_semantic_shadow_sample")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        conn.execute(
+            r#"
+            INSERT INTO semantic_shadow_samples (
+                query_hash, k, python_count, rust_count, shared, top1_agreement,
+                overlap_k, max_abs_err, mean_abs_err, embed_ms, scan_ms, python_ms,
+                rust_visible, chroma_scope, only_in_chroma, in_both_diff_rank,
+                only_in_rust, cold_start, note
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
+            "#,
+            params![
+                sample.query_hash,
+                sample.k,
+                sample.python_count,
+                sample.rust_count,
+                sample.shared,
+                i64::from(sample.top1_agreement),
+                f64::from(sample.overlap_k),
+                sample.max_abs_err.map(f64::from),
+                sample.mean_abs_err.map(f64::from),
+                sample.embed_ms,
+                sample.scan_ms,
+                sample.python_ms,
+                i64::try_from(sample.rust_visible).unwrap_or(i64::MAX),
+                sample
+                    .chroma_scope
+                    .map(|value| i64::try_from(value).unwrap_or(i64::MAX)),
+                sample.only_in_chroma,
+                sample.in_both_diff_rank,
+                sample.only_in_rust,
+                i64::from(sample.cold_start),
+                sample.note,
+            ],
+        )
+        .map_err(|error| format!("Failed to record semantic shadow sample: {error}"))?;
+        // Bounded retention: keep only the most recent rows.
+        conn.execute(
+            r#"
+            DELETE FROM semantic_shadow_samples
+            WHERE id NOT IN (
+                SELECT id FROM semantic_shadow_samples ORDER BY id DESC LIMIT ?1
+            )
+            "#,
+            params![MAX_RETAINED_SAMPLES],
+        )
+        .ok();
+        Ok(())
+    }
+
+    pub fn get_semantic_shadow_report(
+        &self,
+        window: u32,
+    ) -> Result<SemanticShadowReport, String> {
+        let window = window.clamp(1, MAX_RETAINED_SAMPLES);
+        // Collect the sample rows and RELEASE the connection lock (drop `guard`)
+        // before fetching the doc-encoder run, which re-acquires the same
+        // non-reentrant DB mutex. Holding the guard across that call would
+        // self-deadlock the storage lock — and, transitively, every reverse-IPC
+        // storage request waiting on it (the watchdog then kills the pipe).
+        let rows: Vec<SampleRow> = {
+            let guard = self.get_connection_named("get_semantic_shadow_report")?;
+            let conn = guard.as_ref().ok_or("Database not initialized")?;
+            let mut statement = conn
+                .prepare(
+                    r#"
+                    SELECT top1_agreement, overlap_k, max_abs_err, mean_abs_err,
+                           embed_ms, scan_ms, python_ms, rust_visible, chroma_scope,
+                           only_in_chroma, in_both_diff_rank, only_in_rust, cold_start,
+                           note
+                    FROM semantic_shadow_samples
+                    ORDER BY id DESC
+                    LIMIT ?1
+                    "#,
+                )
+                .map_err(|error| format!("Failed to prepare shadow report query: {error}"))?;
+            let collected = statement
+                .query_map(params![window], |row| {
+                    Ok(SampleRow {
+                        top1_agreement: row.get::<_, i64>(0)? != 0,
+                        overlap_k: row.get::<_, f64>(1)?,
+                        max_abs_err: row.get::<_, Option<f64>>(2)?,
+                        mean_abs_err: row.get::<_, Option<f64>>(3)?,
+                        embed_ms: row.get::<_, f64>(4)?,
+                        scan_ms: row.get::<_, f64>(5)?,
+                        python_ms: row.get::<_, f64>(6)?,
+                        rust_visible: row.get::<_, i64>(7)?,
+                        chroma_scope: row.get::<_, Option<i64>>(8)?,
+                        only_in_chroma: row.get::<_, i64>(9)?,
+                        in_both_diff_rank: row.get::<_, i64>(10)?,
+                        only_in_rust: row.get::<_, i64>(11)?,
+                        cold_start: row.get::<_, i64>(12)? != 0,
+                        note: row.get::<_, Option<String>>(13)?,
+                    })
+                })
+                .map_err(|error| format!("Failed to query shadow samples: {error}"))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| format!("Failed to read shadow sample: {error}"))?;
+            // Bind before the block ends so the borrowing `MappedRows` temporary
+            // is dropped before `statement`/`conn`/`guard` (drop-order borrow).
+            collected
+        };
+        // Lock released above; safe to re-acquire it here.
+        let doc_encoder = self.get_latest_doc_encoder_run()?;
+        Ok(aggregate_report(window, rows, doc_encoder))
+    }
+
+    /// Persist one document-encoder parity run summary, enforcing bounded
+    /// retention so the diagnostic table cannot grow without bound.
+    pub fn record_doc_encoder_run(&self, run: &SemanticDocEncoderRun) -> Result<(), String> {
+        let guard = self.get_connection_named("record_doc_encoder_run")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        conn.execute(
+            r#"
+            INSERT INTO semantic_doc_encoder_runs (
+                doc_sample_count, requested, source_changed, missing_text,
+                cos_min, cos_p05, cos_p50, cos_mean, cos_max,
+                cold_start_ms, steady_ms_per_doc, note
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+            "#,
+            params![
+                i64::try_from(run.doc_sample_count).unwrap_or(i64::MAX),
+                i64::try_from(run.requested).unwrap_or(i64::MAX),
+                i64::try_from(run.source_changed).unwrap_or(i64::MAX),
+                i64::try_from(run.missing_text).unwrap_or(i64::MAX),
+                run.cos_min.map(f64::from),
+                run.cos_p05.map(f64::from),
+                run.cos_p50.map(f64::from),
+                run.cos_mean.map(f64::from),
+                run.cos_max.map(f64::from),
+                run.cold_start_ms,
+                run.steady_ms_per_doc,
+                run.note,
+            ],
+        )
+        .map_err(|error| format!("Failed to record doc-encoder run: {error}"))?;
+        conn.execute(
+            r#"
+            DELETE FROM semantic_doc_encoder_runs
+            WHERE id NOT IN (
+                SELECT id FROM semantic_doc_encoder_runs ORDER BY id DESC LIMIT ?1
+            )
+            "#,
+            params![MAX_RETAINED_DOC_RUNS],
+        )
+        .ok();
+        Ok(())
+    }
+
+    /// The most recent document-encoder run, or `None` if no probe has run.
+    pub fn get_latest_doc_encoder_run(&self) -> Result<Option<SemanticDocEncoderRun>, String> {
+        let guard = self.get_connection_named("get_latest_doc_encoder_run")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        conn.query_row(
+            r#"
+            SELECT created_at, doc_sample_count, requested, source_changed,
+                   missing_text, cos_min, cos_p05, cos_p50, cos_mean, cos_max,
+                   cold_start_ms, steady_ms_per_doc, note
+            FROM semantic_doc_encoder_runs
+            ORDER BY id DESC
+            LIMIT 1
+            "#,
+            [],
+            |row| {
+                let cos_min = row.get::<_, Option<f64>>(5)?;
+                Ok(SemanticDocEncoderRun {
+                    created_at: row.get::<_, String>(0)?,
+                    doc_sample_count: row.get::<_, i64>(1)?.max(0) as u64,
+                    requested: row.get::<_, i64>(2)?.max(0) as u64,
+                    source_changed: row.get::<_, i64>(3)?.max(0) as u64,
+                    missing_text: row.get::<_, i64>(4)?.max(0) as u64,
+                    cos_min: cos_min.map(|value| value as f32),
+                    cos_p05: row.get::<_, Option<f64>>(6)?.map(|value| value as f32),
+                    cos_p50: row.get::<_, Option<f64>>(7)?.map(|value| value as f32),
+                    cos_mean: row.get::<_, Option<f64>>(8)?.map(|value| value as f32),
+                    cos_max: row.get::<_, Option<f64>>(9)?.map(|value| value as f32),
+                    max_abs_err: cos_min.map(|value| (1.0 - value) as f32),
+                    cold_start_ms: row.get::<_, Option<f64>>(10)?,
+                    steady_ms_per_doc: row.get::<_, Option<f64>>(11)?,
+                    note: row.get::<_, Option<String>>(12)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(|error| format!("Failed to read doc-encoder run: {error}"))
+    }
+}
+
+#[cfg_attr(test, derive(Clone))]
+struct SampleRow {
+    top1_agreement: bool,
+    overlap_k: f64,
+    max_abs_err: Option<f64>,
+    mean_abs_err: Option<f64>,
+    embed_ms: f64,
+    scan_ms: f64,
+    python_ms: f64,
+    rust_visible: i64,
+    chroma_scope: Option<i64>,
+    only_in_chroma: i64,
+    in_both_diff_rank: i64,
+    only_in_rust: i64,
+    cold_start: bool,
+    note: Option<String>,
+}
+
+fn aggregate_report(
+    window: u32,
+    rows: Vec<SampleRow>,
+    doc_encoder: Option<SemanticDocEncoderRun>,
+) -> SemanticShadowReport {
+    let mut report = SemanticShadowReport {
+        window,
+        window_row_count: rows.len() as u64,
+        retrieval_scope: RETRIEVAL_SCOPE_BI_ENCODER.to_string(),
+        doc_encoder,
+        ..Default::default()
+    };
+    // Rows arrive newest-first, so the first row is the latest sample. Coverage
+    // counters and the note text are meaningful on note rows too.
+    if let Some(latest) = rows.first() {
+        report.rust_visible_latest = u64::try_from(latest.rust_visible).ok();
+        report.chroma_scope_latest = latest.chroma_scope.and_then(|value| u64::try_from(value).ok());
+    }
+    report.last_note = rows.iter().find_map(|row| row.note.clone());
+
+    // Everything below is a measurement, so it is computed over comparable rows
+    // only. A note row never made the Rust-vs-Chroma comparison at all.
+    let comparable: Vec<&SampleRow> = rows.iter().filter(|row| row.note.is_none()).collect();
+    report.sample_count = comparable.len() as u64;
+    report.note_sample_count = report.window_row_count - report.sample_count;
+    if comparable.is_empty() {
+        return report;
+    }
+
+    let agreements = comparable.iter().filter(|row| row.top1_agreement).count();
+    report.top1_agreement_rate = Some(agreements as f32 / comparable.len() as f32);
+
+    report.only_in_chroma_total = comparable
+        .iter()
+        .map(|row| row.only_in_chroma.max(0) as u64)
+        .sum();
+    report.in_both_diff_rank_total = comparable
+        .iter()
+        .map(|row| row.in_both_diff_rank.max(0) as u64)
+        .sum();
+    report.only_in_rust_total = comparable
+        .iter()
+        .map(|row| row.only_in_rust.max(0) as u64)
+        .sum();
+
+    let overlaps: Vec<f64> = comparable.iter().map(|row| row.overlap_k).collect();
+    report.overlap_mean = mean(&overlaps).map(|value| value as f32);
+    report.overlap_p50 = percentile(&overlaps, 0.50).map(|value| value as f32);
+    report.overlap_p05 = percentile(&overlaps, 0.05).map(|value| value as f32);
+
+    let max_errs: Vec<f64> = comparable.iter().filter_map(|row| row.max_abs_err).collect();
+    report.max_abs_err = max_errs
+        .iter()
+        .copied()
+        .fold(None, |acc: Option<f64>, value| {
+            Some(acc.map_or(value, |current| current.max(value)))
+        })
+        .map(|value| value as f32);
+    let mean_errs: Vec<f64> = comparable
+        .iter()
+        .filter_map(|row| row.mean_abs_err)
+        .collect();
+    report.mean_abs_err = mean(&mean_errs).map(|value| value as f32);
+
+    let python_ms: Vec<f64> = comparable.iter().map(|row| row.python_ms).collect();
+    report.python_ms_p50 = percentile(&python_ms, 0.50);
+    report.python_ms_p95 = percentile(&python_ms, 0.95);
+
+    // Latency: a single cold-start sample (first query after worker/ONNX init)
+    // can dwarf every steady-state query, so it is reported on its own and
+    // excluded from the percentiles. The newest cold-start row is the headline
+    // cold figure. embed vs scan are split so the O(N) exact scan is visible.
+    report.rust_cold_start_ms = comparable
+        .iter()
+        .find(|row| row.cold_start)
+        .map(|row| row.embed_ms + row.scan_ms);
+    let steady: Vec<&&SampleRow> = comparable.iter().filter(|row| !row.cold_start).collect();
+    report.steady_sample_count = steady.len() as u64;
+    let steady_total: Vec<f64> = steady.iter().map(|row| row.embed_ms + row.scan_ms).collect();
+    report.rust_ms_p50 = percentile(&steady_total, 0.50);
+    report.rust_ms_p95 = percentile(&steady_total, 0.95);
+    let steady_embed: Vec<f64> = steady.iter().map(|row| row.embed_ms).collect();
+    report.rust_embed_ms_p50 = percentile(&steady_embed, 0.50);
+    report.rust_embed_ms_p95 = percentile(&steady_embed, 0.95);
+    let steady_scan: Vec<f64> = steady.iter().map(|row| row.scan_ms).collect();
+    report.rust_scan_ms_p50 = percentile(&steady_scan, 0.50);
+    report.rust_scan_ms_p95 = percentile(&steady_scan, 0.95);
+    report
+}
+
+fn mean(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    Some(values.iter().sum::<f64>() / values.len() as f64)
+}
+
+/// Nearest-rank percentile over a copy of `values`. `q` is in `[0, 1]`.
+fn percentile(values: &[f64], q: f64) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let rank = (q * (sorted.len() as f64 - 1.0)).round() as usize;
+    sorted.get(rank.min(sorted.len() - 1)).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_row(overlap: f64, top1: bool, python_ms: f64) -> SampleRow {
+        SampleRow {
+            top1_agreement: top1,
+            overlap_k: overlap,
+            max_abs_err: Some(0.001),
+            mean_abs_err: Some(0.0005),
+            embed_ms: 20.0,
+            scan_ms: 5.0,
+            python_ms,
+            rust_visible: 1000,
+            chroma_scope: Some(1200),
+            only_in_chroma: 0,
+            in_both_diff_rank: 1,
+            only_in_rust: 2,
+            cold_start: false,
+            note: None,
+        }
+    }
+
+    #[test]
+    fn empty_rows_produce_zeroed_report() {
+        let report = aggregate_report(100, Vec::new(), None);
+        assert_eq!(report.sample_count, 0);
+        assert!(report.overlap_mean.is_none());
+        assert!(report.top1_agreement_rate.is_none());
+        assert_eq!(report.retrieval_scope, RETRIEVAL_SCOPE_BI_ENCODER);
+    }
+
+    #[test]
+    fn aggregates_overlap_top1_and_latency() {
+        let rows = vec![
+            sample_row(1.0, true, 100.0),
+            sample_row(0.8, false, 200.0),
+            sample_row(0.6, true, 300.0),
+        ];
+        let report = aggregate_report(100, rows, None);
+        assert_eq!(report.sample_count, 3);
+        assert!((report.top1_agreement_rate.unwrap() - 2.0 / 3.0).abs() < 1e-6);
+        assert!((report.overlap_mean.unwrap() - 0.8).abs() < 1e-6);
+        assert_eq!(report.rust_visible_latest, Some(1000));
+        assert_eq!(report.chroma_scope_latest, Some(1200));
+        // rust_ms = embed(20) + scan(5) = 25 for every row.
+        assert!((report.rust_ms_p50.unwrap() - 25.0).abs() < 1e-6);
+        // Steady-state splits: embed=20, scan=5 for every row.
+        assert!((report.rust_embed_ms_p50.unwrap() - 20.0).abs() < 1e-6);
+        assert!((report.rust_scan_ms_p50.unwrap() - 5.0).abs() < 1e-6);
+        assert_eq!(report.steady_sample_count, 3);
+        assert!(report.rust_cold_start_ms.is_none());
+        assert_eq!(report.only_in_chroma_total, 0);
+        assert_eq!(report.in_both_diff_rank_total, 3);
+        assert_eq!(report.only_in_rust_total, 6);
+    }
+
+    #[test]
+    fn cold_start_sample_is_excluded_from_steady_latency() {
+        let mut cold = sample_row(1.0, true, 100.0);
+        cold.cold_start = true;
+        cold.embed_ms = 5000.0;
+        cold.scan_ms = 100.0;
+        let rows = vec![
+            cold,
+            sample_row(1.0, true, 100.0),
+            sample_row(1.0, true, 100.0),
+        ];
+        let report = aggregate_report(100, rows, None);
+        // Cold row reported separately: 5000 + 100 = 5100.
+        assert!((report.rust_cold_start_ms.unwrap() - 5100.0).abs() < 1e-6);
+        // Steady percentiles ignore the cold outlier: only the two 25ms rows.
+        assert_eq!(report.steady_sample_count, 2);
+        assert!((report.rust_ms_p95.unwrap() - 25.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn doc_encoder_run_is_attached_to_report() {
+        let run = SemanticDocEncoderRun {
+            doc_sample_count: 256,
+            cos_min: Some(0.98),
+            max_abs_err: Some(0.02),
+            ..Default::default()
+        };
+        let report = aggregate_report(100, Vec::new(), Some(run));
+        let doc = report.doc_encoder.expect("doc encoder attached");
+        assert_eq!(doc.doc_sample_count, 256);
+        assert!((doc.max_abs_err.unwrap() - 0.02).abs() < 1e-6);
+    }
+
+    #[test]
+    fn note_rows_are_excluded_from_every_measurement() {
+        // Two real samples at overlap 1.0, plus three unavailable-index rows
+        // that carry filler zeros. The filler must not move any statistic.
+        let mut empty_a = sample_row(0.0, false, 0.0);
+        empty_a.note = Some("python_empty_results: ...".to_string());
+        empty_a.max_abs_err = None;
+        empty_a.mean_abs_err = None;
+        let mut empty_b = empty_a.clone();
+        empty_b.note = Some("embed_failed: worker down".to_string());
+        let mut empty_c = empty_a.clone();
+        empty_c.note = Some("classification_lookup_failed: 2 of 10".to_string());
+
+        let rows = vec![
+            empty_a,
+            empty_b,
+            empty_c,
+            sample_row(1.0, true, 100.0),
+            sample_row(1.0, true, 100.0),
+        ];
+        let report = aggregate_report(500, rows, None);
+
+        assert_eq!(report.window_row_count, 5);
+        assert_eq!(report.note_sample_count, 3);
+        assert_eq!(report.sample_count, 2);
+        // Gate numbers reflect the two comparable rows, not 2/5.
+        assert!((report.top1_agreement_rate.unwrap() - 1.0).abs() < 1e-6);
+        assert!((report.overlap_mean.unwrap() - 1.0).abs() < 1e-6);
+        assert!((report.overlap_p05.unwrap() - 1.0).abs() < 1e-6);
+        // python_ms percentiles ignore the note rows' 0.0 filler.
+        assert!((report.python_ms_p50.unwrap() - 100.0).abs() < 1e-6);
+        // The newest note is still surfaced for diagnosis.
+        assert_eq!(report.last_note.as_deref(), Some("python_empty_results: ..."));
+        // Divergence totals come from comparable rows only.
+        assert_eq!(report.in_both_diff_rank_total, 2);
+    }
+
+    #[test]
+    fn a_window_of_only_note_rows_reports_no_measurements() {
+        let mut note = sample_row(0.0, false, 0.0);
+        note.note = Some("python_empty_results: ...".to_string());
+        let report = aggregate_report(500, vec![note], None);
+        assert_eq!(report.sample_count, 0);
+        assert_eq!(report.note_sample_count, 1);
+        // Critically: NOT Some(0.0), which would read as "0% top-1 agreement".
+        assert!(report.top1_agreement_rate.is_none());
+        assert!(report.overlap_mean.is_none());
+        assert!(report.python_ms_p50.is_none());
+        // Coverage counters survive: they are recorded on note rows too.
+        assert_eq!(report.rust_visible_latest, Some(1000));
+    }
+
+    #[test]
+    fn percentile_uses_nearest_rank() {
+        let values = vec![10.0, 20.0, 30.0, 40.0, 100.0];
+        assert_eq!(percentile(&values, 0.0), Some(10.0));
+        assert_eq!(percentile(&values, 0.5), Some(30.0));
+        assert_eq!(percentile(&values, 0.95), Some(100.0));
+    }
+
+    fn test_storage() -> (tempfile::TempDir, StorageState) {
+        use crate::credential_manager::CredentialManagerState;
+        use rusqlite::Connection;
+        use std::sync::Arc;
+        let temp = tempfile::tempdir().expect("temp storage directory");
+        let credential_state = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        let storage = StorageState::new(temp.path().to_path_buf(), credential_state);
+        let connection = Connection::open_in_memory().expect("in-memory database");
+        storage.init_tables(&connection).expect("initialize schema");
+        *storage.db.lock().unwrap_or_else(|error| error.into_inner()) = Some(connection);
+        (temp, storage)
+    }
+
+    /// Regression guard: `get_semantic_shadow_report` used to fetch the
+    /// doc-encoder run WHILE still holding the connection guard, re-locking the
+    /// non-reentrant DB mutex and self-deadlocking the whole storage layer. This
+    /// test would HANG under that bug; it must return quickly and reflect the run.
+    #[test]
+    fn report_reads_doc_run_without_holding_the_connection_lock() {
+        let (_temp, storage) = test_storage();
+
+        // Empty path: no samples, no doc run, scope label still set.
+        let report = storage.get_semantic_shadow_report(500).expect("empty report");
+        assert_eq!(report.sample_count, 0);
+        assert!(report.doc_encoder.is_none());
+        assert_eq!(report.retrieval_scope, RETRIEVAL_SCOPE_BI_ENCODER);
+
+        storage
+            .record_doc_encoder_run(&SemanticDocEncoderRun {
+                doc_sample_count: 128,
+                requested: 130,
+                source_changed: 2,
+                cos_min: Some(0.97),
+                cos_p50: Some(0.999),
+                ..Default::default()
+            })
+            .expect("record doc-encoder run");
+
+        // The previously-deadlocking path: report reads the just-recorded run.
+        let report = storage.get_semantic_shadow_report(500).expect("report with doc run");
+        let doc = report.doc_encoder.expect("doc encoder present");
+        assert_eq!(doc.doc_sample_count, 128);
+        assert_eq!(doc.requested, 130);
+        assert_eq!(doc.source_changed, 2);
+        // max_abs_err is derived from cos_min on read (1 - 0.97).
+        assert!((doc.max_abs_err.unwrap() - 0.03).abs() < 1e-6);
+    }
+}

--- a/src/components/settings/AdvancedSection.jsx
+++ b/src/components/settings/AdvancedSection.jsx
@@ -4,7 +4,7 @@ import AdvancedWarning from './advanced/AdvancedWarning';
 import ClusteringTechnicalCard from './advanced/ClusteringTechnicalCard';
 import CpuLimitCard from './advanced/CpuLimitCard';
 import DatabaseMaintenanceCard from './advanced/DatabaseMaintenanceCard';
-import { DmlAccelerationCard, OcrEngineCard, OnnxRuntimeCard } from './advanced/InferenceCards';
+import { DmlAccelerationCard, OcrEngineCard, OnnxRuntimeCard, SemanticShadowCard } from './advanced/InferenceCards';
 import NetworkAccessCard from './advanced/NetworkAccessCard';
 import OcrQueueCard from './advanced/OcrQueueCard';
 import { useAdvancedSectionController } from './useAdvancedSectionController';
@@ -44,6 +44,15 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
     handleManualVacuum,
     handleRestartMlOcr,
     handleDownloadRustOcrModel,
+    semanticShadowReport,
+    semanticShadowLoading,
+    handleSemanticShadowToggle,
+    refreshSemanticShadowReport,
+    semanticProbeRunning,
+    semanticProbeSummary,
+    handleRunSemanticProbe,
+    docProbeRunning,
+    handleRunDocEncoderProbe,
   } = useAdvancedSectionController({ monitorStatus, t });
 
   if (loading || !config) {
@@ -109,6 +118,19 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
         onToggle={handleToggle}
         onRestartMonitor={onRestartMonitor}
         onClearChanged={clearOnnxChanged}
+      />
+
+      <SemanticShadowCard
+        config={config}
+        report={semanticShadowReport}
+        reportLoading={semanticShadowLoading}
+        onToggleShadow={handleSemanticShadowToggle}
+        onRefresh={refreshSemanticShadowReport}
+        onRunProbe={handleRunSemanticProbe}
+        probeRunning={semanticProbeRunning}
+        probeSummary={semanticProbeSummary}
+        onRunDocProbe={handleRunDocEncoderProbe}
+        docProbeRunning={docProbeRunning}
       />
 
       <ClusteringTechnicalCard

--- a/src/components/settings/advanced/InferenceCards.jsx
+++ b/src/components/settings/advanced/InferenceCards.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle, ChevronDown, Cpu, Monitor, RefreshCw, Zap } from 'lucide-react';
+import { AlertTriangle, ChevronDown, Cpu, FlaskConical, Monitor, RefreshCw, Zap } from 'lucide-react';
 import SettingsHelpTooltip from '../SettingsHelpTooltip';
 import { SettingsSwitch } from '../SettingsControls';
 
@@ -228,6 +228,234 @@ export function DmlAccelerationCard({
             {t('settings.advanced.dml.changed_notice')}
           </ChangedNotice>
         )}
+      </div>
+    </div>
+  );
+}
+
+function formatPercent(value) {
+  if (value == null) return '—';
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatMs(value) {
+  if (value == null) return '—';
+  return `${Math.round(value)} ms`;
+}
+
+function formatErr(value) {
+  if (value == null) return '—';
+  return value.toExponential(1);
+}
+
+function formatCos(value) {
+  if (value == null) return '—';
+  return value.toFixed(4);
+}
+
+export function SemanticShadowCard({
+  config,
+  report,
+  reportLoading,
+  onToggleShadow,
+  onRefresh,
+  onRunProbe,
+  probeRunning,
+  probeSummary,
+  onRunDocProbe,
+  docProbeRunning,
+}) {
+  const { t } = useTranslation();
+  const runtime = config.semantic_runtime || 'python';
+  const shadowOn = runtime === 'rust_shadow';
+  const doc = report?.doc_encoder;
+
+  return (
+    <div className="space-y-3">
+      <label className="text-sm font-semibold text-ide-accent px-1 flex items-center gap-2">
+        <FlaskConical className="w-4 h-4" />
+        {t('settings.advanced.semantic_shadow.title', 'MiniLM 语义检索影子对比')}
+      </label>
+
+      <div className="p-4 bg-ide-bg border border-ide-border rounded-xl space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-ide-text font-medium">
+              {t('settings.advanced.semantic_shadow.label', '实时影子对比')}
+            </p>
+            <p className="text-xs text-ide-muted mt-1">
+              {t(
+                'settings.advanced.semantic_shadow.desc',
+                '开启后，聚类页的每次自然语言检索都会在后台额外跑一次 Rust 精确扫描检索，与权威的 Chroma/Python 结果对比并记录本地诊断。不改变搜索结果，Python 保持权威。',
+              )}
+            </p>
+          </div>
+          <SettingsSwitch checked={shadowOn} onChange={() => onToggleShadow(!shadowOn)} />
+        </div>
+
+        <div className="flex items-center justify-between gap-4 rounded-lg border border-ide-border/60 bg-ide-panel/40 p-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm text-ide-text font-medium">
+              {t('settings.advanced.semantic_shadow.probe', '运行内置查询集')}
+            </p>
+            <p className="text-xs text-ide-muted mt-1">
+              {t(
+                'settings.advanced.semantic_shadow.probe_desc',
+                '用一组内置查询自动驱动对比，无需手动搜索。需要监控进程在运行且 MiniLM 索引已就绪。',
+              )}
+            </p>
+            {probeSummary && (
+              <p className="text-xs text-ide-muted mt-1">
+                {t(
+                  'settings.advanced.semantic_shadow.probe_summary',
+                  '本次：{{queries}} 条查询 · 有效 {{full}} · 提示 {{note}} · Python 失败 {{fail}}',
+                  {
+                    queries: probeSummary.queries ?? 0,
+                    full: probeSummary.full_samples ?? 0,
+                    note: probeSummary.note_samples ?? 0,
+                    fail: probeSummary.python_failures ?? 0,
+                  },
+                )}
+              </p>
+            )}
+          </div>
+          <button
+            onClick={onRunProbe}
+            disabled={probeRunning}
+            className="px-3 py-1.5 text-xs rounded bg-ide-accent text-white hover:opacity-90 disabled:opacity-50 shrink-0"
+          >
+            {probeRunning
+              ? t('settings.advanced.semantic_shadow.probe_running', '运行中…')
+              : t('settings.advanced.semantic_shadow.probe_run', '开始测试')}
+          </button>
+        </div>
+
+        <div className="rounded-lg border border-ide-border/60 bg-ide-panel/40 p-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-ide-muted">
+              {t('settings.advanced.semantic_shadow.samples', '样本数')}:{' '}
+              <span className="text-ide-text font-medium">{report?.sample_count ?? 0}</span>
+              <span className="text-ide-muted">
+                {' '}({t('settings.advanced.semantic_shadow.steady', '稳态')}{' '}
+                {report?.steady_sample_count ?? 0})
+              </span>
+              {report?.note_sample_count ? (
+                <span className="text-ide-warning">
+                  {' '}·{' '}
+                  {t('settings.advanced.semantic_shadow.excluded', '已排除')}{' '}
+                  {report.note_sample_count}
+                </span>
+              ) : null}
+            </p>
+            <button
+              onClick={onRefresh}
+              disabled={reportLoading}
+              className="p-1.5 text-ide-muted hover:text-ide-text hover:bg-ide-hover rounded transition-colors disabled:opacity-50"
+              title={t('settings.advanced.semantic_shadow.refresh', '刷新诊断')}
+            >
+              <RefreshCw className={`w-3.5 h-3.5 ${reportLoading ? 'animate-spin' : ''}`} />
+            </button>
+          </div>
+
+          <div className="rounded border border-ide-border/60 bg-ide-panel/40 px-2.5 py-1.5 text-[11px] text-ide-warning-muted leading-snug">
+            {t(
+              'settings.advanced.semantic_shadow.scope',
+              '作用域：仅 bi-encoder 检索层，reranker 已关闭 —— 这些数字不代表线上最终排序（带 rerank 的端到端对照属 M2.5 step 5）。',
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+            <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.top1', 'Top-1 一致率')}</span>
+            <span className="text-ide-text text-right">{formatPercent(report?.top1_agreement_rate)}</span>
+            <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.overlap50', 'Overlap@10 p50')}</span>
+            <span className="text-ide-text text-right">{formatPercent(report?.overlap_p50)}</span>
+            <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.overlap05', 'Overlap@10 p05')}</span>
+            <span className="text-ide-text text-right">{formatPercent(report?.overlap_p05)}</span>
+            <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.max_err', '查询编码 余弦最大误差')}</span>
+            <span className="text-ide-text text-right">{formatErr(report?.max_abs_err)}</span>
+            <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.rust_ms', 'Rust 稳态 p50/p95')}</span>
+            <span className="text-ide-text text-right">{formatMs(report?.rust_ms_p50)} / {formatMs(report?.rust_ms_p95)}</span>
+            <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.cold_ms', 'Rust 冷启动(首查)')}</span>
+            <span className="text-ide-text text-right">{formatMs(report?.rust_cold_start_ms)}</span>
+            <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.embed_scan', '编码/扫描 p50')}</span>
+            <span className="text-ide-text text-right">{formatMs(report?.rust_embed_ms_p50)} / {formatMs(report?.rust_scan_ms_p50)}</span>
+            <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.python_ms', 'Python p50/p95')}</span>
+            <span className="text-ide-text text-right">{formatMs(report?.python_ms_p50)} / {formatMs(report?.python_ms_p95)}</span>
+            <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.coverage', '覆盖 Rust/Chroma')}</span>
+            <span className="text-ide-text text-right">{report?.rust_visible_latest ?? '—'} / {report?.chroma_scope_latest ?? '—'}</span>
+            <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.divergence', '分歧 仅C/名次/仅R')}</span>
+            <span className="text-ide-text text-right">
+              <span className={report?.only_in_chroma_total ? 'text-ide-warning' : ''}>{report?.only_in_chroma_total ?? 0}</span>
+              {' / '}{report?.in_both_diff_rank_total ?? 0}{' / '}{report?.only_in_rust_total ?? 0}
+            </span>
+          </div>
+          <p className="text-[11px] text-ide-muted leading-snug">
+            {t(
+              'settings.advanced.semantic_shadow.divergence_hint',
+              '分歧分解：仅C=Rust 缺失 Chroma 的文档（真分歧，需关注）；名次=两库都有但排名不同（近似/排序差异）；仅R=Rust 独有。扫描为 O(N) 精确扫描，规模上限为“覆盖 Rust”那一层。',
+            )}
+          </p>
+
+          <div className="border-t border-ide-border/60 pt-2 space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-xs text-ide-text font-medium">
+                  {t('settings.advanced.semantic_shadow.doc_title', '文档编码对照')}
+                </p>
+                <p className="text-[11px] text-ide-muted mt-0.5 leading-snug">
+                  {t(
+                    'settings.advanced.semantic_shadow.doc_desc',
+                    'Rust 重新编码迁移文档，与存储的 Python 文档向量比余弦——补上查询对比未覆盖的另一半链路（Rust 文档编码器）。',
+                  )}
+                </p>
+              </div>
+              <button
+                onClick={onRunDocProbe}
+                disabled={docProbeRunning}
+                className="px-3 py-1.5 text-xs rounded bg-ide-accent text-white hover:opacity-90 disabled:opacity-50 shrink-0"
+              >
+                {docProbeRunning
+                  ? t('settings.advanced.semantic_shadow.probe_running', '运行中…')
+                  : t('settings.advanced.semantic_shadow.doc_run', '编码对照')}
+              </button>
+            </div>
+            {doc ? (
+              <>
+                <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                  <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.doc_samples', '文档样本 对照/抽样')}</span>
+                  <span className="text-ide-text text-right">{doc.doc_sample_count ?? 0} / {doc.requested ?? 0}</span>
+                  <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.doc_cos', '余弦 p50/p05/最小')}</span>
+                  <span className="text-ide-text text-right">{formatCos(doc.cos_p50)} / {formatCos(doc.cos_p05)} / {formatCos(doc.cos_min)}</span>
+                  <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.doc_max_err', '文档编码 余弦最大误差')}</span>
+                  <span className="text-ide-text text-right">{formatErr(doc.max_abs_err)}</span>
+                  <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.doc_latency', '冷启动/稳态每文档')}</span>
+                  <span className="text-ide-text text-right">{formatMs(doc.cold_start_ms)} / {formatMs(doc.steady_ms_per_doc)}</span>
+                  <span className="text-ide-muted">{t('settings.advanced.semantic_shadow.doc_skipped', '跳过 源变更/缺失')}</span>
+                  <span className="text-ide-text text-right">
+                    <span className={doc.source_changed ? 'text-ide-warning' : ''}>{doc.source_changed ?? 0}</span>
+                    {' / '}{doc.missing_text ?? 0}
+                  </span>
+                </div>
+                <p className="text-[11px] text-ide-muted leading-snug">
+                  {t(
+                    'settings.advanced.semantic_shadow.doc_hint',
+                    '余弦越接近 1 越好；最大误差=1−最小余弦。源变更=OCR/标题自迁移后已改（跳过，避免对比不同文本）；缺失=截图已删或文本为空。',
+                  )}
+                </p>
+              </>
+            ) : (
+              <p className="text-[11px] text-ide-muted leading-snug">
+                {t('settings.advanced.semantic_shadow.doc_empty', '尚无文档编码对照数据，点击“编码对照”运行一次。')}
+              </p>
+            )}
+          </div>
+
+          {report?.last_note && (
+            <p className="text-xs text-ide-warning-muted mt-1">
+              {t('settings.advanced.semantic_shadow.last_note', '最近提示')}: {report.last_note}
+            </p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/settings/useAdvancedSectionController.js
+++ b/src/components/settings/useAdvancedSectionController.js
@@ -19,6 +19,11 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
   const [mlOcrStatusLoading, setMlOcrStatusLoading] = useState(false);
   const [rustOcrModelStatus, setRustOcrModelStatus] = useState(null);
   const [rustOcrModelDownloading, setRustOcrModelDownloading] = useState(false);
+  const [semanticShadowReport, setSemanticShadowReport] = useState(null);
+  const [semanticShadowLoading, setSemanticShadowLoading] = useState(false);
+  const [semanticProbeRunning, setSemanticProbeRunning] = useState(false);
+  const [semanticProbeSummary, setSemanticProbeSummary] = useState(null);
+  const [docProbeRunning, setDocProbeRunning] = useState(false);
 
   const saveConfig = async (newConfig) => {
     const previousConfig = config;
@@ -174,6 +179,75 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     }
   };
 
+  const refreshSemanticShadowReport = async () => {
+    setSemanticShadowLoading(true);
+    try {
+      setSemanticShadowReport(await invoke('get_semantic_shadow_report', { window: 500 }));
+    } catch (err) {
+      console.warn('Failed to read semantic shadow report:', err);
+    } finally {
+      setSemanticShadowLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (config?.semantic_runtime === 'rust_shadow') {
+      refreshSemanticShadowReport();
+    }
+  }, [config?.semantic_runtime]);
+
+  useEffect(() => {
+    // The report/probe surface is always visible, so load the diagnostic once
+    // on mount regardless of whether the passive shadow toggle is on.
+    refreshSemanticShadowReport();
+  }, []);
+
+  const handleSemanticShadowToggle = async (enabled) => {
+    const newConfig = { ...config, semantic_runtime: enabled ? 'rust_shadow' : 'python' };
+    const saved = await saveConfig(newConfig);
+    if (saved && enabled) {
+      await refreshSemanticShadowReport();
+    }
+  };
+
+  const handleRunSemanticProbe = async () => {
+    setSemanticProbeRunning(true);
+    try {
+      const summary = await withAuth(() => invoke('run_semantic_shadow_probe', {}), { autoPrompt: true });
+      setSemanticProbeSummary(summary);
+      if (summary?.report) {
+        setSemanticShadowReport(summary.report);
+      } else {
+        await refreshSemanticShadowReport();
+      }
+    } catch (err) {
+      console.error('Failed to run semantic shadow probe:', err);
+    } finally {
+      setSemanticProbeRunning(false);
+    }
+  };
+
+  const handleRunDocEncoderProbe = async () => {
+    setDocProbeRunning(true);
+    try {
+      const summary = await withAuth(
+        () => invoke('run_semantic_doc_encoder_probe', {}),
+        { autoPrompt: true },
+      );
+      // The command returns the full report (with the doc-encoder section
+      // attached), so update the shared report directly when present.
+      if (summary?.report) {
+        setSemanticShadowReport(summary.report);
+      } else {
+        await refreshSemanticShadowReport();
+      }
+    } catch (err) {
+      console.error('Failed to run document-encoder probe:', err);
+    } finally {
+      setDocProbeRunning(false);
+    }
+  };
+
   const handleRestartMlOcr = async () => {
     try {
       await withAuth(
@@ -258,6 +332,11 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     mlOcrStatusLoading,
     rustOcrModelStatus,
     rustOcrModelDownloading,
+    semanticShadowReport,
+    semanticShadowLoading,
+    semanticProbeRunning,
+    semanticProbeSummary,
+    docProbeRunning,
     setCpuDropdownOpen,
     setGpuDropdownOpen,
     setClusteringDropdownOpen,
@@ -273,5 +352,9 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     handleManualVacuum,
     handleRestartMlOcr,
     handleDownloadRustOcrModel,
+    handleSemanticShadowToggle,
+    refreshSemanticShadowReport,
+    handleRunSemanticProbe,
+    handleRunDocEncoderProbe,
   };
 }


### PR DESCRIPTION
## Summary

- Adds the M2.5 step-3 shadow harness: a passive per-query comparison of the authoritative Chroma/Python `nl_cluster_query` against an equivalent Rust exact scan, an active probe driven by a built-in non-sensitive query corpus, and a document-encoder probe that re-encodes migrated documents with the Rust MiniLM runtime and compares them against the stored Python vectors. Samples are local and telemetry-free; only a query hash is persisted. Python/Chroma stays authoritative and user-visible search behavior is unchanged.
- Adds the Rust read path the step-4 cutover needs: `semantic_text_topk`, an exact cosine scan over query-visible `semantic_text` embeddings, served from a resident vector matrix that the derived-index write path keeps current and a 60s idle sweep releases.
- Fixes MiniLM source-text reconstruction to replay OCR boxes in insertion (engine) order rather than geometric order, so rebuilt text matches the text the stored vectors were actually encoded from.
- Adds `semantic_runtime` / `semantic_index` enum configuration, the settings diagnostic card, and a Python `get_task_vectors_count` command so coverage compares live Rust against the live Chroma hot layer.
- Updates the roadmap to require that this shadow scaffolding is deleted at the cutover PR that proves its gate and never reaches a production build, with the MiniLM artifact list separating the shadow-only surface from the read path that stays.

## Note

Following the M2.4 migration work, this change adds a comparator that checks whether retrieval results agree before and after the migration. The results are as follows.

**Query side — 256-query sample**

| Metric | Value |
| --- | --- |
| Top-1 agreement rate | 90.7% |
| Overlap@10 p50 | 100.0% |
| Overlap@10 p05 | 50.0% |
| Query-encoder max absolute cosine error | 6.0e-7 |
| Rust steady-state p50 / p95 | 324 ms / 988 ms |
| Rust cold start (first query) | 6484 ms |
| Encode / scan p50 | 6 ms / 318 ms |
| Python p50 / p95 | 78 ms / 181 ms |

**Document side**

| Metric | Value |
| --- | --- |
| Documents compared / sampled | 256 / 256 |
| Cosine p50 / p05 / min | 0.9917 / 0.9868 / 0.9796 |
| Document-encoder max absolute error | 2.0e-2 |
| Cold start / steady state per document | 5164 ms / 122 ms |

There is some divergence, but we consider it acceptable. The reason is that the Rust side uses a more accurate — or rather, more brute-force — scanning method than the Python side, so vectors that the Python side may have missed are recalled by Rust. In practice this is therefore closer to a Python-side issue (though it hardly qualifies as a problem) than an error introduced by the migration to Rust.
