### PR TITLE
m2: cut over capture-side MiniLM vector indexing to Rust

### DIFF
--- a/docs/python-removal-roadmap.md
+++ b/docs/python-removal-roadmap.md
@@ -1,635 +1,1344 @@
-# CarbonPaper v0.8.4 Beta M2 / 0.8.x Python Removal Roadmap
+# Python Removal Roadmap (CarbonPaper 0.8.x)
 
-Baseline: CarbonPaper `0.8.3`, revised on 2026-07-18 from a direct source-code audit of the shipped tree.
-Supersedes the 0.8.1-baseline plan (kept for reference in `roadmap.0.8.1-original.md`).
-2026-07-19 update: Milestone 1 was reduced to an **internal migration baseline**: collection semantics, scope decisions, a stable count-level CLIP baseline, and the Chroma version pin. It is not a user-facing health feature and does not need a separate release; its per-row ledger, rebuild executor, and actionable maintenance UI belong to Milestone 2.
-2026-07-19 correction: the earlier Milestone 1 "demote Chinese-CLIP / one NL text path" decision is **reversed**. It rested on a dead-code rationale (`search_by_image` / `search_by_ocr_text`) that missed the *live* CLIP consumer — `search_by_text`, the text→image backend actually serving `search_nl` from two frontend surfaces and the MCP. Text→image visual search ("search 'sea', get sea-looking screenshots") is a distinct cross-modal capability that neither the shipped Rust keyword search (`storage/search.rs::search_text`) nor a future MiniLM-over-OCR semantic search can reproduce. CLIP is now **retained as a first-class search surface**; see the Milestone 1 decisions and Milestone 2 below.
-2026-07-19 implementation review: Milestone 2 is revised around **behavioral equivalence**, not merely moving an ONNX call site. Rust cutover must preserve feature availability, data coverage, filters, response contracts, ranking quality, foreground isolation, upgrade/rollback, and the still-live Python consumers. ChromaDB cannot be removed in Milestone 2 while `task_vectors` / `task_centroids` still serve Milestone 4 task clustering, and Python BGE inference cannot be removed before the classification consumer has a Rust path or an explicit Rust inference bridge.
-2026-07-19 delivery decision: **Milestone 2 is the committed scope for v0.8.4 Beta**, delivered as short stacked PRs with disabled/shadow infrastructure allowed to land before individual capability cutovers. This accelerates implementation without weakening the parity, migration, rollback, foreground-isolation, or one-release fallback gates. v0.8.4 Beta completing M2 does not mean that ChromaDB or the Python distribution can be removed in the same release.
-2026-07-28 cutover-scope correction (three changes, all forced by reading the shipped code rather than the plan). First, the old step 4 bundled two things the code cannot separate the way the plan assumed: Smart Cluster calibration is hard-wired to `enable_rerank = true` (`NlClusterView.jsx:95`) and Python's `query_by_text` fuses retrieval and reranking into one call with no standalone rerank command, so "cut over the calibration prefilter" would require a throwaway Rust→Python rerank bridge. Calibration moves to the reranker step instead, and step 4 cuts over the non-reranked path only. Second, the M2.5 release gate's "top-10 overlap ≥ 99%" wording was written assuming two implementations of the *same* retrieval method; the shipped Rust path is an exact scan and Chroma is ANN, so the measured divergence is a recall superset, not a defect. The gate is rewritten to say so rather than shipping against a gate known to fail on its literal text. Third, the numbered steps never contained a Rust capture-side MiniLM indexing step — new screenshots are still encoded and enqueued only by Python, which the M2.5 "with Python stopped" gate silently requires. It is now an explicit step between the query cutover and the reranker.
+**Goal.** Remove the Python monitor stack from CarbonPaper without losing user
+data, without breaking OCR or search, and without letting background machine
+learning interfere with whatever the user has in the foreground.
 
-Goal (unchanged): gradually remove the Python monitor stack from CarbonPaper while keeping user data safe, keeping OCR/search usable, and avoiding foreground ML interference.
+**Current milestone.** Milestone 2, targeted at v0.8.4 Beta. Steps 1-5 of the
+M2.5 cutover sequence are done; step 6 is next.
 
-## Why This Revision
+---
 
-The original plan assigned one milestone per `0.8.x` version and assumed a **direct Python-to-Rust hop, one feature at a time**. The audit shows the codebase diverged from that plan in three important ways, so version numbers no longer describe reality:
+## 1. How to read this document
 
-1. **OCR is already Rust-default** (the original 0.8.5 target) even though the shipped version is `0.8.3`. It was implemented not via the in-process `OcrEngine` trait but as a standalone `carbonpaper-ml.exe` worker built on the pinned crate `rapidocr-core = "=0.2.2"`. The Python-default beta phase (original 0.8.4) and its dual-run diagnostics were **skipped entirely**.
-2. **A "two-hop" migration is actually in progress** (see below). The team first unified all ML onto ONNX inside Python and lifted model-asset management into Rust, rather than porting each feature straight to Rust.
-3. **The Agent/MCP parallel track ran ahead** of the Python-removal track, reaching the original 0.8.3 target.
+The document is organized by **milestone**, not by version. Milestones are
+ordered commitments; version numbers next to them are estimates. Only Milestone
+2 is tied to a specific release (v0.8.4 Beta). Do not infer a milestone's status
+from the app's version number — section 3 explains why the two drifted apart.
 
-Consequence for this document: Milestone 2 is explicitly targeted at **v0.8.4 Beta**. Later milestones remain ordered commitments rather than promises tied to a specific patch number. Do not infer later milestone status from the version number.
+Each milestone has the same five parts:
 
-## The Two-Hop Migration Reality
+| Part | Answers |
+| --- | --- |
+| **Goal** | Why this milestone exists |
+| **Where the code is** | What is already true, in the shipped or in-flight tree |
+| **Work** | What has to be built, and what is already built |
+| **Release gate** | What must be provably true before the milestone is called done |
+| **Depends on** | Which earlier milestone has to land first |
 
-The real path is not `Python(PyTorch) -> Rust`. It is:
+Status words are used strictly:
 
-- **Hop 1 — ONNX unification + Rust asset ownership (mostly done).** All ML models (OCR PP-OCRv5, CLIP, BGE, MiniLM, bge-reranker) are ONNX; `use_onnx` defaults to `true` (`model_management.rs:390`) and `torch`/`sentence-transformers` are fallback-only (`monitor/main.py:12-18` ONNX sentinel skips the torch import). Model registration, install status, sizing, and OCR **inference** are Rust-owned. Python is compressed into a thin layer: `onnxruntime-directml` inference + ChromaDB + post-process orchestration.
-- **Hop 2 — move ONNX inference from Python to Rust (only OCR done).** Everything except OCR still runs its ONNX inference inside the Python `onnxruntime`.
+- **DONE** — merged and gate-checked.
+- **IN PROGRESS** — partially merged; the milestone body says which parts.
+- **IMPLEMENTED, SOAKING** — code is written and on a branch, awaiting an
+  on-machine run before it counts as done.
+- **PLANNED** — not started.
 
-This matters for planning: because embedding, reranking, and classification already share one Python ONNX runtime, they are cheaper to move **together** (swap the inference layer once) than one feature per release. The milestone plan is reorganized around that.
+Code references (`file.rs:123`) are pointers, not contracts. Line numbers drift
+with every commit; the file and symbol names are the durable part. Where a
+reference matters for a decision, the symbol name is given so it can be found
+again.
 
-## What Actually Shipped (audited 2026-07-18)
+---
 
-Line references are as of the audit and will drift.
+## 2. Status at a glance
 
-**Reliability & migration baseline (original 0.8.2) — DONE**
-- Frontend image/detail queue deadlines with `deadline_exceeded` (`src/lib/monitor_api.js:15-122`).
-- Python `StorageClient` reverse-IPC watchdog with per-phase deadlines and status reporting (`monitor/storage_client.py:105-113,344-497`).
-- Monitor crash recovery via `MonitorRecoveryState` — chose the "recoverable state + restart" option, `policy = manual_restart`, crash counter, `monitor-recovery` events (`src-tauri/src/monitor.rs:44-74`).
-- Non-silent OCR/index failure: screenshot preserved on OCR failure, `screenshot_ocr_status` carries `status` + `postprocess_status/attempts/next_retry` (`storage/schema.rs:162-173`; `capture.rs:1734-1749`); retry command `storage_retry_vector_indexing`.
-- Index health panel wired to UI (`components/settings/storage/IndexHealthCard.jsx` + `storage_get_index_health`).
-- Scheduled HDBSCAN is idle-gated (`monitor/task_clustering.py:1347-1354`).
-- Repo hygiene clean: `git ls-files` shows no tracked db/key/pyz/venv/installer.
+| Milestone | Target | Status | What it is waiting on |
+| --- | --- | --- | --- |
+| M1 — Vector semantics and migration baseline | folded into M2 | **DONE** | — |
+| M2 — Rust ONNX inference and per-kind index ownership | v0.8.4 Beta | **IN PROGRESS** — 5 of 10 cutover steps done | reranker + Smart Cluster scoring (step 6), then CLIP (steps 7-9), then BGE shadow (step 10) |
+| M3 — Smart Cluster worker in Rust | post-v0.8.4 Beta | **PLANNED** (scope reduced) | M2 step 6 |
+| M4 — Task clustering decision | post-M3 | **PLANNED** | M2 (embedding similarity) |
+| M5 — Classification and PII resolution | post-M4 | **PLANNED** | M2-M4 |
+| M6 — Python-free default build | later 0.8.x | **PLANNED** | M1-M5 default and stable for a release |
+| M7 — Infrastructure deletion and simplification | final 0.8.x | **PLANNED** | M6 |
+| Parallel track — Agent skill and MCP | ongoing | **MOSTLY DONE** | settings-page MCP smoke test; per-agent setup variants |
 
-**OCR = Rust default (original 0.8.4 + 0.8.5) — DONE / exceeded**
-- Capture hot path calls Rust OCR directly; status recorded as `engine="rust"` (`capture.rs:1785-1855`). Engine is `rapidocr-core "=0.2.2"` with `directml` feature (`src-tauri/Cargo.toml:74`).
-- Rust OCR runtime has a watchdog timeout that kills a stuck worker (`ml_runtime.rs:216-295`) and a post-process retry loop with a real-failure-only retry budget (`ml_runtime.rs:1143-1270`).
-- Online model repair + status UI (`components/OcrModelRepairCard.jsx`, `settings/advanced/InferenceCards.jsx`).
-- Divergence from the original plan, recorded as debt: there is **no `ocr_engine` config flag and no registry-level Python OCR fallback**; Python OCR recognition is disabled by a runtime handshake (`monitor/ocr_service.py:129`, `_rust_ocr_provider_active`). Dual-run diagnostics were never built.
+---
 
-**ONNX unification + Rust model asset registry (not in original plan) — DONE**
-- `ModelInventoryEntry` reports id / purpose / installed / `active_runtime` (`onnx`|`pytorch`) / size / per-runtime variants; exposed via `get_model_inventory` (`model_management.rs:878-1063,1160`; UI `settings/organize/ModelInventoryTable.jsx`).
-- This over-delivers the original 0.8.3 "ModelRegistry" but only covers assets — there is **no `rust-native` runtime** for anything but OCR.
+## 3. Where the code actually is
 
-**Rust ML contracts (original 0.8.3) — PARTIAL / different shape**
-- `ml_contracts.rs` defines `OcrEngine`/`TextEmbedder`/`Reranker`/`VectorIndex`/`ModelRegistry`, but the four non-OCR traits are deliberate placeholders with no method surface and **no `impl` anywhere** (`ml_contracts.rs:1-4,25-39`). Real OCR bypasses the trait via the worker process + `ml_protocol` IPC.
-- The "bounded job runner" exists only as an OCR-specific narrow implementation (watchdog + post-process retry). There is **no general named-queue runner and no idle gating** in Rust.
+### The migration is two hops, not one
 
-**Agent/MCP track — reached original 0.8.3** (see the parallel-track section).
+The original plan assumed a direct `Python (PyTorch) -> Rust` port, one feature
+per release. What the team actually built is two hops:
 
-## Non-Negotiable Direction
+**Hop 1 — unify everything on ONNX, move model assets to Rust. Done.** All five
+models (OCR PP-OCRv5, Chinese-CLIP, BGE, MiniLM, bge-reranker) are ONNX.
+`use_onnx` defaults to `true` (`commands/utility.rs:146`, `monitor.rs:1440`), and
+when the `CARBONPAPER_USE_ONNX` sentinel is set the Python entry point skips the
+`torch` import entirely (`monitor/main.py:6-20`), which saves roughly 250-400 MB
+of DLL working set. Model registration, install status, sizing, and OCR
+*inference* are Rust-owned. Python is compressed to a thin layer:
+`onnxruntime-directml` inference, ChromaDB, and post-process orchestration.
 
-Unchanged except where the audit forces a correction.
+**Hop 2 — move ONNX inference from Python into Rust. OCR and MiniLM retrieval
+done.** Everything else still runs its ONNX session inside the Python
+`onnxruntime`.
 
-- SQLite-owned screenshots, OCR, and metadata remain the source of truth. Embeddings and ANN indexes are derived caches: they may be persisted and migrated to avoid expensive recomputation, but they must remain versioned, diagnosable, and rebuildable from SQLite-owned inputs. ChromaDB is currently the operational vector store, not an owner of unrecoverable user data.
-- Every cross-thread, IPC, model, and UI request path must have a deadline, cancellation behavior, and user-visible failure state.
-- A Rust replacement is not complete merely because it can load the same ONNX file. Before default cutover it must pass the Python-oracle behavior contract for preprocessing/tokenization, pooling/normalization, response shape, filtering/pagination, ranking quality, lifecycle, and rollback.
-- **Corrected flag rule:** prefer shipping a Rust replacement behind a config flag, then default, then remove the Python fallback a release later. Where a replacement ships default without a flag (as OCR did), it **must** still expose an observable fallback/degrade path and a diagnostic. Track any skipped flag as debt rather than pretending it exists.
-- Heavy ML must use the existing idle policy or an explicit manual-run path. No background model load/inference should surprise a foreground app.
-- **Migration diagnostics are development scaffolding, not product surface.** Shadow comparison toggles, parity probes, and their sample tables exist only to prove one cutover gate. Once that gate is proven and the capability is cut over, they must be removed from the default build before the capability ships in a production (non-beta) release. Shipping one to end users is a defect, not a harmless extra: it exposes a meaningless switch, keeps a second inference path alive on a user's machine, and invites bug reports about numbers no user can act on. Whatever must survive for the "observable fallback" rule is a minimal read-only status field on an existing status command, never a dev panel.
-- Delete infrastructure only after the previous release ran without needing it by default.
-- Model downloads must be explicit, pinned by expected files and hashes where practical, and described as local ML assets.
-- Do not port a Python feature just because it exists. If it is low value, hard to explain, or expensive to maintain, demote or remove it.
+This is why Milestone 2 is organized around a shared runtime rather than one
+feature per release: embedding, reranking, and classification already sit on one
+Python ONNX runtime, so they are cheaper to move by swapping the inference layer
+once than by porting each consumer separately.
 
-## Target End State
+### What Rust owns today
 
-By the end of the `0.8.x` line:
+Capture, OCR, OCR storage, keyword search, thumbnails, the model asset registry,
+task and Smart Cluster persistence, MCP, app lifecycle — and, as of Milestone 2,
+MiniLM semantic-text inference, the derived embedding store, non-reranked
+semantic retrieval, capture-side semantic indexing, and semantic retention.
 
-- Rust owns capture, OCR, OCR storage, keyword search, thumbnails, model registry, task/smart-cluster persistence, MCP, and app lifecycle. *(Already true today except for the ML inference and vector-store layers.)*
+Specifics worth knowing before touching this area:
+
+- **OCR** runs in a standalone `carbonpaper-ml.exe` worker built on the pinned
+  crate `rapidocr-core = "=0.2.2"` with the `directml` feature
+  (`src-tauri/Cargo.toml`). The capture hot path calls it directly and records
+  `engine="rust"` (`capture.rs`). The runtime has a watchdog that kills a stuck
+  worker and a post-process retry loop with a real-failure-only budget
+  (`ml_runtime.rs`).
+- **Semantic inference** runs in a second worker process, reached over a
+  versioned protocol (`ml_protocol.rs`, `semantic_engine.rs`) that exposes
+  `embed_text`, `embed_image`, `rerank`, status, and unload. It deliberately does
+  not share the OCR queue or failure domain.
+- **The trait layer in `ml_contracts.rs` is documentation, not the seam.** The
+  traits (`TextEmbedder`, `ImageEmbedder`, `Reranker`, `VectorIndex`,
+  `ModelRegistry`, `OcrEngine`) now carry real method surfaces, but there is no
+  `impl` of any of them anywhere in the tree — the module is declared
+  `#[allow(dead_code)]` in `lib.rs`. Both OCR and semantic inference bypass the
+  traits via the worker process plus IPC. Treat `ml_contracts.rs` as a written
+  record of the intended boundaries; do not expect to find behavior behind it.
+- **There is still no general named-queue job runner in Rust.** There are three
+  purpose-built ones instead: the OCR watchdog and retry loop, the idle-gated
+  MiniLM index worker (`minilm_index.rs`), and the migration orchestrator
+  (`minilm_migration.rs`). Idle gating exists (`idle.rs`, `IdleState`), but each
+  consumer wires it up for itself.
+
+### What Python still owns today
+
+- **Chinese-CLIP** image and text inference, and the Chroma `screenshots`
+  collection. `search_nl` still forwards to Python (`monitor.rs:600`), and the
+  MCP tool list drops `search_nl` when the Python monitor is not running
+  (`mcp_server.rs:435`, `commands/mcp.rs`).
+- **bge-reranker** inference (`monitor/reranker.py`), which serves both Smart
+  Cluster calibration and the Smart Cluster scoring worker.
+- **BGE classification** (`monitor/classifier.py`), invoked from OCR
+  post-process (`monitor/monitor/worker_process.py`).
+- **HDBSCAN / PaCMAP task clustering** (`monitor/task_clustering.py`), including
+  the `task_vectors` hot layer and the `task_centroids` cold layer.
+- **MiniLM inference in three places that are not the capture path**: the
+  reranked NL query encode (`task_clustering.py:1486`), the hot-layer rebuild
+  (`_backfill_from_screenshots`, `task_clustering.py:1237`), and the Smart
+  Cluster worker's own encode and live-encode fallback
+  (`smart_cluster_worker.py:296,479`).
+- **Presidio NER** as tier 2 of the MCP output PII filter, default-on
+  (`sensitive_filter.rs:73` sets `presidio_enabled: true`; the call site is
+  `mcp_server.rs:825-865`).
+
+### Why the version numbers stopped tracking the plan
+
+Three divergences, all confirmed by reading the shipped tree:
+
+1. **OCR became Rust-default early.** That was the original 0.8.5 target, and it
+   shipped while the app was still on 0.8.3. The planned Python-default beta
+   phase (original 0.8.4) and its dual-run diagnostics were skipped entirely.
+2. **The two-hop reality above** replaced the one-feature-per-release plan.
+3. **The Agent/MCP parallel track ran ahead** and reached the original 0.8.3
+   target on its own schedule.
+
+One consequence is recorded as debt rather than smoothed over: OCR shipped
+default with **no `ocr_engine` config flag and no registry-level Python OCR
+fallback**. Python OCR recognition is switched off by a runtime handshake
+(`monitor/ocr_service.py:129`, `_rust_ocr_provider_active`), which is not a user-
+or operator-reachable rollback. Dual-run diagnostics were never built. Milestones
+2-5 must not repeat that pattern; see the flag rule in section 4.
+
+---
+
+## 4. Rules that bind every milestone
+
+**SQLite is the source of truth.** Screenshots, OCR, and metadata live in
+SQLite. Embeddings and ANN indexes are derived caches: they may be persisted and
+migrated to avoid expensive recomputation, but they must stay versioned,
+diagnosable, and rebuildable from SQLite-owned inputs. ChromaDB is the current
+operational vector store, never an owner of unrecoverable user data.
+
+**Every path has a deadline.** Every cross-thread, IPC, model, and UI request
+path needs a deadline, a defined cancellation behavior, and a user-visible
+failure state.
+
+**Loading the same ONNX file is not parity.** Before a Rust replacement becomes
+the default it must pass the Python-oracle behavior contract for preprocessing
+and tokenization, pooling and normalization, response shape, filtering and
+pagination, ranking quality, lifecycle, and rollback.
+
+**The flag rule.** Ship a Rust replacement behind a config flag, then make it
+the default, then remove the Python fallback one release later. If a replacement
+ships default without a flag — as OCR did — it must still expose an observable
+fallback or degrade path and a diagnostic. A skipped flag is tracked as debt, not
+pretended into existence.
+
+**Heavy machine learning waits for idle, or for the user to ask.** Background
+model loads and inference use the idle policy or an explicit manual-run path. No
+background work should surprise a foreground application. This is a hard
+requirement, not a preference: a foreground game stutter caused by background
+inference is a release blocker.
+
+**Migration diagnostics are scaffolding, not product.** Shadow comparison
+toggles, parity probes, and their sample tables exist to prove one cutover gate.
+Once the gate is proven and the capability is cut over, they are removed from the
+default build before that capability ships in a production (non-beta) release.
+Shipping one to end users is a defect: it exposes a meaningless switch, keeps a
+second inference path alive on the user's machine, and invites bug reports about
+numbers nobody can act on. Whatever must survive for the observable-fallback rule
+is a read-only status field on an existing status command, never a settings panel.
+
+**Delete late.** Remove infrastructure only after the previous release ran
+without needing it by default.
+
+**Model downloads are explicit,** pinned by expected files and hashes where
+practical, and described to the user as local machine-learning assets.
+
+**Do not port a feature just because it exists.** If a Python feature is low
+value, hard to explain, or expensive to maintain, demote or remove it instead —
+but decide that against the *live* consumers, not against what the code looks
+like. The reversed CLIP decision in Milestone 1 is the standing warning here.
+
+---
+
+## 5. Target end state
+
+By the end of the 0.8.x line:
+
+- Rust owns capture, OCR, OCR storage, keyword search, thumbnails, the model
+  registry, task and Smart Cluster persistence, MCP, and app lifecycle. *(Already
+  true, except for the remaining machine-learning inference and vector-store
+  layers.)*
 - Python is not installed by default.
-- `monitor.pyz`, `requirements.txt`, bundled Python installer, pip sync UI, Python venv checks, Python named-pipe server, reverse storage IPC, and Python worker supervision are removed from the default build.
-- Optional legacy/experimental ML features, if kept, are external add-ons rather than part of the core capture pipeline.
+- `monitor.pyz`, `requirements.txt`, the bundled Python installer, the pip sync
+  UI, Python venv checks, the Python named-pipe server, reverse storage IPC, and
+  Python worker supervision are gone from the default build.
+- Any surviving legacy or experimental machine-learning feature is an external
+  add-on, not part of the core capture pipeline.
 
-## Milestone Plan (Revised)
+---
 
-Milestones are ordered. Version hints are estimates. Each keeps the original Purpose / Recommended changes / Release gate shape and adds **Current reality** and **Depends on** so the plan stays honest.
+## 6. Milestones
 
-### Milestone 1 — Vector Semantics & Internal Migration Baseline — MINI, FOLDED INTO M2 PREPARATION
+### Milestone 1 — Vector semantics and migration baseline — DONE
 
-Slimmed on 2026-07-19 after a direct source audit. Key correction to the original framing: ChromaDB holds **no unrecoverable data** — every vector, document, and metadata field is derived from SQLite-owned sources (images + OCR text + window metadata), so "make vector state safe" was already true by construction. What was actually missing was *verifiability* and *scope decisions*. The per-row status ledger and the rebuild executor originally planned here are deliberately **moved to Milestone 2**: a ledger is only trustworthy when the index writer maintains it first-party, and the writer becomes Rust in Milestone 2 — building a Python-driven ledger/rebuilder first would be throwaway scaffolding.
+**Goal.** Decide what the vector collections mean and what is in scope, and
+establish a stable pre/post-migration baseline. This is an internal engineering
+baseline, not a user-facing health feature, so it needed no release of its own
+and landed as the first Milestone 2 preparation branch.
 
-Audit facts this rests on (2026-07-19):
+**Where the code is.** ChromaDB held **no unrecoverable data** — every vector,
+document, and metadata field is derived from SQLite-owned sources (images, OCR
+text, window metadata). "Make vector state safe" was therefore already true by
+construction. What was actually missing was *verifiability* and *scope
+decisions*. The per-row status ledger and the rebuild executor originally planned
+here moved to Milestone 2, because a ledger is only trustworthy when the index
+writer maintains it first-party, and the writer becomes Rust in Milestone 2.
 
-- Three collections, two key schemes: `screenshots` (CLIP image vectors, keyed `md5("memory://" + image_hash)`), `task_vectors` (MiniLM text vectors, keyed `str(screenshot_id)`), `task_centroids` (cold centroids).
-- **Important scope of the Milestone 1 health check:** `actual_clip_image_rows` is only the live row count of the Python Chroma `screenshots` collection — normalized Chinese-CLIP **image embeddings** used by `search_nl` text→image search. It is not the Rust OCR/keyword index, not the MiniLM `task_vectors` collection, not the `task_centroids` collection, and not a check of vector quality or search ranking.
-- `postprocess_status = 'completed'` never meant "vector exists": text-less screenshots skip vector indexing but still complete.
-- `task_vectors` ingest is fire-and-forget with no status anywhere (model-missing / session-locked / queue-full drops are silent); screenshot deletion does not clean it — the 30-day hot-layer expiry is the only reaper.
-- Restart marks unfinished postprocess `discarded` terminally, and the retry button only drains a ≤32-entry in-memory backlog. Both are **confirmed intentional design** (bounded failure, no unbounded retry/IO). Consequence: any rebuild must be explicit, budgeted, and idempotent — delivered in Milestone 2, never as automatic resurrection.
+Audit facts the milestone rests on:
 
-Internal implementation candidate in the current working tree:
+- Three collections, two key schemes: `screenshots` (Chinese-CLIP image vectors,
+  keyed `md5("memory://" + image_hash)`), `task_vectors` (MiniLM text vectors,
+  keyed `str(screenshot_id)`), and `task_centroids` (cold centroids).
+- `postprocess_status = 'completed'` never meant "a vector exists" — text-less
+  screenshots skip vector indexing and still complete.
+- `task_vectors` ingest was fire-and-forget with no status anywhere. Drops from a
+  missing model, a locked session, or a full queue were silent, and screenshot
+  deletion did not clean the collection. The 30-day hot-layer expiry was the only
+  reaper.
+- Restart marks unfinished post-process work `discarded` terminally, and the
+  retry button only drains an in-memory backlog of at most 32 entries. **Both are
+  confirmed intentional** — bounded failure, no unbounded retry or IO storm. The
+  consequence for this plan is that any rebuild must be explicit, budgeted, and
+  idempotent, never automatic resurrection.
 
-- Expected CLIP-image baseline owned by Rust: `count_expected_clip_image_rows` = distinct `image_hash` among non-deleted screenshots with an active OCR row (`storage/screenshot.rs`). This deliberately keeps the same stable proxy for all pre/post migration comparisons; it does not add a temporary schema field that Milestone 2's ledger would immediately replace.
-- Count-level CLIP diagnostic in `storage_get_index_health`: `clip_image_index {expected_eligible_images, actual_rows, missing_lower_bound, orphaned_lower_bound, assessment}`. It is retained only as internal JSON/log/copy-diagnostics input for M2 migration comparisons. The existing user UI is unchanged and does not display the gap or terminal postprocess counts.
-- The purpose is coverage observability for one rebuildable derived cache: detect that CLIP visual search may have fewer eligible image rows than SQLite suggests, or may retain rows for deleted/non-eligible inputs. It does not prove that the vectors are numerically correct, that nearest-neighbor ranking is good, or that the other semantic/task indexes are healthy.
-- `chromadb==1.5.1` pinned (was `>=0.4.0` while 1.5.1 was actually deployed; on-disk format is not stable across majors and the cache is keyed to this version until Milestone 2 replaces it).
+**Work — delivered.**
 
-Decisions recorded (binding for later milestones):
+- `count_expected_clip_image_rows` (`storage/screenshot.rs`) — distinct
+  `image_hash` among non-deleted screenshots that have an active OCR row. A
+  stable proxy usable for pre- and post-migration comparison, deliberately
+  avoiding a temporary schema field that Milestone 2's ledger would replace
+  immediately.
+- A count-level CLIP diagnostic inside `storage_get_index_health`:
+  `clip_image_index { expected_eligible_images, actual_rows, missing_lower_bound,
+  orphaned_lower_bound, assessment }`. Internal only — it feeds JSON, logs, and
+  copy-diagnostics, and the ordinary settings UI does not display the gap.
+- `chromadb==1.5.1` pinned. It was declared `>=0.4.0` while 1.5.1 was actually
+  deployed; the on-disk format is not stable across majors and the cache is keyed
+  to this version until Milestone 2 replaces it.
+- A storage-backed test proving that multiple OCR rows and duplicate image hashes
+  do not inflate the expected CLIP row count.
 
-- **Chinese-CLIP text→image search is retained as a distinct surface — reversal of the earlier demotion.** `search_nl`'s live backend is `search_by_text` (CLIP text encoder → `screenshots` image-vector collection), reachable from two frontend surfaces (`AdvancedSearch.jsx`, `SearchBox.jsx`) and the MCP `search_nl` tool. It is cross-modal — a text query matching a screenshot's *visual* content — which neither the shipped Rust keyword search (`storage/search.rs::search_text`, a blind bigram index over OCR text) nor a future MiniLM-over-OCR semantic search can reproduce. The withdrawn "demote, no Rust port" decision evaluated the two genuinely dead functions (`search_by_image`, `search_by_ocr_text`) and missed the live one. Its valid parts survive as *scoping*, not deletion: CLIP indexing is gated on `ocr_text.strip()` (`worker_process.py:166`), so the retained capability is exactly "text→image over text-bearing screenshots"; and the expensive image re-encode is avoided by **keeping the already-populated collection** — deletion, not retention, is what would force the costly rebuild.
-- **Three labeled search surfaces, not one collapsed NL path.** OCR keyword (Rust, shipped) · semantic text over OCR (MiniLM, → Rust in Milestone 2) · visual/NL image search (CLIP text→image, retained). Different modalities, non-comparable scores; the "two NL surfaces confuse users" problem is solved by clear labeling (Milestone 2 UI copy), not by folding text→image into text→OCR.
-- **This retention makes the internal baseline coherent.** `count_expected_clip_image_rows` counts `DISTINCT image_hash` with an active OCR row (`storage/screenshot.rs`) versus the live `screenshots` count (`get_collection_stats`). Deleting that collection later would have voided the migration baseline.
-- `task_vectors` (MiniLM, keyed `screenshot_id`) and `screenshots` (CLIP, keyed `image_hash`) are **independent collections serving different surfaces** — Milestone 2 re-homes each on its own terms; neither replaces the other. `task_vectors` deletion-orphan rows stay accepted debt (30-day self-expiry) until its Milestone 2 ledger.
-- Discard-on-restart and memory-only retry stay exactly as designed; the Milestone 2 rebuild is the explicit, user-triggered complement that makes discarding lossless.
+What this diagnostic does **not** prove: that the vectors are numerically
+correct, that nearest-neighbor ranking is good, or that the MiniLM and centroid
+indexes are healthy. It detects only that CLIP visual search may cover fewer
+eligible images than SQLite implies, or may retain rows for inputs that are gone.
 
-Internal preparation gate:
+**Binding decisions.** These carry into every later milestone.
 
-- Internal diagnostics can record the same estimated-vs-actual CLIP count before and after migration without changing the ordinary settings UI.
-- The scope decisions above are written down here and reflected in the Milestone 2 plan.
-- A storage-backed test proves multiple OCR rows and duplicate image hashes do not inflate the expected CLIP row count.
-- Keep the unrelated `.github/workflows/release.yml` change out of the migration branch/PR.
+1. **Chinese-CLIP text-to-image search is retained as a distinct surface.** This
+   reverses an earlier decision to demote it. `search_nl`'s live backend is
+   `search_by_text` — the CLIP text encoder scoring against the `screenshots`
+   image-vector collection — reachable from `AdvancedSearch.jsx`, `SearchBox.jsx`,
+   and the MCP `search_nl` tool. It is cross-modal: a text query matching a
+   screenshot's *visual* content. Neither the shipped Rust keyword search
+   (`storage/search.rs::search_text`, a blind bigram bitmap index over OCR text)
+   nor a future MiniLM-over-OCR semantic search can reproduce it. The withdrawn
+   demotion had evaluated two genuinely dead functions (`search_by_image`,
+   `search_by_ocr_text`) and missed the live one.
+   Its valid parts survive as *scoping* rather than deletion: CLIP indexing is
+   gated on `ocr_text.strip()` (`monitor/monitor/worker_process.py:166`), so the
+   retained capability is precisely "text-to-image over text-bearing
+   screenshots"; and the expensive image re-encode is avoided by keeping the
+   already-populated collection, since deletion — not retention — is what would
+   force a costly rebuild.
+2. **Three labeled search surfaces, not one collapsed natural-language path.**
+   OCR keyword (Rust, shipped) · semantic text over OCR (MiniLM, Rust as of
+   Milestone 2) · visual and natural-language image search (CLIP text-to-image,
+   retained). Different modalities with non-comparable scores. The "two
+   natural-language surfaces confuse users" problem is solved by clear labeling,
+   not by folding text-to-image into text-over-OCR.
+3. **`task_vectors` and `screenshots` are independent collections serving
+   different surfaces.** Milestone 2 re-homes each on its own terms; neither
+   replaces the other. `task_vectors` deletion-orphan rows stay accepted debt
+   until the Milestone 2 ledger covers them.
+4. **Discard-on-restart and memory-only retry stay exactly as designed.** The
+   Milestone 2 rebuild is the explicit, user-triggered complement that makes
+   discarding lossless.
 
-Depends on: nothing. This preparation may land as the first `m2/contracts-and-baseline` PR rather than as a separately released milestone.
+**Depends on.** Nothing.
 
-### Milestone 2 — Behavior-Equivalent Rust ONNX + Per-Kind Index Ownership (target: v0.8.4 Beta)
+---
 
-Purpose: complete "hop 2" without changing product capability. Introduce Rust ONNX inference and Rust-owned derived indexes, but cut over **one capability at a time** only after Python-oracle parity, dual-write, shadow query, data migration, foreground-isolation, and rollback gates pass. CLIP text→image, MiniLM semantic-text retrieval, reranking, classification, and unsupervised task clustering are separate consumers even when they share ONNX Runtime; shared runtime code does not justify a big-bang consumer switch.
+### Milestone 2 — Behavior-equivalent Rust ONNX and per-kind index ownership — IN PROGRESS
 
-v0.8.4 Beta delivery shape: the complete M2 implementation is developed in this version, but still lands incrementally. Infrastructure may merge while disabled; MiniLM, reranker, and CLIP each move through `python/chroma -> rust_shadow/dual -> rust with Python fallback`. A capability is part of the v0.8.4 Beta completion claim only after its own release gate passes. BGE classification and `task_centroids` remain explicitly outside the production cutover even though the shared Rust runtime may exercise BGE in shadow mode.
+**Target: v0.8.4 Beta.**
 
-Current reality:
+**Goal.** Complete hop 2 without changing product capability. Introduce Rust
+ONNX inference and Rust-owned derived indexes, and cut over **one capability at a
+time**, each only after its own parity, dual-write, shadow-query, migration,
+foreground-isolation, and rollback gates pass. CLIP text-to-image, MiniLM
+semantic-text retrieval, reranking, classification, and unsupervised task
+clustering are separate consumers even though they share one ONNX Runtime. A
+shared runtime does not justify a big-bang consumer switch.
 
-- `TextEmbedder`/`Reranker` are empty traits; `ml_protocol` only exposes OCR; `search_nl` still forwards to Python (`monitor.rs:600`).
-- Python owns CLIP image/text inference and the `screenshots` collection; MiniLM and the `task_vectors` / `task_centroids` collections still support semantic retrieval and Milestone 4 task clustering; BGE still feeds Python classification; the reranker feeds both calibration and the Python Smart Cluster worker.
-- Therefore "remove Python ONNX + Chroma in Milestone 2" would be a functional regression. Chroma remains available for the still-live task-clustering collections until Milestone 4, and Python BGE remains available until classification has a Rust consumer (Milestone 5) or an explicit Python→Rust inference bridge.
-- Milestone 1's worktree implementation provides only count-level CLIP observability. Milestone 2 upgrades each migrated index kind to subject-level status.
+**Delivery shape.** The complete implementation is developed inside this version
+but lands incrementally as short stacked branches. Infrastructure may merge while
+disabled. Each of MiniLM, the reranker, and CLIP moves through
+`python/chroma -> rust_shadow/dual -> rust with Python fallback`. A capability
+counts toward the v0.8.4 Beta completion claim only after its own gate passes.
 
-#### M2.1 — Freeze the Python behavior contract
+**Explicitly out of scope for this milestone's production cutover:** BGE
+classification and `task_centroids`, even though the shared Rust runtime may
+exercise BGE in shadow mode.
 
-- Build a local, telemetry-free Python oracle/golden harness using non-sensitive fixture text/images. Record and test the exact contracts already shipped:
-  - Chinese-CLIP: RGB conversion; direct square BICUBIC resize; `preprocessor_config.json` rescale/mean/std; tokenizer padding with no truncation; explicit text/image output selection; L2 normalization.
-  - MiniLM: tokenizer max length 256; attention-mask mean pooling; L2 normalization; combined text format `process | title | OCR[:200]`.
-  - BGE: tokenizer max length 512; CLS pooling; L2 normalization.
-  - bge-reranker: pair tokenization; max length 512; raw logits, not sigmoid; variant-specific model file and output.
-  - CLIP search: cosine distance, minimum similarity 0.32, current over-fetch/filter/pagination order, and the existing JSON response fields.
-- Rust token IDs must match exactly. CPU vectors should match to a very tight cosine/absolute-error tolerance; DirectML may use a slightly wider numeric tolerance, but ranking and threshold decisions must remain within the release gate below.
-- Treat known current bugs separately from migration parity. For example, changing NL time/category filtering behavior is an explicit bug fix with tests and release notes, not an accidental consequence of the backend switch.
+**What Milestone 2 cannot do.** Removing Python ONNX and Chroma here would be a
+functional regression. Chroma stays available for the still-live task-clustering
+collections until Milestone 4, and Python BGE stays available until
+classification has a Rust consumer (Milestone 5) or a deliberately supported
+Rust inference bridge.
 
-#### M2.2 — Add a separate Rust semantic runtime
+#### Sub-milestone status
 
-- Implement batch-capable Rust interfaces with real method surfaces: text embedding, image embedding, and reranking. Reuse the pinned model assets and tokenizer JSON files; make input/output tensor names and pooling/preprocessing explicit model descriptors rather than output-name heuristics.
-- Extend the versioned ML protocol with bounded `embed_text`, `embed_image`, `rerank`, status, and unload operations, including maximum batch/token/body limits, deadlines, cancellation behavior, provider/model/version diagnostics, and stable error kinds.
-- Keep OCR on a dedicated high-priority worker/process. Semantic inference must not serialize behind or hold memory inside the OCR critical worker. A separate semantic worker may share executable/runtime code, but not the OCR queue or failure domain.
-- Idle-gate only background capture indexing, rebuild, and maintenance model loads. A user-initiated search/calibration request is foreground/manual work: it remains deadline-bound but must not silently fail merely because the system is not idle.
-- Match the existing ONNX Runtime safety settings or justify/test any change in graph optimization, allocator, file-vs-buffer loading, thread counts, CPU fallback, and DirectML device selection.
+| | Sub-milestone | Status |
+| --- | --- | --- |
+| M2.1 | Freeze the Python behavior contract | **DONE** |
+| M2.2 | Separate Rust semantic runtime | **DONE** |
+| M2.3 | Rust-owned derived embedding storage and ledger | **DONE** 2026-07-21 |
+| M2.4 | Sentinel-triggered MiniLM migration | **DONE** 2026-07-24 |
+| M2.5 | Dual-write, shadow-query, then cut over by capability | **IN PROGRESS** — 5 of 10 steps |
+
+#### M2.1 — Freeze the Python behavior contract — DONE
+
+A local, telemetry-free Python oracle and golden harness over non-sensitive
+fixture text and images (`monitor/oracle/golden-v1.json`), recording and testing
+the contracts already shipped:
+
+- **Chinese-CLIP** — RGB conversion; direct square BICUBIC resize;
+  `preprocessor_config.json` rescale/mean/std; tokenizer padding with no
+  truncation; explicit text/image output selection; L2 normalization.
+- **MiniLM** — tokenizer max length 256; attention-mask mean pooling; L2
+  normalization; combined text format `process | title | OCR[:200]`.
+- **BGE** — tokenizer max length 512; CLS pooling; L2 normalization.
+- **bge-reranker** — pair tokenization; max length 512; **raw logits, not
+  sigmoid**; variant-specific model file and output.
+- **CLIP search** — cosine distance; minimum similarity 0.32; the current
+  over-fetch, filter, and pagination order; the existing JSON response fields.
+
+Rust token IDs must match exactly. CPU vectors must match to a very tight
+cosine and absolute-error tolerance. DirectML may use a slightly wider numeric
+tolerance, but ranking and threshold decisions still have to satisfy the M2.5
+release gate.
+
+Known current bugs are tracked separately from migration parity. Changing
+natural-language time or category filtering, for instance, is an explicit bug fix
+with its own tests and release note — not an accidental consequence of switching
+backends.
+
+#### M2.2 — Add a separate Rust semantic runtime — DONE
+
+- Batch-capable Rust interfaces for text embedding, image embedding, and
+  reranking, reusing the pinned model assets and tokenizer JSON. Input and output
+  tensor names, pooling, and preprocessing are explicit model descriptors
+  (`semantic_models.rs`) rather than output-name heuristics.
+- The versioned ML protocol (`ml_protocol.rs`) carries bounded `embed_text`,
+  `embed_image`, `rerank`, status, and unload operations, with maximum batch,
+  token, and body limits, deadlines, cancellation behavior, provider/model/version
+  diagnostics, and stable error kinds.
+- **OCR keeps its own high-priority worker.** Semantic inference does not
+  serialize behind the OCR critical worker and does not hold memory inside it. The
+  two may share executable and runtime code, never the queue or the failure
+  domain.
+- **Idle gating applies to background work only** — capture indexing, rebuild,
+  and maintenance model loads. A user-initiated search or calibration request is
+  foreground work: deadline-bound, but never refused merely because the machine
+  is in use.
+- ONNX Runtime safety settings match the existing Python ones, or a change to
+  graph optimization, allocator, file-versus-buffer loading, thread counts, CPU
+  fallback, or DirectML device selection is justified and tested.
+
+**Provider constraint recorded here because it shapes later steps.**
+`semantic_engine.rs::provider_supports_model` refuses any non-CPU provider for
+MiniLM and for bge-reranker-v2-m3, following the 2026-07-20 audit that rejected
+DirectML parity for both. The Rust engine also holds **one** model resident
+(`semantic_engine.rs`, `loaded: Option<LoadedModel>`), where the Python reranker
+path keeps two.
 
 #### M2.3 — Rust-owned derived embedding storage and ledger — DONE 2026-07-21
 
-Implementation status: `m2/derived-vector-store` adds the first-party SQLite
-`derived_embeddings` cache, the `(index_kind, subject_key)`
-`derived_index_jobs` ledger, and generation metadata. Vector + completed-ledger
-writes and vector + ledger deletion are transactional. Query-visible reads join
-both tables and require exact model revision, embedding version, and source
-fingerprint agreement, so pending, failed, discarded, invalidated, or partial
-rows cannot leak into search. The generalized keys are `screenshot_id` strings
-for `semantic_text` and `image_hash` for `clip_image`.
+Landed on `m2/derived-vector-store`. Two layers, by design:
 
-Workers claim queued subjects with random execution leases; completion, failure,
-and discard are compare-and-set transitions against the active lease, and commits
-also require the referenced screenshot or image hash to remain active. This
-prevents late workers from resurrecting deleted/discarded work or hiding a
-newer completion. Startup requeues any `processing` lease left behind by an
-interrupted process so rebuilds remain resumable after crashes.
+1. **A SQLite `derived_embeddings` cache** holding the migrated or generated
+   float32 vector plus `index_kind`, `subject_key`, dimensions, model id and
+   revision, embedding version, source fingerprint, and timestamps.
+2. **A generation-versioned ANN sidecar** used purely as a rebuildable
+   acceleration layer, written via temporary file, fsync, and atomic replace, and
+   validated by header and checksum. It is never authoritative.
 
-The branch also publishes immutable, checksummed `.cpdvec` generations through
-temporary-file fsync and atomic rename. The initial payload is a flat exact-scan
-snapshot; SQLite remains authoritative, and the payload can be replaced by an
-ANN layout when the M2.5 query path needs it without changing persistence or
-generation semantics. Runtime publication never deletes finalized sidecars;
-unreferenced generations are cleaned during the next startup, before readers
-are exposed. M2.4 owns the paged MiniLM migration and the temporary
-Chroma/Rust index dual-write; M2.5 owns shadow queries, production query
-cutover, and the later CLIP overlap.
+Persisting derived vectors is what avoids an expensive CLIP re-encode during
+migration, and it gives ledger and vector writes one transactional boundary.
 
-- Prefer a two-layer derived design:
-  1. a SQLite `derived_embeddings` cache holding the migrated/generated float32 vector plus `index_kind`, `subject_key`, dimensions, model id/revision, embedding version, source fingerprint, and timestamps;
-  2. a generation-versioned ANN sidecar used only as a rebuildable acceleration layer, written via temporary file + fsync + atomic replace and validated by header/checksum.
-  SQLite screenshots/OCR/metadata remain the source inputs. Persisting derived vectors avoids expensive CLIP re-encoding during migration and gives ledger/vector writes one transactional boundary; the ANN file is never authoritative.
-- Use a generalized subject key rather than `(screenshot_id, index_kind)`:
-  - `text_embedding` → `subject_key = screenshot_id`;
-  - `image_embedding` → `subject_key = image_hash`.
-- Ledger sketch: `derived_index_jobs(index_kind, subject_key, status, error_code, error, attempts, next_retry_at, model_id, model_revision, embedding_version, source_fingerprint, updated_at)`, PK `(index_kind, subject_key)`. `discarded` remains legal and visible; rebuild is explicit, never automatic resurrection.
-- New vectors become query-visible only after the embedding row and completed ledger state commit. ANN generation lag must be safe: queries use the last complete generation plus a bounded exact-scan delta, or wait for an atomic generation swap.
-- Deletion, model-version invalidation, duplicate image hashes, session lock/unlock, and interrupted writes need first-party tests.
+**Generalized subject keys** rather than `(screenshot_id, index_kind)`:
+`semantic_text` uses the `screenshot_id` as a string, `clip_image` uses the
+`image_hash`.
+
+**The ledger** is `derived_index_jobs(index_kind, subject_key, status,
+error_code, error, attempts, next_retry_at, model_id, model_revision,
+embedding_version, source_fingerprint, updated_at)` with primary key
+`(index_kind, subject_key)`. `discarded` is a legal, visible state; rebuild is
+explicit and never automatic resurrection.
+
+**Visibility and safety properties, all first-party tested:**
+
+- Vector plus completed-ledger writes, and vector plus ledger deletion, are
+  transactional. Query-visible reads join both tables and require exact
+  agreement on model revision, embedding version, and source fingerprint, so
+  pending, failed, discarded, invalidated, or partial rows cannot leak into
+  search results.
+- Workers claim queued subjects with random execution leases. Completion,
+  failure, and discard are compare-and-set transitions against the active lease,
+  and a commit additionally requires the referenced screenshot or image hash to
+  still be active. A late worker therefore cannot resurrect deleted or discarded
+  work, nor hide a newer completion.
+- Startup requeues any `processing` lease left behind by an interrupted process,
+  so a rebuild stays resumable across crashes.
+- Runtime publication of a `.cpdvec` generation never deletes a finalized
+  sidecar. Unreferenced generations are cleaned during the next startup, before
+  readers are exposed.
+- Deletion, model-version invalidation, duplicate image hashes, session lock and
+  unlock, and interrupted writes each have tests.
+
+The initial sidecar payload is a flat exact-scan snapshot. SQLite remains
+authoritative, so the payload can be replaced by an ANN layout later without
+changing persistence or generation semantics.
 
 #### M2.4 — Sentinel-triggered MiniLM migration — DONE 2026-07-24
 
-The Chroma `task_vectors` collection is a ~30-day hot layer whose expired
-vectors are compressed into `task_centroids`, so "every SQLite screenshot has
-a MiniLM vector" is **not** a migration completion condition, and the Rust
-coverage denominator for the later cutover gate is the set of valid, mappable
-vectors in the Chroma snapshot — not all screenshots.
+**What the migration is copying.** The Chroma `task_vectors` collection is a
+roughly 30-day hot layer whose expired vectors are compressed into
+`task_centroids`. So "every SQLite screenshot has a MiniLM vector" is **not** a
+completion condition, and the coverage denominator for the later cutover gate is
+the set of valid, mappable vectors in the Chroma snapshot — not the set of all
+screenshots.
 
-The mandatory copy is entirely sentinel-triggered. For each vector-space
-revision, the absence of
-`app_metadata.minilm_auto_migration_done_<revision>` starts one full-scope,
-idempotent copy at startup. The worker waits for Windows Hello unlock before
-reading encrypted OCR inputs. A crash, process exit, or transient worker
-failure leaves the sentinel unset; the next launch/unlock resumes from the
-durable cursor and snapshot. Legacy manual/time-bounded run records are never
-resumed or allowed to settle the sentinel; the automatic mode starts a fresh
-full copy instead.
-Terminally quarantined invalid/orphan rows may finish as
-`completed_with_errors` and still settle the sentinel; transient orchestration
-failures remain unfinished and retry automatically.
+**Triggering.** Entirely sentinel-driven. For each vector-space revision, the
+absence of `app_metadata.minilm_auto_migration_done_<revision>` starts one
+full-scope, idempotent copy at startup. The worker waits for Windows Hello unlock
+before reading encrypted OCR inputs. A crash, process exit, or transient worker
+failure leaves the sentinel unset, and the next launch or unlock resumes from the
+durable cursor and snapshot. Legacy manual or time-bounded run records are never
+resumed and never allowed to settle the sentinel; the automatic mode starts a
+fresh full copy instead. Terminally quarantined invalid or orphan rows may finish
+as `completed_with_errors` and still settle the sentinel, whereas transient
+orchestration failures stay unfinished and retry automatically.
 
-The whole run executes under global maintenance mode: a non-dismissable
-full-window overlay, `MAINTENANCE_IN_PROGRESS` rejection at MCP and reverse
-IPC boundaries (with a small session/crypto/status/dual-write allowlist),
-gated monitor start/stop/pause/resume commands, and a paused
-retention/delete-queue loop. Capture is paused for the duration; the previous
-monitor running/paused state is recorded and restored exactly. The migration
-cannot be started from settings and cannot be cancelled; closing the app is
-the only interruption.
+**Maintenance mode, and its cost.** The whole run executes under global
+maintenance mode: a non-dismissable full-window overlay,
+`MAINTENANCE_IN_PROGRESS` rejection at the MCP and reverse-IPC boundaries (with a
+small session, crypto, and status allowlist in
+`maintenance.rs::reverse_ipc_command_allowed`), gated monitor
+start/stop/pause/resume commands, and a paused retention and delete-queue loop.
+The migration cannot be started from settings and cannot be cancelled; closing
+the app is the only interruption.
 
-The full hot-layer ID snapshot is built asynchronously by an internal Python
-protocol (`start_task_vectors_export` → status polling → exact-id pages →
-`finish_task_vectors_export`), persisted with an atomically renamed manifest
-under `data/migrations/minilm/<export_id>/`, and bounded by a 10-minute logical
-build deadline plus 24 h idle / 7 d hard / 1 h `.tmp` TTLs. It has no
-user-facing time range or cancellation option.
+**Capture is paused for the duration.** The previous monitor running or paused
+state is recorded and restored exactly, but screenshots that would have been
+taken during the run are not taken. This is the first maintenance operation in
+the app that stops capture, and it is accepted deliberately: the alternative is
+letting new captures race a rewrite of the store they are being written into.
+Keeping the run short is therefore a correctness-adjacent concern, not just a
+polish one.
+
+**The snapshot.** The full hot-layer ID snapshot is built asynchronously by an
+internal Python protocol (`start_task_vectors_export` -> status polling -> exact
+ID pages -> `finish_task_vectors_export`), persisted with an atomically renamed
+manifest under `data/migrations/minilm/<export_id>/`, and bounded by a 10-minute
+logical build deadline plus 24-hour idle, 7-day hard, and 1-hour `.tmp` TTLs.
+There is no user-facing time range and no cancellation.
+
 Pages carry vectors as one little-endian float32 blob in Base64
-(`embeddings_f32_le_b64`, ~256 KB per 128-row page) instead of tens of
-thousands of JSON floats. Run state is durable in
-`minilm_migration_runs` / `minilm_migration_subjects` /
-`minilm_migration_run_errors`: each page commits ledger rows, embeddings,
-counters, and the export cursor in one transaction, so a crash either retries
-an uncommitted page or continues after it, and an interrupted run resumes by
-re-attaching to the persisted snapshot (a snapshot Python can no longer
-restore forces a cursor reset rather than a silently reordered page walk).
-Rust accepts only canonical positive screenshot ids and finite, non-zero
-384-dimensional vectors (zero vectors are quarantined, never imported), maps
-them to active SQLite screenshots, and rehydrates process/title/category/OCR
-from SQLite. A valid legacy vector whose current SQLite text is empty is still
-copied but marked `legacy_chroma_unverified` instead of being recomputed.
-Orphan Chroma ids, corrupt vectors, and rows that disappear after the snapshot
-remain persisted diagnostics and yield `completed_with_errors`. After the
-copy, a full-scope run deletes Rust `semantic_text` rows outside the snapshot
-scope (`reconcile`), and Python's hot-layer expiry now mirrors deletions to
-Rust through reverse IPC with a persisted retry queue, so the Rust collection
-tracks — rather than outgrows — the Chroma hot layer. A disk preflight
-(`estimated peak × 1.25 + 1 GiB`, with a 64 MiB transient allowance) rejects
-the run before any vector write; generation publication runs on a blocking
-worker with progress phases `publishing_sync` / `publishing_verify` /
-`publishing_commit`. The migration never requests cancellation; the final
-`sync_all` window is surfaced to the user as an uninterruptible safe write.
+(`embeddings_f32_le_b64`, roughly 256 KB per 128-row page) rather than as tens of
+thousands of JSON floats.
 
-The MiniLM source contract remains exactly `process | title | OCR[:200]`; its
-versioned fingerprint excludes category and is computed from the final
-Rust-rehydrated model input. Legacy Chroma rows do not record their producing
-runtime, so imported and newly generated vectors share the reviewed
-compatibility contract `minilm-l12-vector-space-v1`. Python capture paths
-best-effort dual-write their vectors to Rust through authenticated reverse IPC;
-Rust ignores Python metadata and recomputes the fingerprint. The migration
-never runs inference to manufacture a missing vector.
-Chroma/Python remains the authoritative query backend in this phase: there is
-no shadow-query or production-query switch in M2.4.
+**Durability.** Run state lives in `minilm_migration_runs`,
+`minilm_migration_subjects`, and `minilm_migration_run_errors`. Each page commits
+ledger rows, embeddings, counters, and the export cursor in one transaction, so a
+crash either retries an uncommitted page or continues past it, and an interrupted
+run resumes by re-attaching to the persisted snapshot. A snapshot Python can no
+longer restore forces a cursor reset rather than a silently reordered page walk.
 
-`task_centroids` and all Chroma operations needed by Python HDBSCAN/PaCMAP stay
-unchanged until Milestone 4. The separate CLIP `screenshots` float-copy
-migration remains step 7 of M2.5, immediately before CLIP new-capture
-dual-write and shadow query. `chromadb` therefore remains a default dependency.
+**Validation and mapping.** Rust accepts only canonical positive screenshot IDs
+and finite, non-zero 384-dimensional vectors — zero vectors are quarantined,
+never imported. It maps them to active SQLite screenshots and rehydrates
+process, title, category, and OCR from SQLite. A valid legacy vector whose
+current SQLite text is empty is still copied, marked
+`legacy_chroma_unverified` rather than recomputed. Orphan Chroma IDs, corrupt
+vectors, and rows that disappear after the snapshot remain persisted diagnostics
+and yield `completed_with_errors`. **The migration never runs inference to
+manufacture a missing vector.**
 
-#### M2.5 — Dual-write, shadow-query, then cut over by capability
+**Reconciliation.** After the copy, a full-scope run deletes Rust
+`semantic_text` rows outside the snapshot scope. During this phase Python's
+hot-layer expiry mirrors its deletions to Rust through reverse IPC with a
+persisted retry queue, so the Rust collection tracks rather than outgrows the
+Chroma hot layer. *(Step 5 later reverses the direction of ownership and removes
+this mirror.)*
 
-Recommended sequence:
+**Operational bounds.** A disk preflight (estimated peak × 1.25 + 1 GiB, with a
+64 MiB transient allowance) rejects the run before any vector write. Generation
+publication runs on a blocking worker with progress phases `publishing_sync`,
+`publishing_verify`, and `publishing_commit`. The final `sync_all` window is
+surfaced to the user as an uninterruptible safe write.
 
-1. MiniLM Rust inference parity.
-2. MiniLM derived-cache/index dual-write and migration. **Done in M2.4.**
-3. Rust semantic shadow queries compared locally with Chroma; Python remains authoritative. **Harness done 2026-07-27** — passive per-query shadow, an active built-in query corpus, and a document-encoder re-encode probe, reported through the telemetry-free `get_semantic_shadow_report`. The whole surface is temporary by construction; see the retirement block below.
-4. Cut over the **non-reranked** semantic-text retrieval path to `semantic_index = rust`; keep rollback. Calibration is deliberately *not* included — see the scope note below.
-5. Rust capture-side MiniLM indexing and retention ownership: new screenshots are encoded and enqueued by Rust, and hot-layer expiry is decided by Rust rather than mirrored from Python. Without this, `semantic_index = rust` means "Rust reads, Python writes".
-6. Reranker parity and shadow scoring; then cut over Smart Cluster calibration, which moves as one unit with the reranker. The Python Smart Cluster worker may temporarily call the Rust reranker, but its Python fallback remains until Milestone 3.
-7. CLIP vector export/migration.
-8. Rust CLIP image encoder dual-write for new captures. **Do not cut over visual search while new screenshots still depend solely on Python image encoding.**
-9. Rust CLIP text-query shadow mode, then cut over `search_nl` and MCP capability reporting.
-10. Implement BGE in the shared Rust runtime and run it in shadow mode, but do not remove Python BGE inference until classification itself has a Rust path or a deliberately supported Rust inference bridge. The classification consumer remains a Milestone 5 completion item.
+**Contract.** The MiniLM source contract stays exactly `process | title |
+OCR[:200]`. Its versioned fingerprint excludes category and is computed from the
+final Rust-rehydrated model input. Legacy Chroma rows do not record which runtime
+produced them, so imported and newly generated vectors share the reviewed
+compatibility contract `minilm-l12-vector-space-v1`.
 
-Step-4 scope: retrieval only, not calibration (recorded 2026-07-28). The earlier
-plan said step 4 cuts over "semantic-text retrieval and Smart Cluster
-calibration prefilter". In the shipped code those are not separable at this
-step. Calibration mode forces `enableRerank = true` because it needs
-`rerank_score` to derive a per-cluster threshold (`NlClusterView.jsx:94-95`),
-and Python's `query_by_text` performs retrieval and reranking in one call
-(`task_clustering.py:1657-1701`) with no standalone rerank command on the
-protocol. Cutting over the calibration prefilter alone would therefore mean
-adding a Rust-retrieve → Python-rerank bridge that exists for exactly one
-release and is deleted at step 6 — more new surface than it saves, on the one
-path where a ranking mistake silently corrupts a saved threshold. So step 4
-cuts over `enable_rerank = false` only; `enable_rerank = true` continues to run
-entirely on Python and moves at step 6, where the end-to-end reranked ordering
-is re-measured anyway.
+**What M2.4 does not do.** Chroma and Python remain the authoritative query
+backend throughout this phase — there is no shadow-query or production-query
+switch here. `task_centroids` and all Chroma operations needed by Python HDBSCAN
+and PaCMAP stay unchanged until Milestone 4, so `chromadb` remains a default
+dependency.
 
-Step-4 defaults and rollback levers. The cutover flips the *defaults* of both
-enums to `rust`, not merely the set of legal values — a "cutover" that left
-`semantic_index` defaulting to `chroma` would ship a switch nobody flips. This
-is safe on a machine whose M2.4 migration has not run, because an empty Rust
-index is treated as a fallback condition and the query is served from Python.
+#### M2.5 — Dual-write, shadow-query, then cut over by capability — IN PROGRESS
+
+The cutover sequence, with status:
+
+| Step | Work | Status |
+| --- | --- | --- |
+| 1 | MiniLM Rust inference parity | **DONE** |
+| 2 | MiniLM derived-cache dual-write and migration | **DONE** (M2.4) |
+| 3 | Rust semantic shadow queries against Chroma, Python authoritative | **DONE** 2026-07-27, harness since retired |
+| 4 | Cut over the **non-reranked** semantic-text retrieval path | **DONE**, merged |
+| 5 | Rust capture-side MiniLM indexing and retention ownership | **IMPLEMENTED, SOAKING** on `m2/minilm-capture-indexing` |
+| 6 | Reranker parity and shadow scoring, then cut over Smart Cluster calibration **and the scoring worker together** | **NEXT** — `m2/reranker-shadow-cutover` |
+| 7 | CLIP vector export and migration | PLANNED |
+| 8 | Rust CLIP image-encoder dual-write for new captures | PLANNED |
+| 9 | Rust CLIP text-query shadow mode, then cut over `search_nl` and MCP capability reporting | PLANNED |
+| 10 | BGE in the shared Rust runtime, shadow mode only | PLANNED |
+
+Two ordering constraints are load-bearing. **Step 8 precedes step 9:** do not cut
+over visual search while new screenshots still depend solely on Python image
+encoding, or old data will be searchable while new captures silently stop being
+indexed. **Step 10 does not remove Python BGE:** the classification consumer is a
+Milestone 5 item, and Python BGE inference stays until classification has a Rust
+path or a deliberately supported Rust inference bridge.
+
+##### Step 3 — measured result (2026-07-27)
+
+Over 256-query and 256-document samples: query-encoder maximum absolute error
+6.0e-7; Overlap@10 p50 100%, p05 50%; top-1 agreement 90.7%; document re-encode
+cosine p50 0.9917, p05 0.9868, min 0.9796.
+
+Retrieval divergence is dominated by Rust returning documents the Chroma
+approximate-nearest-neighbor path does not surface. The Rust side is an exact
+scan over the same hot layer, so a strict superset of recall is the expected
+outcome, and it was accepted as a difference in retrieval *method* rather than a
+Rust defect.
+
+Recorded honestly: this clears the query-encoder numeric gate but not the
+*original literal* wording of "top-10 overlap at least 99%, top-1 effectively
+unchanged", which assumed two implementations of the same retrieval method. That
+wording is superseded in the release gate below rather than waived.
+
+The 0.83 document-encoder figure seen in an earlier report was a measurement
+artifact, not a divergence: the probe read OCR blocks in geometric order
+(`ORDER BY box_y1`) while the write path encoded them in engine order. The fix
+was to match engine order on the rebuild side. Production clustering vectors were
+never affected.
+
+##### Step 4 — non-reranked retrieval cutover — DONE
+
+`semantic_query.rs` serves the non-reranked natural-language query from a Rust
+MiniLM query encode plus an exact cosine scan over the migrated derived store,
+rehydrating response metadata from SQLite.
+
+**Scope: retrieval only, not calibration.** An earlier version of this plan had
+step 4 cutting over "semantic-text retrieval and Smart Cluster calibration
+prefilter". In the shipped code those are not separable here. Calibration always
+reranks — `NlClusterView.jsx` initializes `enableRerank` from `isCalibrate` and
+renders the toggle only in the non-calibrate branch, so a calibration session has
+no way to turn it off — because it needs `rerank_score` to derive a per-cluster
+threshold. And Python's `query_by_text` (`task_clustering.py:1433`) performs
+retrieval and reranking in one call, with no standalone rerank operation on the
+protocol. Cutting over the calibration prefilter alone would mean building a
+Rust-retrieve-then-Python-rerank bridge that exists for exactly one release and
+is deleted at step 6 — more new surface than it saves, on the one path where a
+ranking mistake silently corrupts a saved threshold. So step 4 cuts over
+`enable_rerank = false` only. `enable_rerank = true` continues to run entirely on
+Python and moves at step 6, where the end-to-end reranked ordering is re-measured
+anyway.
+
+**Defaults and rollback levers.** The cutover flips the *defaults* of both enums
+to `rust`, not merely the set of legal values — a cutover that left
+`semantic_index` defaulting to `chroma` would ship a switch nobody flips. This is
+safe on a machine whose M2.4 migration has not run, because an empty Rust index
+is a fallback condition and the query is served from Python.
+
 Two independent levers restore the previous behavior for the one required
-release: `semantic_index = chroma` (Python owns retrieval) and
-`semantic_runtime = python` (no Rust MiniLM inference). The second is honored as
-a refusal rather than silently overridden, because serving from the Rust store
-necessarily encodes the query with the Rust runtime. Every refusal is recorded
-with its reason and read back through `get_ml_semantic_status.backend`, which
-the Settings → Advanced "semantic retrieval backend" card renders together with
-the `semantic_index` switch, so both the diagnostic and the rollback are
-reachable without a registry editor.
+release:
 
-Step-4 coverage rule (recorded 2026-07-28, extended 2026-07-29 after review).
-An empty Rust index falls back, but a *partially* filled one would not, and that
-is the failure this step actually has to defend against: ranking an incomplete
-corpus returns a plausible page with screenshots silently missing from it, which
-no user can detect and no after-the-fact instrument can reconstruct. Three
-things can leave the index short, and each has its own refusal.
+- `semantic_index = chroma` — Python owns retrieval.
+- `semantic_runtime = python` — no Rust MiniLM inference at all. This is honored
+  as a *refusal* rather than silently overridden, because serving from the Rust
+  store necessarily encodes the query with the Rust runtime.
 
-*The migration may not have finished.* The M2.4 copy commits page by page
-against a persisted cursor, and a migrated row becomes query-visible the moment
-its job row reaches `completed` — there is no generation gate in front of the
-read path. A run that fails mid-session drops the maintenance guard and does not
-retry until the next launch, so the rest of that session would otherwise serve a
-prefix of the corpus. The once-per-revision sentinel therefore gates retrieval
-too (`last_fallback_reason = migration_incomplete`), cached in-process because it
-is a one-way transition.
+Every refusal is recorded with its reason and read back through
+`get_ml_semantic_status.backend`, which the Settings → Advanced "semantic
+retrieval backend" card renders alongside the `semantic_index` switch. Both the
+diagnostic and the rollback are reachable without a registry editor.
 
-*A mirror may have been lost.* The Python dual-write is durable — a mirror that
-fails is queued to `migrations/minilm/rust-import-retry.json` and retried from
-Chroma on the next capture or clustering pass, the same treatment hot-layer
-deletions already had. The size of that queue travels with every dual-write, so
-the Rust read path knows when its copy is behind and refuses to serve until the
-backlog is paid (`last_fallback_reason = index_incomplete`). Because the Rust
-counter is process-global and starts at zero, Python also reports the queue it
-loads off disk at monitor startup, and again after every retry pass including
-the ones that wrote nothing — otherwise a backlog that survived an app restart
-would be invisible to Rust until the next capture happened to write, which with
-the monitor paused is never.
+**Coverage is the failure mode this step defends against.** An empty Rust index
+falls back, but a *partially* filled one would not, and ranking an incomplete
+corpus returns a plausible page with screenshots silently missing from it —
+something no user can detect and no after-the-fact instrument can reconstruct.
+Two conditions can leave the local store a prefix of a corpus somebody else holds
+in full, and each keeps its refusal:
 
-*The debt must stay payable.* Only mirrors that can still arrive count. Chroma
-keeps documents for screenshots the user deleted until they age out (Python
-prunes the hot layer on age alone), so a queued id can become one Rust rejects
-every time it is offered. Rust therefore classifies each rejected row as
-permanent or transient, Python drops the permanent ones instead of queueing
-them, and a retry pass no longer stops at the first failing batch. Without this
-a single deleted screenshot would hold the debt above zero — and Rust retrieval
-switched off — for as long as the queue survived.
+- **`migration_incomplete`** — the M2.4 copy has not finished. It commits page by
+  page and a migrated row becomes query-visible the moment its job row reaches
+  `completed`; there is no generation gate in front of the read path. A run that
+  fails mid-session drops the maintenance guard and does not retry until the next
+  launch, so the rest of that session would otherwise serve a prefix. The
+  once-per-revision sentinel gates retrieval too, cached in-process because it is
+  a one-way transition.
+- **`rust_index_empty`** — the store is empty outright, which is the unmigrated
+  machine.
 
-This is what replaces the deleted shadow harness's `only_in_chroma` metric as a
-*runtime* guard; the release gate below still expects the offline measurement
-before the step is called done. One residual window remains, recorded honestly:
-while the reverse-IPC pipe itself is down, Python cannot report the debt it is
-accumulating, so the Rust index can be behind without knowing it until the pipe
-recovers. Step 5 removes the reporting problem altogether by making Rust the
-writer.
+A third refusal, `index_incomplete`, existed in step 4 and was removed by step 5;
+the reasoning is in the step-5 section.
 
-Step-5 scope: why an extra step exists (recorded 2026-07-28). The numbered
-sequence had no Rust capture-side MiniLM indexing step, even though the M2.5
-release gate requires that "with Python stopped … new-capture Rust CLIP/MiniLM
-indexing continue to work". CLIP got such a step (now step 8); MiniLM was
-skipped. In the shipped code the only writers of `semantic_text` rows are the
-M2.4 migration and the Python dual-write over reverse IPC
-(`reverse_ipc.rs`), and the only reaper is Python's hot-layer expiry mirroring
-its deletions to Rust. Rust can already embed (`semantic_runtime::embed_text`),
-but nothing calls it for a new screenshot. So step 4 delivers `semantic_index =
-rust` in the honest sense of "Rust owns the read path", not "Rust owns the
-index". Step 5 closes that: an idle-gated Rust enqueue/drain worker on the
-capture path plus Rust-owned retention, after which the "Python stopped" gate
-can genuinely be evaluated. Until then the capability is advertised as
-Rust-read / Python-written, per the honest-advertisement rule.
+**Behavior difference, recorded as a bug fix.** Python reads process, title,
+timestamp, and category out of Chroma metadata, so a screenshot deleted after
+indexing is still rendered from a stale copy. Rust reads them from SQLite and
+drops rows that no longer map to an active screenshot, which means a Rust
+response can be shorter than `n_results` where the Python one was not. This
+belongs in the release notes.
 
-Step-3 measurement (2026-07-27, 256-query and 256-document samples): query-encoder
-maximum absolute error 6.0e-7; Overlap@10 p50 100%, p05 50%; top-1 agreement
-90.7%; document re-encode cosine p50 0.9917 / p05 0.9868 / min 0.9796. Retrieval
-divergence is dominated by Rust returning documents the Chroma ANN path does not
-surface — the Rust side is an exact scan over the same hot layer, so a strict
-superset of recall is expected and was accepted as a difference in retrieval
-method rather than a Rust defect. Recorded honestly: this clears the query-encoder
-numeric gate but not the *original literal* "top-10 overlap ≥ 99% / top-1
-effectively unchanged" wording, which assumed two implementations of the same
-retrieval method; that wording is superseded below rather than waived. The
-step-4 cutover therefore keeps the `python` fallback and should re-check ranking
-on the reranked end-to-end path (step 6), where the bi-encoder recall difference
-is re-scored anyway.
+**Shadow scaffolding was retired with this step, as the rule requires.** Deleted:
+`semantic_shadow.rs` and `storage/semantic_shadow.rs`; the
+`semantic_shadow_samples` and `semantic_doc_encoder_runs` tables, now dropped in
+`storage/schema.rs`; `SemanticShadowCard` and its wiring in `AdvancedSection.jsx`
+and `useAdvancedSectionController.js`; the three shadow Tauri commands; the
+`rust_shadow` value of `semantic_runtime`, which now normalizes to the shipped
+default like any unrecognized string.
 
-- Use enum backends, not ambiguous booleans: `semantic_runtime = python|rust_shadow|rust`, `semantic_index = chroma|dual|rust`, `clip_runtime = python|rust_shadow|rust`, `clip_index = chroma|dual|rust`. Invalid or unavailable Rust configurations fall back observably for one release, with a local diagnostic explaining why.
-- Preserve and explicitly test search response schemas, filters, offsets, limits, thresholds, MCP tool availability, and frontend labels. OCR keyword, MiniLM semantic text, CLIP visual/NL image search, and Smart Cluster assignment remain separately labeled; their scores are not compared across models.
+Explicitly **not** scaffolding — this is the production read path and stays:
+`derived_index::semantic_text_topk`, `ScoredSubject`,
+`count_query_visible_embeddings`; `storage/semantic_cache.rs` (the resident
+vector matrix), its `StorageState` fields, the idle-eviction ticker in `lib.rs`,
+and the cache resets in `storage/schema.rs`; the `semantic_runtime` and
+`semantic_index` enums themselves, minus the retired value, since they are the
+observable rollback switch. `minilm_index::minilm_sources` was the
+document-encoder probe's source builder and is now the capture worker's — it is
+production code.
 
-##### Shadow-scaffolding retirement — release-blocking, not optional cleanup
+##### Step 5 — Rust capture-side indexing and retention — IMPLEMENTED, SOAKING
 
-Every `rust_shadow` harness in this milestone is a development instrument with a
-scheduled death. It proves one gate, and then it goes. A production (non-beta)
-release must not contain the shadow toggle or its probes for a capability that
-has already cut over. Enforce this per capability, at the cutover PR, rather
-than as an end-of-milestone sweep — an unowned diagnostic panel never gets
-deleted later.
+**Why this step exists.** The numbered sequence originally had no Rust
+capture-side MiniLM indexing step, even though the M2.5 release gate requires
+that "with Python stopped, new-capture Rust CLIP and MiniLM indexing continue to
+work". CLIP got such a step (now step 8); MiniLM was skipped. Before this step,
+the only writers of `semantic_text` rows were the M2.4 migration and the Python
+dual-write over reverse IPC, and the only reaper was Python's hot-layer expiry
+mirroring its deletions across. Rust could already embed, but nothing called it
+for a new screenshot. So step 4 delivered `semantic_index = rust` in the honest
+sense of "Rust owns the read path", not "Rust owns the index". Step 5 closes
+that, after which the "Python stopped" gate can genuinely be evaluated.
 
-MiniLM instance of the rule. Shadow-only, delete with (or immediately after)
-the step-4 cutover:
+**What landed.**
 
-- `semantic_shadow.rs` — `spawn_shadow_sample`, `run_semantic_shadow_probe`, `run_semantic_doc_encoder_probe`, the built-in probe corpus, and the single-flight guards; the `spawn_shadow_sample` call site in `monitor.rs::monitor_nl_cluster_query`; the three Tauri commands registered in `lib.rs`.
-- `storage/semantic_shadow.rs` and the `semantic_shadow_samples` / `semantic_doc_encoder_runs` tables plus their in-place column upgrades in `storage/schema.rs`. Dropping these tables loses no user data — they hold query hashes and parity/latency numbers only, never query text or screenshot content.
-- `SemanticShadowCard` in `settings/advanced/InferenceCards.jsx`, its wiring in `AdvancedSection.jsx`, and the report/probe state in `useAdvancedSectionController.js`.
-- `minilm_migration::minilm_sources_for_ids`, whose only caller is the document-encoder probe.
-- The `rust_shadow` value of `semantic_runtime` once nothing can enter that mode.
+- `minilm_index.rs` — the capture path enqueues a `semantic_text` ledger job on
+  the OCR commit. An idle-gated worker claims, encodes, and commits vector and
+  ledger in one transaction, queues the Smart Cluster pending entry, and mirrors
+  the finished row into Chroma through the existing `upsert_task_vectors`
+  command. The same worker ages rows out at 30 days and re-queues screenshots
+  whose enqueue never ran.
+- `semantic_query.rs` — the `index_incomplete` refusal is gone. The ledger depth,
+  the count of jobs whose retry budget is spent, and the age of the oldest
+  waiting screenshot are reported instead, and Settings → Advanced shows them.
+  `migration_incomplete` and `rust_index_empty` stay.
+- Python — `add_snapshot`, the dual-write, the durable import-retry journal, the
+  delete mirror, and the capture-path clustering ingest queue are removed, along
+  with the three reverse-IPC handlers that served them. `HotColdManager` keeps
+  the hot layer as a *consumer*: clustering reads it, `compress_to_cold` ages it,
+  and `_backfill_from_screenshots` rebuilds it when it is found empty.
 
-Explicitly **not** shadow scaffolding — this code is the production read path and stays:
+**Decision 1 — Rust becomes the only MiniLM encoder on the capture path, and the
+mirror reverses direction.** The obvious reading of "Rust encodes new captures"
+would add a second encoder beside the Python one, embedding every screenshot
+twice. Dropping the hot layer instead is not available: Milestone 4 task
+clustering still reads `task_vectors`, and `compress_to_cold` still derives
+`task_centroids` from it. So Rust takes over the inference and hands the finished
+vector to Python for the Chroma write — the M2.4 dual-write with its direction
+reversed. The failure modes reverse with it, in the direction that matters: a
+lost mirror now degrades unsupervised clustering rather than making a screenshot
+unfindable by natural-language search.
 
-- `derived_index::semantic_text_topk`, `ScoredSubject`, `count_query_visible_embeddings`.
-- `storage/semantic_cache.rs` (the resident vector matrix), its `StorageState` fields, the idle-eviction ticker in `lib.rs`, and the cache resets in `storage/schema.rs`.
-- The `semantic_runtime` / `semantic_index` enums themselves, minus the retired value: they remain the observable rollback switch required above.
+Note the precise scope. Python still runs MiniLM for the reranked query encode,
+for `_backfill_from_screenshots`, and inside the Smart Cluster worker. Those
+consumers move at step 6 and Milestones 3 and 4.
 
-What may survive the cutover is the *fallback* diagnostic the enum rule demands
-— which backend is active and why a Rust configuration was refused — and it
-survives as a field on an existing status command, not as a settings card with
-percentiles in it. Apply the same shape to the reranker, CLIP, and BGE shadows
-when their turn comes.
+**Decision 2 — indexing is strictly idle-gated, and the coverage rule changes
+shape rather than tightening.** MiniLM is a 118 MB model
+(`semantic_models.rs`, 118,308,126 bytes), over the line at which background
+inference waits for an idle window, so the drain worker is gated on the existing
+idle policy instead of running inline on the post-process path the way Python
+did.
 
-Release gate:
+Three consequences, all deliberate and all recorded rather than smoothed over:
 
-- Token IDs match exactly for the golden corpus. CPU embedding cosine is at least 0.99999 with maximum absolute error 0.0001; DirectML embedding cosine is at least 0.999 with maximum absolute error 0.001 unless a model-specific, reviewed tolerance is documented. Raw reranker logits use the same CPU/DirectML absolute-error profiles.
-- **Retrieval equivalence, stated as a recall-superset gate (rewritten 2026-07-28).** The original wording — "top-10 overlap at least 99%, top-1 effectively unchanged" — assumed the Rust and Python paths were two implementations of the *same* retrieval method. They are not: Chroma is approximate (HNSW), the Rust path is an exact cosine scan over the same hot layer. An exact scan that agreed with an ANN index 99% of the time at k=10 would be evidence that one of them is wrong, not that both are right. The gate is therefore:
-  - **Recall superset.** For each query, every Python top-K result that is present in the Rust store must be reachable by the Rust scan at a score no worse than Python assigns it. A Python-top result that is *absent* from the Rust store is a real coverage defect and blocks the cutover; a Python-top result that is present but ranked differently is the expected ANN-vs-exact difference. The shipped shadow harness reports these separately as `only_in_chroma` (blocking) and `in_both_diff_rank` (accepted) precisely so the two cannot be confused. Since the harness is deleted at step 4, this remains an offline gate measured before the cutover lands; what enforces it afterwards is the runtime coverage rule above (durable dual-write plus a debt-gated read path), not a metric nobody can read anymore.
-  - **Query-encoder numerics.** Cosine agreement between the Rust query encoder and the Python one, measured against the same stored document vectors, must meet the CPU tolerance above. This is the part that would catch a genuine Rust inference bug, and it is the part the 2026-07-27 measurement passed at 6.0e-7 maximum absolute error.
-  - **Contracts.** Filter, offset, limit, threshold, and JSON response contracts still match 100%. This is unchanged and is not softened by the above.
-  - Overlap@10 and top-1 agreement remain **recorded** as descriptive numbers, not pass/fail thresholds, for the bi-encoder retrieval step. They return to being a pass/fail gate at step 6, where reranked end-to-end ordering — which is what the user actually sees on the calibration path — is compared.
-- Migrated subject-key sets match exactly per index kind; unmappable/corrupt rows are listable and keep the legacy backend active. Existing CLIP vectors are byte-copied/float-copied rather than re-encoded during normal migration.
-- With Python stopped, Rust-owned semantic-text search, migrated CLIP visual search, and new-capture Rust CLIP/MiniLM indexing continue to work for capabilities marked `rust`. Capabilities still marked Python-backed remain advertised honestly and usable through fallback. **MiniLM reaches this gate at step 5, not step 4** — see the step-5 scope note. Step 4 may ship with the capability advertised as Rust-read / Python-written.
+1. **Search freshness regresses.** A screenshot captured during active use is not
+   semantically searchable until the next idle window, where previously it was
+   searchable within seconds. The backlog depth and the age of the oldest waiting
+   screenshot are reported in the backend diagnostic so the cost is visible
+   rather than merely felt.
+2. **There is no manual-run path yet.** Section 4 permits heavy machine learning
+   to gate on idle *or* on an explicit manual run; this worker has only the
+   former. Adding a bounded "index now" action belongs with this step's soak
+   follow-up.
+3. **Idle requires AC power.** `idle.rs` computes `is_idle` as
+   `idle_secs >= IDLE_THRESHOLD_SECS && !fullscreen && ac_connected`, and
+   `power_saving_mode_enabled` defaults to true. On a laptop running on battery
+   the worker therefore never runs, so neither the Rust semantic index nor — since
+   Rust is now the capture-path encoder — the Chroma hot layer gains new rows for
+   as long as that lasts. The backlog is bounded only by how long the machine
+   stays unplugged. This needs a decision before the milestone is called done: a
+   manual run, a battery-time allowance, or an explicit statement that
+   battery-only machines index on the next AC session.
 
-- Existing automatic classification and task clustering do not regress: Python BGE remains until its consumer migrates, and `task_vectors` / `task_centroids` remain available to the Milestone 4 path.
-- Embedding migration/rebuild is interruptible/resumable; session lock/unlock, process crash, partial ANN generation, model upgrade, rollback to the previous release, and deletion are tested without screenshot loss or silent vector loss.
-- Background semantic work cannot trigger a model load during fullscreen/game activity. User-initiated search remains available with a deadline. OCR p95 latency and reliability show no material regression from semantic work; search p95 latency and peak memory stay within an explicitly recorded budget.
-- The Python fallback remains available for one released version after each capability becomes Rust-default.
-- **No shadow/probe development surface for an already-cut-over capability ships in a production build.** The retirement list above is executed, not deferred: the settings card, the probe commands, and the sample tables are gone, and the only remaining backend diagnostic is the read-only fallback status the enum rule requires. A beta may ship the harness; a production release may not.
+**Why the `index_incomplete` refusal did not survive.** Not because idle gating
+would trip it nightly. That refusal assumed Python held a complete corpus to fall
+back *to*, which was true while Python was the encoder. Once Rust encodes and
+Chroma receives its rows from the Rust mirror, both stores are behind by
+essentially the same screenshots, so handing the query to Python buys the user
+nothing while costing them the faster path. The backlog therefore stops being a
+reason to refuse and becomes a reported number.
 
-Depends on: Milestone 1 semantics/decisions landed and reviewed, including the approximate-count caveats above.
+One caveat on "essentially": `_backfill_from_screenshots` can still write Chroma
+rows that never reach Rust, since it encodes from SQLite with Python's own
+embedder and there is no longer a reverse dual-write. It only fires when the hot
+layer is found entirely empty, so this is an edge case rather than a routine
+divergence — but the two stores are not identical by construction, and a future
+step that depends on their being identical must not assume it.
 
-### Milestone 3 — Smart Cluster Worker in Rust (target: post-v0.8.4 Beta)
+**Decision 3 — retention becomes first-party; deletion already was.** The
+pre-implementation audit recorded that a user-deleted screenshot leaves its
+derived row behind as an unbounded storage leak. That was wrong, and it is
+corrected here rather than quietly dropped: the schema has carried
+`cleanup_derived_index_on_screenshot_soft_delete` and its hard-delete twin since
+the derived layer was introduced, and both remove the embedding and the ledger
+row inside the deleting transaction. What was genuinely mirrored from Python was
+*expiry on age* — the only deleter of aged Rust `semantic_text` rows was Python's
+hot-layer expiry sending its own deletions back over reverse IPC. Step 5 gives
+Rust its own 30-day rule against SQLite `created_at` and removes that mirror;
+Python keeps expiring its own Chroma hot layer for the clustering path. The two
+stores stop tracking each other, which is what ownership means here. The reaper
+also sweeps subjects with no live screenshot, which after the triggers is a
+safety net for rows written before they existed rather than a live path.
 
-Purpose: move Smart Cluster scoring entirely into Rust. Note Smart Cluster (user-controllable, NL-anchored, already Rust-persisted in `storage/smart_cluster.rs`) is a **different system** from unsupervised task clustering — do not conflate them.
+**Decision 4 — the Chroma mirror is best-effort, and the residual gap is named.**
+Rust holds the authoritative copy, so a mirror lost while the monitor is down or
+clustering is disabled costs that screenshot its place in unsupervised task
+clustering, not its findability by search. It is not re-sent:
+`_backfill_from_screenshots` rebuilds the hot layer only when it is found
+*entirely* empty, so a partial gap stays open until the row ages out. The Smart
+Cluster prefilter is unaffected, since it already falls back to a live encode for
+any ID the collection lacks. Closing the clustering gap belongs with Milestone 4,
+which is where `task_vectors` is actually consumed and where a Rust-to-Python
+vector read would have a second user.
 
-Current reality: persistence and schema are Rust; the scoring worker `monitor/smart_cluster_worker.py` and `monitor/reranker.py` are still Python (`monitor_smart_cluster_worker_status` forwards to Python).
+**The Smart Cluster pending enqueue moved with the encoder.** Python's
+`add_snapshot` called `smart_cluster_enqueue_pending` right after it wrote the
+vector, so the Rust writer makes that call in the same position — which also puts
+the queue entry point in Rust before step 6 needs it.
 
-Recommended changes:
+##### Step 6 — reranker and Smart Cluster scoring — NEXT
 
-- Move pending-queue drain into Rust using the Milestone 2 reranker.
-- Preserve the current good behavior: idle gate before load, idle re-check during batches, manual force-run, reranker unload after idle, per-cluster threshold assignment.
-- Remove `monitor/smart_cluster_worker.py` from the default runtime path; keep the SQLite schema unless a migration is clearly needed.
-- Add cheap assignment explainability if practical: prefilter score, rerank score, threshold, model id/version.
+**Scope: the scoring worker moves with the reranker.** An earlier version of this
+plan allowed the Python Smart Cluster worker to keep scoring while calibration
+moved to Rust, with a temporary reverse-IPC rerank bridge as an option. A source
+audit rules that arrangement out.
 
-Release gate:
+`monitor/reranker.py` builds its own provider list and prefers DirectML
+(`reranker.py:186-187`), so today both the calibration scores and the worker's
+assignment scores come from a GPU session, while the Rust engine refuses
+DirectML for this model outright. Calibration writes its result into
+`smart_clusters.threshold` and leaves it there, and the worker compares its own
+logits against that stored number. Moving calibration alone would leave a
+persisted threshold produced by one scorer being applied by another —
+assignments that quietly over- or under-fire, against a number the user never
+sees and cannot correct.
 
-- Creation, calibration preview, pending drain, assignment, rescan, and summary storage all work without Python.
+So step 6 cuts over calibration and the scoring worker as one unit, pulling the
+Milestone 3 scoring path forward. Milestone 3 keeps the rest of that worker's
+surface.
+
+**Three implementation consequences.**
+
+1. **Batching and a foreground latency budget.** The Rust cross-encoder is
+   CPU-only while Python's is not, and the calibration path over-fetches
+   `n_results * rerank_overfetch` — 120 documents at the defaults
+   (`task_clustering.py:1433`, `n_results = 30`, `rerank_overfetch = 4`) —
+   against a protocol cap of `MAX_RERANK_DOCUMENTS = 64`
+   (`ml_protocol.rs:18`). The step needs request batching and a *measured*
+   foreground latency budget before it can claim its gate. The shipped Python
+   path also keeps two models resident, where the Rust engine holds one and
+   re-verifies a 570 MB file (`semantic_models.rs`, 570,727,094 bytes) on every
+   swap.
+2. **Thresholds already on disk were produced by the retired scorer.** Each
+   cluster has to record the scorer that produced its threshold — model,
+   revision, variant, provider — so that a threshold from a scorer that no longer
+   exists is recognizable rather than silently reused.
+3. **The `rerank_variant` selector is a loose end to resolve, not carry across.**
+   Rust pins `model_uint8.onnx`, which is also the only variant
+   `model_management.rs` installs, so the multi-variant dropdown already offers no
+   real choice. There is a live inconsistency to clean up at the same time:
+   `NlClusterView.jsx` and `query_by_text` default to `uint8`, while
+   `task_api.js` and `monitor.rs` default to `q4f16` — a variant that is never
+   installed. Do not carry the dropdown across the cutover as a live switch.
+
+##### Configuration surface
+
+Enum backends, not ambiguous booleans, because inference and index ownership cut
+over at different times:
+
+| Setting | Values | Default today |
+| --- | --- | --- |
+| `semantic_runtime` | `python` \| `rust` | `rust` |
+| `semantic_index` | `chroma` \| `dual` \| `rust` | `rust` |
+| `clip_runtime` | `python` \| `rust_shadow` \| `rust` | not yet introduced |
+| `clip_index` | `chroma` \| `dual` \| `rust` | not yet introduced |
+
+Invalid or unavailable Rust configurations fall back observably for one release,
+with a local diagnostic explaining why. `rust_shadow` is retired from
+`semantic_runtime` now that nothing can enter shadow mode for MiniLM; CLIP will
+introduce and then retire its own.
+
+Search response schemas, filters, offsets, limits, thresholds, MCP tool
+availability, and frontend labels are preserved and explicitly tested. OCR
+keyword, MiniLM semantic text, CLIP visual and natural-language image search, and
+Smart Cluster assignment stay separately labeled, and their scores are never
+compared across models.
+
+##### Milestone 2 release gate
+
+**Numeric parity.** Token IDs match exactly for the golden corpus. CPU embedding
+cosine is at least 0.99999 with maximum absolute error 0.0001. DirectML embedding
+cosine is at least 0.999 with maximum absolute error 0.001, unless a
+model-specific reviewed tolerance is documented. Raw reranker logits use the same
+CPU and DirectML absolute-error profiles.
+
+**Retrieval equivalence, stated as a recall-superset gate.** The original wording
+— "top-10 overlap at least 99%, top-1 effectively unchanged" — assumed the Rust
+and Python paths were two implementations of the *same* retrieval method. They
+are not: Chroma is approximate (HNSW), the Rust path is an exact cosine scan over
+the same hot layer. An exact scan that agreed with an approximate index 99% of
+the time at k=10 would be evidence that one of them is wrong, not that both are
+right. So:
+
+- **Recall superset.** For each query, every Python top-K result that is present
+  in the Rust store must be reachable by the Rust scan at a score no worse than
+  Python assigns it. A Python-top result that is *absent* from the Rust store is
+  a real coverage defect and blocks the cutover. A Python-top result that is
+  present but ranked differently is the expected approximate-versus-exact
+  difference. The retired shadow harness reported these separately as
+  `only_in_chroma` (blocking) and `in_both_diff_rank` (accepted) precisely so the
+  two could not be confused. Since the harness was deleted at step 4, this is an
+  **offline gate measured before a cutover lands**; what enforces coverage
+  afterwards is the runtime refusal set, not a metric nobody can read anymore.
+- **Query-encoder numerics.** Cosine agreement between the Rust and Python query
+  encoders, measured against the same stored document vectors, must meet the CPU
+  tolerance above. This is the part that catches a genuine Rust inference bug,
+  and the part the 2026-07-27 measurement passed at 6.0e-7.
+- **Contracts.** Filter, offset, limit, threshold, and JSON response contracts
+  still match 100%. Not softened by anything above.
+- Overlap@10 and top-1 agreement stay **recorded** as descriptive numbers for the
+  bi-encoder step, not pass/fail thresholds. They return to being a pass/fail
+  gate at step 6, where reranked end-to-end ordering — what the user actually
+  sees on the calibration path — is compared.
+
+**Migration.** Migrated subject-key sets match exactly per index kind.
+Unmappable and corrupt rows are listable and keep the legacy backend active.
+Existing CLIP vectors are float-copied, not re-encoded, during normal migration.
+
+**Python stopped.** With Python stopped, Rust-owned semantic-text search,
+migrated CLIP visual search, and new-capture Rust CLIP and MiniLM indexing
+continue to work for every capability marked `rust`. Capabilities still marked
+Python-backed are advertised honestly and remain usable through fallback.
+**MiniLM reaches this gate at step 5, not step 4** — step 4 may ship with the
+capability advertised as Rust-read and Python-written.
+
+**No regressions elsewhere.** Existing automatic classification and task
+clustering do not regress: Python BGE remains until its consumer migrates, and
+`task_vectors` and `task_centroids` remain available to the Milestone 4 path.
+
+**Lifecycle.** Embedding migration and rebuild are interruptible and resumable.
+Session lock and unlock, process crash, partial ANN generation, model upgrade,
+rollback to the previous release, and deletion are all tested without screenshot
+loss or silent vector loss.
+
+**Foreground isolation.** Background semantic work cannot trigger a model load
+during fullscreen or game activity. User-initiated search stays available with a
+deadline. OCR p95 latency and reliability show no material regression from
+semantic work. Search p95 latency and peak memory stay inside an explicitly
+recorded budget.
+
+**Rollback.** The Python fallback remains available for one released version
+after each capability becomes Rust-default.
+
+**Scaffolding is gone.** No shadow or probe development surface for an
+already-cut-over capability ships in a production build. The settings card, the
+probe commands, and the sample tables are deleted, and the only remaining backend
+diagnostic is the read-only fallback status the flag rule requires. A beta may
+ship a harness; a production release may not.
+
+**Depends on.** Milestone 1's semantics and decisions, landed and reviewed,
+including the count-level caveats.
+
+---
+
+### Milestone 3 — Smart Cluster worker in Rust — PLANNED
+
+**Target: post-v0.8.4 Beta.**
+
+**Goal.** Move the remainder of Smart Cluster scoring into Rust.
+
+Smart Cluster — user-controllable, natural-language-anchored, already
+Rust-persisted in `storage/smart_cluster.rs` — is a **different system** from
+unsupervised task clustering. Do not conflate the two.
+
+**Where the code is.** Persistence and schema are Rust. The scoring worker
+`monitor/smart_cluster_worker.py` and `monitor/reranker.py` are still Python, and
+`monitor_smart_cluster_worker_status` (`monitor.rs:796`) forwards to Python.
+
+**Scope reduced 2026-07-29.** The pending-queue drain and the reranker scoring
+move earlier, in M2.5 step 6, because the calibration threshold and the
+assignment score have to come from the same scorer and calibration cuts over
+there. What remains here is the surface around that scorer.
+
+**Work.**
+
+- Keep the current good behavior intact: idle gate before load, idle re-check
+  during batches, manual force-run, reranker unload after idle, per-cluster
+  threshold assignment.
+- Port the status command, force-run, and queue plumbing.
+- Add cheap assignment explainability if practical: prefilter score, rerank
+  score, threshold, model id and version.
+- Remove `monitor/smart_cluster_worker.py` from the default runtime path once the
+  Rust drain has run for a release. Keep the SQLite schema unless a migration is
+  clearly needed.
+
+**Release gate.**
+
+- Creation, calibration preview, pending drain, assignment, rescan, and summary
+  storage all work without Python.
 - Old pending entries are processed or left retryable, never silently dropped.
 
-Depends on: Milestone 2 (Rust reranker).
+**Depends on.** Milestone 2 step 6 (Rust reranker and scoring).
 
-### Milestone 4 — Task Clustering Decision (target: post-Milestone 3)
+---
 
-Purpose: decide whether HDBSCAN/PaCMAP task clustering deserves to survive Python removal. Default stance: it does not.
+### Milestone 4 — Task clustering decision — PLANNED
 
-Current reality: `monitor/task_clustering.py` (PaCMAP + sklearn HDBSCAN) with a periodic auto-scheduler is fully Python; the scheduler is idle-gated but there is no Rust replacement.
+**Target: post-Milestone 3.**
 
-Recommended direction:
+**Goal.** Decide whether HDBSCAN and PaCMAP task clustering deserves to survive
+Python removal. **Default stance: it does not.**
 
-- Do not port HDBSCAN/PaCMAP unless user value is proven. Prefer simpler Rust-owned grouping: session windows, process/title/URL continuity, Rust embedding similarity, Smart Cluster assignments, user corrections.
-- If unsupervised clustering is still wanted, make it manual/idle-only, cancellable, rebuildable, and off the capture/OCR hot path.
+**Where the code is.** `monitor/task_clustering.py` (PaCMAP plus scikit-learn
+HDBSCAN) with a periodic auto-scheduler, fully Python. The scheduler is
+idle-gated (`task_clustering.py:1696`), but there is no Rust replacement.
+
+**Work.**
+
+- Do not port HDBSCAN and PaCMAP unless user value is proven. Prefer simpler
+  Rust-owned grouping: session windows, process/title/URL continuity, Rust
+  embedding similarity, Smart Cluster assignments, user corrections.
+- If unsupervised clustering is still wanted, make it manual or idle-only,
+  cancellable, rebuildable, and off the capture and OCR hot path.
 - Remove or hide the periodic automatic Python HDBSCAN scheduler.
-- Keep existing saved tasks in SQLite with migration/compat display.
+- Keep existing saved tasks in SQLite with migration and compatibility display.
+- Decide the fate of the `task_vectors` hot layer, which after M2.5 step 5 is fed
+  only by a best-effort Rust mirror and is not repaired when partially behind.
+  This is where a Rust-to-Python vector read would get its second user, and where
+  the clustering coverage gap opened by step 5 is closed or accepted.
 
-Release gate:
+**Release gate.**
 
-- No dependency on Python HDBSCAN/PaCMAP for capture, OCR, search, or Smart Cluster.
-- Task view stays useful; any expensive clustering run is explicitly idle-gated or manual.
+- No dependency on Python HDBSCAN or PaCMAP for capture, OCR, search, or Smart
+  Cluster.
+- The task view stays useful, and any expensive clustering run is explicitly
+  idle-gated or manual.
 
-Depends on: Milestone 2 (embedding similarity), if the simpler grouping uses it.
+**Depends on.** Milestone 2, if the simpler grouping uses embedding similarity.
 
-### Milestone 5 — Classification & PII Resolution (target: post-Milestone 4)
+---
 
-Purpose: remove the remaining Python-only ML features or make them optional add-ons.
+### Milestone 5 — Classification and PII resolution — PLANNED
 
-Current reality: classification `monitor/classifier.py` (BGE, ONNX + torch fallback) runs in OCR post-process (`monitor/monitor/worker_process.py`). PII is a **two-tier MCP-output filter**: Rust aho-corasick dictionary masking (tier 1, `sensitive_filter.rs:264`) + Python Presidio NER (tier 2, default-on `presidio_enabled:true`, `mcp_server.rs:503-558`). The Rust rule layer is already the first line, but only on the MCP read path — capture-time PII is untouched. `torch`/`spacy`/`presidio-*` remain in `requirements.txt`.
+**Target: post-Milestone 4.**
 
-Recommended changes:
+**Goal.** Remove the remaining Python-only machine-learning features, or make
+them optional add-ons.
 
-- Replace Python BGE classification with Rust embedding-based scoring (Milestone 2 engine), simple process/title rules, user-defined Smart Clusters, or remove automatic classification from the default experience.
-- PII: keep and extend the Rust deterministic rules; decide Presidio/spaCy's fate — add ONNX NER only for a concrete workflow, otherwise make advanced PII optional and not part of the default install. Clarify whether PII also applies at capture-write time, not only MCP read.
-- Remove `torch`, `sentence-transformers`, `hdbscan`, `pacmap`, `spacy`, `presidio-*` from default dependencies once no default feature needs them.
-- Audit UI for now-backendless controls; demote experimental panels; simplify wizards.
+**Where the code is.** Classification (`monitor/classifier.py`, BGE via ONNX with
+a torch fallback) runs inside OCR post-process
+(`monitor/monitor/worker_process.py`). PII is a **two-tier MCP-output filter**:
+tier 1 is Rust aho-corasick dictionary masking (`sensitive_filter.rs`), tier 2 is
+Python Presidio NER, default-on (`presidio_enabled: true` at
+`sensitive_filter.rs:73`, applied at `mcp_server.rs:825-865`). The Rust rule
+layer is already the first line, but only on the MCP read path — capture-time PII
+is untouched. `torch`, `spacy`, and `presidio-*` remain in `requirements.txt`.
 
-Release gate:
+**Work.**
 
-- Default install needs no Python packages for classification, PII, OCR, semantic search, or Smart Cluster.
-- Advanced toggles reflect what is installed; no UI path starts Python implicitly.
+- Replace Python BGE classification with Rust embedding-based scoring using the
+  Milestone 2 engine, or with simple process and title rules, or with
+  user-defined Smart Clusters — or remove automatic classification from the
+  default experience.
+- PII: keep and extend the Rust deterministic rules. Decide Presidio and spaCy's
+  fate — add ONNX NER only for a concrete workflow, otherwise make advanced PII
+  optional and not part of the default install. Clarify whether PII also applies
+  at capture-write time, not only on the MCP read path.
+- Remove `torch`, `sentence-transformers`, `hdbscan`, `pacmap`, `spacy`, and
+  `presidio-*` from default dependencies once no default feature needs them.
+- Audit the UI for now-backendless controls, demote experimental panels, simplify
+  wizards.
 
-Depends on: Milestones 2-4.
+**Release gate.**
 
-### Milestone 6 — Python-Free Default Build (target: later 0.8.x)
+- A default install needs no Python packages for classification, PII, OCR,
+  semantic search, or Smart Cluster.
+- Advanced toggles reflect what is actually installed, and no UI path starts
+  Python implicitly.
 
-Purpose: ship the first default build that does not install or start Python.
+**Depends on.** Milestones 2-4.
 
-Current reality: unchanged from the original plan — all of it is still present. `python.rs` provides `request_install_python` / `install_python_venv` / `install_spacy_model` / dep sync; `build.rs` packages and integrity-checks `monitor.pyz`; the release still bundles the Python installer.
+---
 
-Recommended changes:
+### Milestone 6 — Python-free default build — PLANNED
 
-- Remove Python auto-install from first-run.
-- Stop bundling/copying `python-3.12.10-amd64.exe`, `monitor.pyz`, `requirements.txt`, venv freshness checks, pip sync UI, spaCy install UI.
-- Keep a temporary `python_legacy_monitor` build flag only if needed, off by default, out of release packaging.
-- Update docs/README: core is Rust-native; downloads are ONNX assets; no Python required. (Also fix stale `CLAUDE.md` OCR wording.)
-- Upgrade cleanup: detect old venv, offer deletion after successful Rust-native operation, never delete user data.
+**Target: later 0.8.x.**
 
-Release gate:
+**Goal.** Ship the first default build that neither installs nor starts Python.
 
-- Fresh install and upgrade both work without Python; legacy Python files are not required for capture, OCR, search, Smart Cluster, settings, MCP, or extension capture.
+**Where the code is.** Unchanged from the original plan — all of it is still
+present. `python.rs` provides `request_install_python`, `install_python_venv`,
+`install_spacy_model`, and dependency sync. `build.rs` packages and
+integrity-checks `monitor.pyz`. The release still bundles the Python installer.
 
-Depends on: Milestones 1-5 all default and stable for at least one release.
+**Work.**
 
-### Milestone 7 — Infrastructure Deletion & Product Simplification (target: final 0.8.x cleanup)
+- Remove Python auto-install from first run.
+- Stop bundling and copying `python-3.12.10-amd64.exe`, `monitor.pyz`,
+  `requirements.txt`, venv freshness checks, the pip sync UI, and the spaCy
+  install UI.
+- Keep a temporary `python_legacy_monitor` build flag only if needed — off by
+  default, out of release packaging.
+- Update docs and README: the core is Rust-native, downloads are ONNX assets, no
+  Python required. This includes fixing `CLAUDE.md`, which still describes OCR as
+  PaddleOCR and still requires a `torch`-before-cv2 import order that the ONNX
+  sentinel path no longer performs.
+- Upgrade cleanup: detect an old venv, offer deletion after successful
+  Rust-native operation, never delete user data.
 
-Purpose: delete the now-unused integration layers and simplify the product surface.
+**Release gate.**
 
-Recommended changes:
+- Fresh install and upgrade both work without Python. Legacy Python files are not
+  required for capture, OCR, search, Smart Cluster, settings, MCP, or extension
+  capture.
 
-- Remove default-build code for the Python launcher, installer/venv manager, monitor named-pipe server, reverse storage IPC, Python worker supervisor, and Python ChromaDB ownership.
-- Remove stale docs/naming: no "Python service handles capture/OCR"; no "demo" labels on production Smart Cluster paths; no obsolete PaddleOCR naming (the runtime is RapidOCR/ONNX).
-- Collapse setup into: app auth/storage, model assets, optional browser extension. Simplify settings into General / Privacy & Security / Search & Models / Storage / Extension / Advanced. Keep advanced diagnostics but off the main path.
+**Depends on.** Milestones 1-5, all default and stable for at least one release.
 
-Release gate:
+---
 
-- Removing Python files removes no user data; tests and packaging no longer reference Python monitor files in default mode.
-- The product reads as one Rust-native local memory app, not a stack of optional subsystems.
+### Milestone 7 — Infrastructure deletion and product simplification — PLANNED
 
-Depends on: Milestone 6.
+**Target: final 0.8.x cleanup.**
 
-## Parallel Track: AI Agent Skill And MCP Onboarding
+**Goal.** Delete the now-unused integration layers and simplify the product
+surface.
 
-Status: reached the original 0.8.3 target. The standalone package `carbonpaper-memory` (repo `carbonPaperSkill`) is now the committed distribution shape (`components/settings/agent-access/agentAccessConstants.js:1-2`).
+**Work.**
 
-**Done:**
-- Full Agent-setup area: endpoint + connection state, one-click copy of the setup prompt, separate token copy, "copy diagnostics" (`components/settings/agent-access/`).
-- `mcp_get_status` returns `server_version`, `skill.tool_schema_version`, and `capabilities` including `search_nl` availability and the `python_monitor_not_running` disabled reason (`commands/mcp.rs:239-308`).
-- 12 MCP tools exposed; `search_nl` is dropped from the tool list when its backend is unavailable (`mcp_server.rs:435`) — capability awareness already works.
+- Remove default-build code for the Python launcher, the installer and venv
+  manager, the monitor named-pipe server, reverse storage IPC, the Python worker
+  supervisor, and Python ChromaDB ownership.
+- Remove stale docs and naming: no "Python service handles capture/OCR"; no
+  "demo" labels on production Smart Cluster paths (`task_clustering.py` still
+  labels the natural-language retrieval section "demo"); no obsolete PaddleOCR
+  naming, since the runtime is RapidOCR on ONNX.
+- Collapse setup into three things: app auth and storage, model assets, and the
+  optional browser extension. Simplify settings into General, Privacy & Security,
+  Search & Models, Storage, Extension, and Advanced. Keep advanced diagnostics,
+  but off the main path.
 
-**Remaining:**
-- Original 0.8.4 items are the gap: a **settings-page MCP smoke test** (authenticated ping, list tools, harmless metadata query, separate auth/port/privacy-filter failure reporting) and per-Agent guided setup variants.
-- Capability-drift control: when Milestone 2/3 move embedding/reranker/Smart Cluster to Rust, update the Skill's capability flags and the `search_nl` wording to track its backend (CLIP text→image, moving Python→Rust in Milestone 2) so it never advertises a Python-only path as stable — while keeping it advertised, since the capability is retained, not removed. Prefer generating/validating the Skill's tool table from the Rust MCP command definitions.
+**Release gate.**
 
-Do not defer this track to Milestones 6-7. The Agent story is already stable; those milestones should only remove obsolete Python wording.
+- Removing Python files removes no user data. Tests and packaging no longer
+  reference Python monitor files in default mode.
+- The product reads as one Rust-native local memory application, not a stack of
+  optional subsystems.
 
-## Feature-Specific Migration Notes
+**Depends on.** Milestone 6.
 
-### OCR — DONE
+---
 
-Shipped via `rapidocr-core` (pinned crate, not the originally planned local `rapidocr-rs` path), as a standalone worker with thin CarbonPaper integration (RGB bytes in, blocks + timings out). Retain the original gate list as regression fixtures: empty/black, mixed CN/EN browser, code/editor, dense document, tiny edge text, transparent/alpha, EXIF-oriented, and fullscreen/game (no foreground stutter).
+## 7. Parallel track: AI agent skill and MCP onboarding
 
-### Semantic Search
+**Status.** Reached the original 0.8.3 target. The standalone package
+`carbonpaper-memory` (repo `carbonPaperSkill`) is the committed distribution
+shape (`components/settings/agent-access/agentAccessConstants.js`).
 
-Keep OCR keyword search as the dependable baseline (Rust `search_text`, shipped). Make semantic text search Rust-owned and rebuildable in Milestone 2. There are **three distinct surfaces, kept separate and clearly labeled**: OCR keyword, semantic text (MiniLM over OCR), and visual/NL image search (Chinese-CLIP text→image). Chinese-CLIP is **retained (2026-07-19 reversal of the earlier demotion)** — it is `search_nl`'s live backend and the only text→image path. Milestone 2 migrates its existing vectors, dual-writes new image embeddings, and cuts over text queries only after parity; it never creates a window where visual search works for old data but new captures stop being indexed. "Prefer one path" applies *within* the text modality (do not ship several redundant text-NL surfaces), not to folding text→image into text→OCR.
+**Done.**
+
+- A full agent-setup area: endpoint and connection state, one-click copy of the
+  setup prompt, separate token copy, and copy-diagnostics
+  (`components/settings/agent-access/`).
+- `mcp_get_status` returns `server_version`, `skill.tool_schema_version`, and
+  `capabilities`, including `search_nl` availability and the
+  `python_monitor_not_running` disabled reason (`commands/mcp.rs`).
+- 12 MCP tools exposed. `search_nl` is dropped from the tool list when its
+  backend is unavailable (`mcp_server.rs:435`), so capability awareness already
+  works.
+
+**Remaining.**
+
+- The original 0.8.4 items: a **settings-page MCP smoke test** (authenticated
+  ping, list tools, harmless metadata query, with auth, port, and privacy-filter
+  failures reported separately) and per-agent guided setup variants. No such
+  command exists today.
+- Capability-drift control. As Milestones 2 and 3 move embedding, reranker, and
+  Smart Cluster work to Rust, update the skill's capability flags and the
+  `search_nl` wording to track its backend — CLIP text-to-image, moving from
+  Python to Rust at M2.5 steps 7-9 — so it never advertises a Python-only path as
+  stable, while keeping it advertised, since the capability is retained rather
+  than removed. Prefer generating and validating the skill's tool table from the
+  Rust MCP command definitions.
+
+Do not defer this track to Milestones 6-7. The agent story is already stable;
+those milestones should only remove obsolete Python wording.
+
+---
+
+## 8. Per-feature notes
+
+### OCR — done
+
+Shipped via `rapidocr-core` (a pinned crate, not the originally planned local
+`rapidocr-rs` path), as a standalone worker with thin CarbonPaper integration:
+RGB bytes in, blocks plus timings out.
+
+Retain the original gate list as regression fixtures: empty and black frames,
+mixed Chinese/English browser content, code and editor windows, dense documents,
+tiny edge text, transparent and alpha content, EXIF-oriented images, and
+fullscreen or game capture with no foreground stutter.
+
+### Semantic search
+
+Keep OCR keyword search as the dependable baseline (Rust `search_text`, shipped).
+Semantic text search is Rust-owned and rebuildable as of Milestone 2.
+
+There are **three distinct surfaces, kept separate and clearly labeled**: OCR
+keyword; semantic text (MiniLM over OCR); and visual or natural-language image
+search (Chinese-CLIP text-to-image).
+
+Chinese-CLIP is **retained** — it is `search_nl`'s live backend and the only
+text-to-image path. Milestone 2 migrates its existing vectors, dual-writes new
+image embeddings, and cuts over text queries only after parity. It must never
+create a window where visual search works for old data while new captures stop
+being indexed.
+
+"Prefer one path" applies *within* the text modality — do not ship several
+redundant text-based natural-language surfaces — not to folding text-to-image
+into text-over-OCR.
 
 ### Smart Cluster
 
-Preserve the current product model; it is more user-controllable than unsupervised task clustering. Rust already owns persistence; Milestone 3 moves the queue/prefilter/reranker/assignment/idle-gate. Add explanation fields before adding more algorithms.
+Preserve the current product model; it is more user-controllable than
+unsupervised task clustering. Rust already owns persistence. M2.5 step 6 moves
+the reranker and scoring; Milestone 3 moves the surrounding surface. Add
+explanation fields before adding more algorithms.
 
-### Task Clustering
+### Task clustering
 
-Treat HDBSCAN/PaCMAP as an experiment that may not survive Python removal (Milestone 4). Prefer simpler grouping; if kept, manual/idle-only and derived from SQLite/embedding data, never a capture dependency.
+Treat HDBSCAN and PaCMAP as an experiment that may not survive Python removal
+(Milestone 4). Prefer simpler grouping. If kept, make it manual or idle-only and
+derive it from SQLite and embedding data, never as a capture dependency.
 
-### PII / Presidio
+### PII and Presidio
 
-The Rust deterministic rule layer already exists and runs first on the MCP path. Extend it; add ONNX NER only for a concrete workflow; avoid shipping spaCy transformer models by default; decide whether PII also belongs at capture-write time (Milestone 5).
+The Rust deterministic rule layer already exists and runs first on the MCP path.
+Extend it. Add ONNX NER only for a concrete workflow, avoid shipping spaCy
+transformer models by default, and decide whether PII also belongs at
+capture-write time (Milestone 5).
 
-## Deletion Checklist
+---
 
-Do not delete a Python component until its Rust replacement has shipped as default for at least one release.
+## 9. Deletion checklist
 
-- Python OCR recognition — **eligible now**: Rust OCR has been default; remove the dormant Python OCR engine and its runtime handshake once Milestone 1 confirms nothing else depends on it. (The rest of `ocr_service.py` still does post-process — remove only the recognition path.)
-- Python Chinese-CLIP inference — **not a demotion; retained** (2026-07-19 reversal). Remove its Python inference only after both Rust CLIP encoders are default for one release, existing vectors are migrated, new captures are Rust-indexed, and `search_nl` parity/rollback gates pass. The `screenshots` collection is migrated, never silently dropped or routinely re-encoded.
-- Python MiniLM inference + Rust-replaced Chroma semantic retrieval — only after the relevant Milestone 2 capability is stable for one release. Keep Chroma and any dual-write needed by `task_vectors` / `task_centroids` until the Milestone 4 task-clustering decision is complete.
-- Python bge-reranker inference — remove from calibration only after Milestone 2 parity/cutover, and remove from the default Python Smart Cluster path only after Milestone 3.
-- Python BGE classification inference — do not remove in Milestone 2 merely because the Rust runtime can load BGE. Remove only when Milestone 5 classification uses Rust directly, or while a deliberately supported Python→Rust inference bridge is active and tested.
-- Python Smart Cluster worker — only after Milestone 3 is stable.
-- Python HDBSCAN/PaCMAP — only after Milestone 4 is stable.
-- Python classification/PII dependencies — only after Milestone 5 is stable.
-- Python installer/venv/pyz/reverse IPC — only after Milestone 6 proves fresh install and upgrade without Python.
+### Python components — wait for a shipped replacement
 
-Migration scaffolding runs on the opposite clock. It is not a Python component
-waiting for a replacement; it is temporary instrumentation that must be removed
-as soon as the gate it proves is signed off, and at the latest before the
-capability's first production release:
+Do not delete a Python component until its Rust replacement has been the default
+for at least one release.
 
-- MiniLM shadow toggle, query/document probes, `semantic_shadow_samples` / `semantic_doc_encoder_runs`, and the settings card — delete with the M2.5 step-4 cutover. Full artifact list in the retirement block under M2.5.
-- Reranker, CLIP, and BGE shadow harnesses — same rule at their own cutovers.
-- The `rust_shadow` enum values — delete once no capability can still enter shadow mode.
+| Component | Condition |
+| --- | --- |
+| Python OCR recognition | **Eligible now.** Rust OCR has been default and Milestone 1 confirmed nothing else depends on it. Remove the dormant engine and its runtime handshake. The rest of `ocr_service.py` still does post-process — remove only the recognition path. |
+| Python Chinese-CLIP inference | **Retained capability, not a demotion.** Remove its Python inference only after both Rust CLIP encoders are default for one release, existing vectors are migrated, new captures are Rust-indexed, and the `search_nl` parity and rollback gates pass. The `screenshots` collection is migrated, never silently dropped or routinely re-encoded. |
+| Python MiniLM inference and Chroma semantic retrieval | Only after the relevant Milestone 2 capability is stable for one release. Note the three surviving Python MiniLM call sites listed in section 3 — the reranked query encode, the hot-layer rebuild, and the Smart Cluster worker — which move at step 6 and Milestones 3-4. Keep Chroma and any dual-write needed by `task_vectors` and `task_centroids` until the Milestone 4 decision is complete. |
+| Python bge-reranker inference | Remove from calibration and from the Smart Cluster scoring path together, after the M2.5 step 6 parity and cutover gates. Remove the remaining worker surface after Milestone 3. |
+| Python BGE classification inference | Do not remove in Milestone 2 merely because the Rust runtime can load BGE. Remove only when Milestone 5 classification uses Rust directly, or while a deliberately supported Python-to-Rust inference bridge is active and tested. |
+| Python Smart Cluster worker | Only after Milestone 3 is stable. |
+| Python HDBSCAN and PaCMAP | Only after Milestone 4 is stable. |
+| Python classification and PII dependencies | Only after Milestone 5 is stable. |
+| Python installer, venv, pyz, reverse IPC | Only after Milestone 6 proves fresh install and upgrade without Python. |
 
-## Branching And Release Discipline
+### Migration scaffolding — the opposite clock
 
-- Keep this roadmap inside the `carbonPaper` repository (for example `docs/python-removal-roadmap.md`) before treating milestone status as branch/PR truth. The current parent-directory `roadmap.md` is outside the repository and cannot be reviewed or versioned with implementation branches.
-- `m2/contracts-and-baseline` / PR #139 contains the Mini Milestone 1 collection semantics/tests, internal CLIP count diagnostics, and Chroma version pin. Keep the Python oracle in the next stacked PR so the already-small baseline PR remains reviewable. Do not include unrelated release-workflow edits or user-facing warnings.
-- Build the v0.8.4 Beta Milestone 2 as short, stacked branches/PRs rather than a big-bang branch: `m2/contracts-and-baseline`, `m2/python-oracle-contracts`, `m2/rust-onnx-runtime`, `m2/derived-vector-store`, `m2/minilm-dual-write-migration`, `m2/minilm-shadow-cutover`, `m2/minilm-query-cutover`, `m2/minilm-capture-indexing`, `m2/reranker-shadow-cutover`, `m2/clip-vector-migration`, `m2/clip-cutover`, `m2/search-ui-capabilities`, and `m2/bge-shadow`. Infrastructure may merge to `main` while disabled; each consumer cutover has its own gate and rollback. (`m2/minilm-query-cutover` and `m2/minilm-capture-indexing` were added on 2026-07-28 for M2.5 steps 4 and 5; calibration is no longer part of the query-cutover PR and rides with `m2/reranker-shadow-cutover`.)
-- Do not open a release branch until the intended capabilities have passed shadow mode on `main`. Release branches are stabilization-only; avoid accumulating new migration architecture there.
-- Intended backend selection is explicit per capability. Prefer enums (`python|rust_shadow|rust`, `chroma|dual|rust`) over one Boolean per replacement because inference and index ownership cut over at different times. **Reality:** only `rust_ocr_dml_beta` (a DirectML accelerator toggle) exists; OCR shipped default without a `rust_ocr` flag. Milestones 2-5 must not repeat that unobservable big-bang cutover.
-- Each flag/replacement should have a telemetry-free local diagnostic command that reports status and last error (the OCR runtime and `mcp_get_status` are the model to follow).
-- Each release should include a rollback path for one version.
-- Add a short release-note section: what moved from Python to Rust, what remains Python-backed, what data can be rebuilt, whether a model re-download is required.
+Scaffolding is not a component waiting for a replacement. It is temporary
+instrumentation, removed as soon as the gate it proves is signed off, and at the
+latest before the capability's first production release.
 
-## Immediate Next Step
+| Scaffolding | Status |
+| --- | --- |
+| MiniLM shadow toggle, query and document probes, `semantic_shadow_samples`, `semantic_doc_encoder_runs`, the settings card | **DELETED** with the M2.5 step-4 cutover. Tables are dropped in `storage/schema.rs`. |
+| The `rust_shadow` value of `semantic_runtime` | **DELETED** — normalizes to the shipped default. |
+| Reranker, CLIP, and BGE shadow harnesses | Not yet built. Same rule applies at their own cutovers: enforce deletion **in the cutover PR**, not as an end-of-milestone sweep. An unowned diagnostic panel never gets deleted later. |
 
-M2.5 step 3 is done: the shadow harness (passive per-query comparison, active
-query corpus, document re-encode probe) landed on `m2/minilm-shadow-cutover`
-together with the resident-vector read path, and its parity/latency numbers are
-recorded above. In progress is step 4 on `m2/minilm-query-cutover` — route the
-**non-reranked** NL semantic-text query through `semantic_index = rust`, keeping
-the `python` enum value as the one-release observable rollback. Reranked queries
-(which is every calibration query) stay on Python until step 6; see the step-4
-scope note for why splitting them there is cheaper than a one-release rerank
-bridge. That same PR must delete the shadow scaffolding per the retirement
-block; the harness has now served its purpose and must not reach a production
-build. The coverage denominator for the gate is the set of valid, mappable
-vectors in the Chroma hot-layer snapshot, not all SQLite screenshots.
+When deleting a shadow harness, check for functions the production path has since
+adopted. `minilm_sources` began life as the document-encoder probe's source
+builder and is now the capture worker's; deleting it as scaffolding would have
+removed production code.
 
-Step 5 (`m2/minilm-capture-indexing`) follows immediately and is not optional
-bookkeeping: until Rust encodes and enqueues new captures and owns retention,
-`semantic_index = rust` means Rust reads an index Python still writes, and the
-"with Python stopped" release gate cannot be evaluated for MiniLM at all. Only
-after that does the reranker step (6) run, which is also where Smart Cluster
-calibration moves. The separate CLIP vector migration/cutover sequence begins
-after those.
+---
 
-No Rust backend becomes authoritative until its Python behavior contract, dual-write/migration, shadow-query, lifecycle, performance, and rollback gates pass. The first recommended cutover is MiniLM semantic retrieval; CLIP follows only after both legacy-vector migration and new-capture Rust image indexing work. Chroma remains for Milestone 4 task clustering, and Python BGE remains for Milestone 5 classification. Until subject-level Rust ledgers exist, the internal count-level CLIP comparison is only a migration baseline, not a product health judgment.
+## 10. Branching and release discipline
+
+- **This roadmap lives in the repository** (`docs/python-removal-roadmap.md`) so
+  milestone status can be reviewed and versioned alongside implementation
+  branches. The former parent-directory `roadmap.md` was outside the repository
+  and could not be.
+- **Build Milestone 2 as short stacked branches**, not one big-bang branch:
+  `m2/contracts-and-baseline`, `m2/python-oracle-contracts`,
+  `m2/rust-onnx-runtime`, `m2/derived-vector-store`,
+  `m2/minilm-dual-write-migration`, `m2/minilm-shadow-cutover`,
+  `m2/minilm-query-cutover`, `m2/minilm-capture-indexing`,
+  `m2/reranker-shadow-cutover`, `m2/clip-vector-migration`, `m2/clip-cutover`,
+  `m2/search-ui-capabilities`, `m2/bge-shadow`. Infrastructure may merge to
+  `main` while disabled; each consumer cutover carries its own gate and rollback.
+- **Do not open a release branch** until the intended capabilities have passed
+  their gates on `main`. Release branches are stabilization-only; do not
+  accumulate new migration architecture there.
+- **Backend selection is explicit per capability.** Prefer enums
+  (`python|rust_shadow|rust`, `chroma|dual|rust`) over one boolean per
+  replacement, because inference and index ownership cut over at different times.
+  The cautionary precedent: only `rust_ocr_dml_beta` (a DirectML accelerator
+  toggle) ever existed for OCR, which shipped default with no `rust_ocr` flag.
+  Milestones 2-5 must not repeat that unobservable big-bang cutover.
+- **Every flag and replacement gets a telemetry-free local diagnostic** command
+  reporting status and last error. The OCR runtime and `mcp_get_status` are the
+  model to follow.
+- **Every release includes a rollback path for one version.**
+- **Every release note says** what moved from Python to Rust, what remains
+  Python-backed, what data can be rebuilt, and whether a model re-download is
+  required.
+
+---
+
+## 11. Immediate next step
+
+**M2.5 step 5 is implemented on `m2/minilm-capture-indexing` and awaiting an
+on-machine soak.** The step's three open items, in priority order:
+
+1. Decide the battery case. `is_idle` requires AC power, so a laptop on battery
+   never indexes and the backlog is bounded only by how long it stays unplugged.
+2. Add a bounded manual "index now" path, which section 4 already permits as the
+   alternative to idle gating and which also gives the battery case an out.
+3. Confirm during the soak that the freshness regression and the reported backlog
+   figures behave as described, including after a session lock and an app
+   restart.
+
+**Then step 6, on `m2/reranker-shadow-cutover`.** It is larger than the numbered
+list originally implied: it cuts over Smart Cluster calibration *and* the scoring
+worker together, because a persisted threshold cannot be produced by one scorer
+and applied by another. Budget for request batching, a measured CPU-only
+foreground latency figure, and threshold provenance recording.
+
+**Then the CLIP sequence** — steps 7 through 9, in that order, with the
+new-capture dual-write (step 8) landing before the text-query cutover (step 9).
+
+**Standing constraints.** No Rust backend becomes authoritative until its Python
+behavior contract, dual-write and migration, shadow-query, lifecycle,
+performance, and rollback gates pass. Chroma remains for Milestone 4 task
+clustering, and Python BGE remains for Milestone 5 classification.
+
+---
+
+## Appendix A — Decision log
+
+Only decisions that changed the plan's direction. The reasoning lives in the
+milestone bodies; this is an index so a reversal is not silently re-reversed.
+
+| Date | Decision |
+| --- | --- |
+| 2026-07-18 | Rebaselined the plan on a source audit of shipped `0.8.3`, superseding the 0.8.1-baseline plan (kept as `roadmap.0.8.1-original.md`). Version numbers stop tracking milestones. |
+| 2026-07-19 | Milestone 1 reduced to an internal migration baseline; its per-row ledger and rebuild executor moved to Milestone 2. |
+| 2026-07-19 | **Reversed the "demote Chinese-CLIP" decision.** It rested on a dead-code rationale that missed `search_by_text`, the live backend serving `search_nl` from two frontend surfaces and the MCP. CLIP is retained as a first-class search surface. |
+| 2026-07-19 | Milestone 2 reframed around behavioral equivalence rather than moving an ONNX call site. ChromaDB cannot be removed while `task_vectors` and `task_centroids` serve Milestone 4; Python BGE cannot be removed before classification has a Rust path. |
+| 2026-07-19 | Milestone 2 committed as the scope for v0.8.4 Beta, delivered as short stacked PRs, with disabled or shadow infrastructure allowed to land before individual cutovers. |
+| 2026-07-20 | DirectML parity rejected for MiniLM and the uint8 reranker after a five-gate audit failed (top-1 changed on 20.5% of queries). Both are CPU-only in Rust. |
+| 2026-07-27 | Step-3 shadow measurement accepted: the query encoder passes numerically, and the retrieval divergence is a recall superset rather than a defect. |
+| 2026-07-28 | Step 4 scoped to non-reranked retrieval only; calibration moves to step 6 rather than through a throwaway Rust-retrieve/Python-rerank bridge. |
+| 2026-07-28 | The "top-10 overlap ≥ 99%" release gate rewritten as a recall-superset gate, because the two paths use different retrieval methods. |
+| 2026-07-28 | Step 5 added: Rust capture-side MiniLM indexing, which the numbered sequence never contained even though the "with Python stopped" gate silently required it. |
+| 2026-07-29 | Step 6 enlarged to move the Smart Cluster scoring worker together with the reranker, and Milestone 3 reduced accordingly. |
+| 2026-07-29 | Step 5 decisions: Rust owns capture-path encoding with the Chroma mirror reversed; indexing is idle-gated and search freshness regresses; retention becomes first-party; the `index_incomplete` refusal is retired. |
+| 2026-07-30 | Document restructured around milestones. Stale "current reality" claims corrected against the tree: the `ml_contracts` traits have method surfaces but no implementations, the MiniLM shadow harness is already deleted, and Python still runs MiniLM outside the capture path. |

--- a/monitor/monitor/__init__.py
+++ b/monitor/monitor/__init__.py
@@ -23,7 +23,6 @@ import uuid
 import base64
 import json
 import logging
-import queue
 import time
 import threading
 
@@ -41,9 +40,6 @@ _last_clustering_auth_check = 0.0
 _last_clustering_session_valid = False
 _clustering_auth_monitor_thread = None
 _clustering_auth_gate_lock = threading.Lock()
-_clustering_ingest_queue = None
-_clustering_ingest_thread = None
-_clustering_ingest_stop = threading.Event()
 _auth_token = None           # Auth token for IPC validation
 _last_seq_no = -1            # Last processed sequence number
 _seen_seq_nos = set()        # Accepted sequence numbers inside the replay window
@@ -142,79 +138,14 @@ def _start_clustering_auth_monitor():
     _clustering_auth_monitor_thread.start()
 
 
-def _start_clustering_ingest_worker(maxsize: int = 128):
-    global _clustering_ingest_queue, _clustering_ingest_thread
-    if _clustering_ingest_thread and _clustering_ingest_thread.is_alive():
-        return
-    _clustering_ingest_queue = queue.Queue(maxsize=max(1, maxsize))
-    _clustering_ingest_stop.clear()
-
-    def _loop():
-        while not _clustering_ingest_stop.is_set():
-            try:
-                item = _clustering_ingest_queue.get(timeout=0.2)
-            except queue.Empty:
-                continue
-            try:
-                if not (_clustering_manager and config.CLUSTERING_ENABLED):
-                    continue
-                if not (_clustering_scheduler_active and _last_clustering_session_valid):
-                    logger.debug(
-                        '[DIAG:clustering_ingest] skipped screenshot_id=%s (session locked/inactive)',
-                        item.get('screenshot_id'),
-                    )
-                    continue
-                started = time.perf_counter()
-                _clustering_manager.add_snapshot(**item)
-                logger.debug(
-                    '[DIAG:clustering_ingest] add_snapshot done screenshot_id=%s elapsed=%.3fs queue_size=%s',
-                    item.get('screenshot_id'),
-                    time.perf_counter() - started,
-                    _clustering_ingest_queue.qsize(),
-                )
-            except Exception as exc:
-                logger.warning(
-                    '[DIAG:clustering_ingest] add_snapshot failed screenshot_id=%s error=%s',
-                    item.get('screenshot_id'),
-                    exc,
-                )
-            finally:
-                _clustering_ingest_queue.task_done()
-
-    _clustering_ingest_thread = threading.Thread(
-        target=_loop,
-        name='clustering-ingest',
-        daemon=True,
-    )
-    _clustering_ingest_thread.start()
-
-
-def _stop_clustering_ingest_worker():
-    global _clustering_ingest_thread, _clustering_ingest_queue
-    _clustering_ingest_stop.set()
-    if _clustering_ingest_thread:
-        _clustering_ingest_thread.join(timeout=2.0)
-    _clustering_ingest_thread = None
-    _clustering_ingest_queue = None
-
-
-def _enqueue_clustering_snapshot(item: dict) -> bool:
-    if not (_clustering_manager and config.CLUSTERING_ENABLED):
-        return False
-    if not (_clustering_scheduler_active and _last_clustering_session_valid):
-        return False
-    if _clustering_ingest_queue is None:
-        _start_clustering_ingest_worker()
-    try:
-        _clustering_ingest_queue.put_nowait(item)
-        return True
-    except queue.Full:
-        logger.warning(
-            '[DIAG:clustering_ingest] queue full; dropped screenshot_id=%s maxsize=%s',
-            item.get('screenshot_id'),
-            _clustering_ingest_queue.maxsize,
-        )
-        return False
+# M2.5 step 5 removed the clustering ingest worker that used to run here.
+# It existed to hand each freshly OCR'd screenshot to
+# `HotColdManager.add_snapshot`, which encoded it with MiniLM and wrote the
+# Chroma hot layer. Rust now owns that encode: it queues the screenshot on the
+# OCR commit, encodes it on an idle-gated worker, and pushes the finished row
+# back through the `upsert_task_vectors` command. Keeping this queue as well
+# would embed every screenshot twice, and the Python half would run on the
+# capture path rather than while the machine is idle.
 
 
 def _delete_vectors_by_hashes(image_hashes):
@@ -521,21 +452,16 @@ def _handle_command_impl(req: dict):
             return {'error': 'OCR postprocess service is not initialised'}
         timeout_secs = int(req.get('timeout_secs', getattr(config, '_ocr_timeout_secs', 120)))
         try:
-            result = _ocr_worker.request(
+            # Sensitive-content filtering and classification only. The semantic
+            # index used to be fed from here too, by handing the same payload to
+            # the clustering ingest queue; M2.5 step 5 moved that to the Rust
+            # capture path, which enqueues the screenshot the moment its OCR row
+            # commits and encodes it while the machine is idle.
+            return _ocr_worker.request(
                 'enqueue_ocr_postprocess',
                 {'request': req},
                 timeout=max(30, min(600, timeout_secs)),
             )
-            if result.get('status') == 'success':
-                _enqueue_clustering_snapshot({
-                    'screenshot_id': screenshot_id,
-                    'process_name': req.get('process_name', ''),
-                    'window_title': req.get('window_title', ''),
-                    'ocr_text': req.get('ocr_text', ''),
-                    'timestamp': req.get('timestamp', 0),
-                    'category': '',
-                })
-            return result
         except Exception as e:
             logger.error(
                 '[DIAG:enqueue_ocr_postprocess] failed screenshot_id=%s error=%s',
@@ -760,7 +686,6 @@ def start(_debug, pipe_name: str = None, auth_token: str = None, storage_pipe: s
     _clustering_auth_monitor_thread = None
     _last_clustering_auth_check = 0.0
     _last_clustering_session_valid = False
-    _stop_clustering_ingest_worker()
 
     if not pipe_name:
         pipe_name = os.environ.get('CARBON_MONITOR_PIPE')
@@ -825,7 +750,6 @@ def start(_debug, pipe_name: str = None, auth_token: str = None, storage_pipe: s
             _clustering_scheduler = ClusteringScheduler(_clustering_manager, storage_client=sc)
             unlocked = _sync_clustering_scheduler_auth_gate(force=True)
             _start_clustering_auth_monitor()
-            _start_clustering_ingest_worker()
             logger.info('Task clustering service initialised (scheduler_active=%s unlocked=%s)', _clustering_scheduler_active, unlocked)
         else:
             logger.warning('Task clustering service skipped: shared ChromaDB client is None')
@@ -868,7 +792,6 @@ def stop():
     """Shut down the OCR service and IPC server."""
     global _clustering_scheduler_active, _clustering_auth_monitor_thread
     stop_event.set()
-    _stop_clustering_ingest_worker()
     if _clustering_scheduler:
         try:
             _clustering_scheduler.stop()

--- a/monitor/smart_cluster_worker.py
+++ b/monitor/smart_cluster_worker.py
@@ -446,11 +446,11 @@ class SmartClusterWorker:
         """Return a tuple of (valid_ids, (N, D) array of MiniLM vectors).
 
         Reuses embeddings already stored in the ``task_vectors`` hot-layer
-        collection (computed during ``HotColdManager.add_snapshot``); only ids
-        absent from the collection fall back to a live MiniLM forward pass.
-        Saves one encode per already-ingested snapshot, which is the common case
-        since the smart-cluster pending queue is populated right after the hot
-        layer insert.
+        collection; only ids absent from the collection fall back to a live
+        MiniLM forward pass. Since M2.5 step 5 those rows are mirrored in by
+        Rust, which queues the pending entry and sends the vector in the same
+        pass, so the fallback now also covers the short window between the two
+        and any mirror that did not arrive at all.
         """
         fetched: Dict[int, np.ndarray] = {}
 

--- a/monitor/storage_client.py
+++ b/monitor/storage_client.py
@@ -14,30 +14,7 @@ logger = logging.getLogger(__name__)
 import win32file
 import win32pipe
 import pywintypes
-from typing import NamedTuple, Optional, Dict, Any, List
-
-
-class MinilmMirrorResult(NamedTuple):
-    """Outcome of one MiniLM dual-write batch, split by what to do next.
-
-    Rust serves natural-language retrieval from the mirrored store and stands
-    down while any mirror is outstanding, so "the batch failed" is not a useful
-    answer on its own — the caller has to know which rows are worth queueing.
-
-    ``retry_ids`` is ``None`` when the batch failed as a whole (the pipe was
-    down, the vault was locked, the response was malformed) and nothing is known
-    about individual rows; the caller then re-queues everything it sent.
-    ``dropped_ids`` are rows Rust rejected permanently — a deleted screenshot,
-    a malformed vector — which must be forgotten rather than retried forever.
-    """
-
-    delivered: bool
-    retry_ids: Optional[List[str]]
-    dropped_ids: List[str]
-
-    @classmethod
-    def whole_batch_failed(cls) -> "MinilmMirrorResult":
-        return cls(delivered=False, retry_ids=None, dropped_ids=[])
+from typing import Optional, Dict, Any, List
 
 
 IPC_PROTOCOL_VERSION = 2
@@ -108,9 +85,6 @@ READ_RETRY_COMMANDS = {
 
 IDEMPOTENT_RETRY_COMMANDS = {
     'update_screenshot_category',
-    'upsert_minilm_derived_embeddings',
-    'delete_minilm_derived_embeddings',
-    'report_minilm_import_debt',
     'set_ocr_postprocess_status',
     'record_ocr_postprocess_retry',
     'smart_cluster_enqueue_pending',
@@ -751,82 +725,6 @@ class StorageClient:
         if response.get('status') == 'success':
             return response.get('data', {'screenshots': []})
         raise RuntimeError(response.get('error', 'Unknown error during IPC get_screenshots_with_ocr_by_ids'))
-
-    def upsert_minilm_derived_embeddings(
-        self,
-        records: List[Dict[str, Any]],
-        pending_imports: int = 0,
-    ) -> MinilmMirrorResult:
-        """Batch dual-write of Python-produced MiniLM vectors to Rust.
-
-        ``pending_imports`` is how many mirrors are still queued for retry after
-        this batch. Rust reads it to decide whether its copy of the index is
-        complete enough to answer semantic queries, so understating it is worse
-        than reporting nothing.
-
-        Returns a :class:`MinilmMirrorResult` rather than a bare success flag,
-        because the caller has to tell a row worth retrying from one Rust will
-        reject every time it is offered.
-        """
-        if not records:
-            return MinilmMirrorResult(delivered=True, retry_ids=[], dropped_ids=[])
-        if len(records) > 128:
-            raise ValueError('MiniLM dual-write batch exceeds 128 records')
-        response = self._send_request({
-            'command': 'upsert_minilm_derived_embeddings',
-            'records': records,
-            'pending_imports': max(0, int(pending_imports)),
-        })
-        if response.get('status') != 'success':
-            return MinilmMirrorResult.whole_batch_failed()
-        errors = response.get('data', {}).get('errors', [])
-        if not isinstance(errors, list):
-            return MinilmMirrorResult.whole_batch_failed()
-        retry_ids: List[str] = []
-        dropped_ids: List[str] = []
-        for entry in errors:
-            if not isinstance(entry, dict):
-                # An unreadable error entry says nothing about which row failed,
-                # so fall back to re-queueing the whole batch.
-                return MinilmMirrorResult.whole_batch_failed()
-            doc_id = str(entry.get('screenshot_id', ''))
-            # Absent means an older Rust build that does not classify its
-            # rejections. Retrying is the safe reading: it can waste work, while
-            # dropping a row that was only transiently rejected loses it.
-            if entry.get('permanent') is True:
-                dropped_ids.append(doc_id)
-            else:
-                retry_ids.append(doc_id)
-        return MinilmMirrorResult(
-            delivered=not errors,
-            retry_ids=retry_ids,
-            dropped_ids=dropped_ids,
-        )
-
-    def report_minilm_import_debt(self, pending_imports: int) -> bool:
-        """Tell Rust how many MiniLM mirrors are still owed, writing nothing.
-
-        Rust's debt counter is process-global and starts at zero, so without
-        this the durable queue loaded at monitor startup would be invisible to
-        it and it would rank against an index it wrongly believed complete.
-        """
-        response = self._send_request({
-            'command': 'report_minilm_import_debt',
-            'pending_imports': max(0, int(pending_imports)),
-        })
-        return response.get('status') == 'success'
-
-    def delete_minilm_derived_embeddings(self, screenshot_ids: List[int]) -> bool:
-        """Mirror hot-layer expiry into the Rust-derived semantic cache."""
-        if not screenshot_ids:
-            return True
-        if len(screenshot_ids) > 128:
-            raise ValueError('MiniLM delete batch exceeds 128 records')
-        response = self._send_request({
-            'command': 'delete_minilm_derived_embeddings',
-            'screenshot_ids': [int(value) for value in screenshot_ids],
-        })
-        return response.get('status') == 'success'
 
     def update_screenshot_category(
         self,

--- a/monitor/task_clustering.py
+++ b/monitor/task_clustering.py
@@ -43,10 +43,31 @@ class ModelNotAvailableError(Exception):
     pass
 
 
+class ManagerBusyError(Exception):
+    """Raised when the hot-layer manager lock could not be taken in time.
+
+    Now that ``run_clustering`` no longer holds the manager lock across its
+    whole body, that lock is only ever held for a single Chroma call or a lazy
+    handle creation, so this should be unreachable. It exists to assert the
+    invariant rather than to be recovered from: the Rust mirror reads an
+    ``error`` field in the response body as a best-effort miss and moves on,
+    which beats parking a named-pipe handler thread for the length of a
+    clustering run.
+    """
+    pass
+
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 EMBEDDING_DIM = 384
+# Longest a hot-layer write will wait for the manager lock before reporting
+# itself busy. Generous next to the milliseconds a Chroma upsert needs, and
+# short next to the minutes a clustering run takes. The longest legitimate
+# holds left are in the task-vector export path, which cannot overlap a mirror:
+# the migration that drives it holds the Rust maintenance guard, and the index
+# worker refuses to run while that guard is held.
+MANAGER_LOCK_BUSY_TIMEOUT_SECS = 5.0
 MAX_TASK_VECTOR_EXPORTS = 4
 TASK_VECTOR_EXPORT_LOGICAL_TIMEOUT_SECS = 10 * 60
 TASK_VECTOR_EXPORT_IDLE_TTL_SECS = 24 * 60 * 60
@@ -172,6 +193,39 @@ class TaskEmbedder:
             self._is_onnx = False
             logger.info("MiniLM-L12-v2 loaded (device=%s)", self._model.device)
 
+    def _acquire_runtime(self, attempts: int = 3):
+        """Return a consistent ``(model, tokenizer, is_onnx)`` snapshot.
+
+        The three pieces are read together under ``_lock`` so a concurrent
+        :meth:`unload` cannot null one of them between the reads. The caller
+        then runs its forward pass against these local references: an unload
+        landing mid-pass drops the singleton's handles while the objects
+        themselves stay alive until that pass returns.
+
+        ``Reranker.rerank`` has always done exactly this — snapshot the session
+        and tokenizer under its lock, then run the forward pass outside it —
+        which is why the reranker never had this bug and this class did.
+
+        The snapshot is what lets ``run_clustering`` keep unloading the model in
+        its ``finally``, worth ~479 MB resident on the ONNX backend, while no
+        longer holding the manager lock across the whole run. A foreground NL
+        search encodes outside that lock on purpose, and until now ``encode``
+        read ``_is_onnx``, ``_tokenizer`` and ``_model`` as three separate
+        unguarded attribute loads, so an interleaved unload turned the third
+        one into ``'NoneType' object has no attribute 'get_inputs'``.
+        """
+        for _ in range(max(1, attempts)):
+            self.load()
+            with self._lock:
+                # `load` assigns the tokenizer before the model on both
+                # backends, so a non-None model implies a usable tokenizer.
+                # Keep that order if either branch is ever rewritten.
+                if self._model is not None:
+                    return self._model, self._tokenizer, self._is_onnx
+        raise ModelNotAvailableError(
+            "MiniLM was unloaded repeatedly while a caller was trying to use it"
+        )
+
     def unload(self):
         """Release model & tokenizer to free memory."""
         with self._lock:
@@ -195,10 +249,13 @@ class TaskEmbedder:
 
     def encode(self, texts: List[str]) -> np.ndarray:
         """Batch-encode texts → (N, 384) L2-normalised numpy array."""
-        self.load()
+        # One consistent snapshot, then a forward pass on local references only:
+        # a concurrent unload() must not be able to null the model out from
+        # under a pass that has already started. See _acquire_runtime.
+        model, tokenizer, is_onnx = self._acquire_runtime()
 
-        if self._is_onnx:
-            encoded = self._tokenizer(
+        if is_onnx:
+            encoded = tokenizer(
                 texts,
                 padding=True,
                 truncation=True,
@@ -206,8 +263,8 @@ class TaskEmbedder:
                 return_tensors="np",
             )
             from onnx_utils import build_transformer_inputs
-            inputs = build_transformer_inputs(self._model, encoded)
-            outputs = self._model.run(None, inputs)
+            inputs = build_transformer_inputs(model, encoded)
+            outputs = model.run(None, inputs)
             token_embeddings = outputs[0]
 
             attention_mask = encoded["attention_mask"]
@@ -222,7 +279,7 @@ class TaskEmbedder:
 
         import torch
 
-        encoded = self._tokenizer(
+        encoded = tokenizer(
             texts,
             padding=True,
             truncation=True,
@@ -230,7 +287,7 @@ class TaskEmbedder:
             return_tensors="pt",
         )
         with torch.no_grad():
-            out = self._model(**encoded)
+            out = model(**encoded)
             # Mean pooling (standard for sentence-transformers)
             attention_mask = encoded["attention_mask"]
             token_embeddings = out.last_hidden_state
@@ -503,9 +560,19 @@ class HotColdManager:
             max_workers=1,
             thread_name_prefix="task-vector-export",
         )
-        # run_clustering calls helpers/properties that also acquire this lock.
-        # Use RLock to avoid self-deadlock on nested acquisitions.
+        # Guards Chroma collection access and the lazy collection handles, and
+        # nothing else. Held only for the length of one Chroma call, because
+        # every caller that reaches it may be a named-pipe handler thread and a
+        # parked handler costs a slot out of the IPC server's pool of 8.
+        # Still an RLock: the collection properties re-acquire it beneath
+        # callers that hold it.
         self._lock = threading.RLock()
+        # Separate, and deliberately not the manager lock: mutual exclusion
+        # between clustering runs only. Two concurrent HDBSCAN runs would
+        # double peak memory on a machine already checked for low memory, and
+        # the scheduler's plain `_running` bool has a check-then-set race
+        # between a scheduled run and a manual one.
+        self._clustering_lock = threading.Lock()
 
         logger.info("[task_clustering] HotColdManager ready (lazy loading collections)")
 
@@ -538,20 +605,34 @@ class HotColdManager:
             return self._cold_collection
 
     def unload_collections(self):
-        """Unload collections from memory to save HNSW overhead."""
+        """Drop the cached collection handles.
+
+        This does **not** free the HNSW indexes, despite what its previous name
+        and comment claimed. Measured on chromadb 1.5.1 against this project's
+        own 10,605-vector hot layer (2026-07-30): dropping the handles releases
+        0.0 MB, and the next query still answers in 1.7 ms against a 24 ms cold
+        load, so the index never left memory.
+
+        Two reasons. The index lives in the Rust core's cache
+        (``chroma_api_impl`` defaults to ``chromadb.api.rust.RustBindingsAPI``),
+        sized ``_getmaxstdio() // 5`` = 102 collections, which this database's
+        two collections never come close to filling, so nothing is ever
+        evicted. And the ``_client._collections`` pop this method used to
+        attempt was dead code: 1.5.1's client has no such attribute, so the
+        ``hasattr`` guard was always False. Only dropping the whole client
+        returns the memory (223 MB for both collections, ``_server.stop()``),
+        and that client is shared with the CLIP ``screenshots`` collection, so
+        a clustering run has no business dropping it.
+
+        What remains is still worth doing and cheap: the next access rebuilds a
+        fresh handle. Keep the lock, which makes the delete atomic against the
+        lazy initialisation in the collection properties.
+        """
         with self._lock:
             if hasattr(self, "_hot_collection"):
                 delattr(self, "_hot_collection")
             if hasattr(self, "_cold_collection"):
                 delattr(self, "_cold_collection")
-            
-            # Try to drop from Chroma's internal cache
-            try:
-                if hasattr(self._client, "_collections"):
-                    self._client._collections.pop("task_vectors", None)
-                    self._client._collections.pop("task_centroids", None)
-            except Exception:
-                pass
 
     # ---- encrypt / decrypt helpers (mirror VectorStore pattern) ----------
 
@@ -941,12 +1022,28 @@ class HotColdManager:
             })
             documents.append(self._encrypt(document))
 
-        self.hot_collection.upsert(
-            ids=ids,
-            embeddings=embeddings,
-            metadatas=metadatas,
-            documents=documents,
-        )
+        # Bounded acquisition, on purpose. This method runs inside a named-pipe
+        # handler thread, and the pool has 8 slots: parking here for the length
+        # of a clustering run drains the pool and takes `status`, `search_nl`
+        # and the OCR post-process enqueue down with it. Now that the manager
+        # lock is only held for single Chroma calls this can never fire, which
+        # is exactly what makes it a useful assertion. Note the encryption
+        # above stays outside the lock — it is a reverse-IPC round trip per
+        # field, and the lock must never wait on the pipe.
+        if not self._lock.acquire(timeout=MANAGER_LOCK_BUSY_TIMEOUT_SECS):
+            raise ManagerBusyError(
+                "hot layer busy: manager lock held for more than "
+                f"{MANAGER_LOCK_BUSY_TIMEOUT_SECS:g}s"
+            )
+        try:
+            self.hot_collection.upsert(
+                ids=ids,
+                embeddings=embeddings,
+                metadatas=metadatas,
+                documents=documents,
+            )
+        finally:
+            self._lock.release()
         return len(ids)
 
     # M2.5 step 5 removed `_dual_write_rust` and `add_snapshot` from this class.
@@ -1097,13 +1194,21 @@ class HotColdManager:
         # M2.5 step 5 the Rust semantic store keeps its own 30-day window
         # against SQLite timestamps, so the deletions no longer have to be
         # mirrored across. The two stores stop tracking each other.
+        #
+        # The read and the delete need the manager lock as a pair. They used to
+        # get it for free from the lock `run_clustering` held across its whole
+        # body; that lock is gone, and without this an id that a Rust mirror
+        # re-upserts between the two calls would be deleted right back out
+        # again. Both calls are single Chroma operations, so the hold is short
+        # enough not to reintroduce the pipe-handler stall.
         try:
-            expired = self.hot_collection.get(
-                where={"timestamp": {"$lt": cutoff}},
-            )
-            if expired["ids"]:
-                self.hot_collection.delete(ids=expired["ids"])
-                logger.info("Removed %d expired vectors from hot layer", len(expired["ids"]))
+            with self._lock:
+                expired = self.hot_collection.get(
+                    where={"timestamp": {"$lt": cutoff}},
+                )
+                if expired["ids"]:
+                    self.hot_collection.delete(ids=expired["ids"])
+                    logger.info("Removed %d expired vectors from hot layer", len(expired["ids"]))
         except Exception as e:
             logger.warning("Failed to clean expired hot vectors: %s", e)
 
@@ -1237,7 +1342,11 @@ class HotColdManager:
                     vectors = self._embedder.encode(texts_to_encode)
                     batch_ids = [e[0] for e in entries]
                     batch_metas = [e[1] for e in entries]
-                    self.hot_collection.add(
+                    # upsert, not add: a Rust mirror for one of these ids can now
+                    # interleave with the backfill, and `add` would fail the whole
+                    # page on the duplicate. That also demotes the dedupe `get`
+                    # above from a correctness requirement to an optimisation.
+                    self.hot_collection.upsert(
                         ids=batch_ids,
                         embeddings=vectors.tolist(),
                         metadatas=batch_metas,
@@ -1245,7 +1354,7 @@ class HotColdManager:
                     added += len(batch_ids)
                     logger.info("Backfilled %d/%d (page offset %d)", added, total, offset)
                 except Exception as e:
-                    logger.warning("Backfill encode/add failed at offset %d: %s", offset, e)
+                    logger.warning("Backfill encode/upsert failed at offset %d: %s", offset, e)
 
             offset += PAGE
 
@@ -1279,7 +1388,37 @@ class HotColdManager:
 
         Returns clustering results dict.
         """
-        with self._lock:
+        # Deliberately NOT the manager lock. That lock guards Chroma access and
+        # the lazy collection handles; holding it across this whole body — the
+        # input estimate, the vector fetch, the HDBSCAN/PaCMAP engine run, the
+        # per-cluster decrypt round trips and the backfill's re-encode — parked
+        # every incoming `upsert_task_vectors` mirror inside a named-pipe
+        # handler thread for minutes at a time, one slot per idle pass, until
+        # the pool of 8 was gone and the whole forward pipe answered "IPC server
+        # busy".
+        #
+        # The invariant restored here used to be spelled out in
+        # `_flush_pending_rust_deletes`, which M2.5 step 5 deleted along with
+        # the rest of the Python capture path: "IPC happens outside the lock;
+        # the manager lock also guards Chroma operations and must not wait on
+        # pipe round-trips." It reads the same in both directions — a lock that
+        # guards Chroma must not be held across IPC, and IPC must not wait on it.
+        #
+        # What we give up is that a run clusters the snapshot taken at its start
+        # rather than a corpus frozen for its duration. For an unsupervised
+        # background job over a 30-day window that is not a loss: a screenshot
+        # arriving mid-run is picked up by the next run.
+        if not self._clustering_lock.acquire(blocking=False):
+            logger.info("Clustering run refused: another run is in progress")
+            return {
+                "clusters": [],
+                "noise_ids": [],
+                "n_clusters": 0,
+                "n_noise": 0,
+                "n_total": 0,
+                "status": "already_running",
+            }
+        try:
             logger.info("Starting clustering run (range=%s–%s) …",
                         start_time or "auto", end_time or "auto")
 
@@ -1411,10 +1550,17 @@ class HotColdManager:
                     "clustering_mode": "batched" if use_approximate else "full",
                 }
             finally:
-                # Always unload the model after clustering to free memory
+                # Reclaims ~479 MB on the ONNX backend, measured 2026-07-30, so
+                # this stays even though the run no longer holds a lock that
+                # would keep other users away. TaskEmbedder._acquire_runtime is
+                # what makes it safe: an in-flight encode holds its own
+                # references and finishes on them.
                 self._embedder.unload()
-                # Unload collections to save HNSW memory overhead when idle
+                # Frees no memory — see unload_collections. Kept because the
+                # next access should start from a fresh handle.
                 self.unload_collections()
+        finally:
+            self._clustering_lock.release()
 
     # ---- Scheduled re-run helper -----------------------------------------
 
@@ -1476,13 +1622,14 @@ class HotColdManager:
         if enable_rerank:
             fetch_n = max(fetch_n, fetch_n * max(1, int(rerank_overfetch)))
 
-        with self._lock:
-            self._embedder.load()
-        # MiniLM forward (~50-200 ms on CPU) deliberately runs OUTSIDE the
-        # manager lock: holding it across encode would stall the foreground
-        # OCR ingest path on every NL search. The embedder's own state is
-        # already protected by load() being a no-op after first call and
-        # encode_single being thread-safe at the model level.
+        # No manager lock around the model load, and none around the forward
+        # pass. Both were the wrong place for it: this runs in a named-pipe
+        # handler thread, and a cold load takes 1.5 s on the ONNX backend and
+        # 22 s on torch — time the manager lock must never spend, since every
+        # hot-layer write waits behind it. TaskEmbedder now hands out a
+        # consistent (model, tokenizer, backend) snapshot per call, so an
+        # unload from a finishing clustering run cannot tear the model down
+        # underneath this encode.
         vec = self._embedder.encode_single(query.strip())
 
         try:
@@ -1713,6 +1860,13 @@ class ClusteringScheduler:
                 manual=False,
                 allow_full_low_memory=CLUSTERING_ALLOW_FULL_LOW_MEMORY,
             )
+            if result.get("status") == "already_running":
+                # A manual run beat us to the clustering guard. Do not touch
+                # `_last_run`: treating this as a completed run would push the
+                # next scheduled attempt out by a whole interval. Returning
+                # False sends the loop into its 60 s backoff instead.
+                logger.info("Scheduled clustering yielded to a run already in progress")
+                return False
             self._last_result = result
             self._last_run = time.time()
             self._save_config()

--- a/monitor/task_clustering.py
+++ b/monitor/task_clustering.py
@@ -47,17 +47,6 @@ class ModelNotAvailableError(Exception):
 # Constants
 # ---------------------------------------------------------------------------
 EMBEDDING_DIM = 384
-RUST_DUAL_WRITE_BATCH_SIZE = 32
-# Upper bound on the durable import-retry queue. The queue is normally bounded
-# by the hot layer itself, because entries Chroma no longer holds are pruned on
-# every flush; this cap only matters if the mirror stays unreachable for months.
-MAX_PENDING_RUST_IMPORTS = 100_000
-# The import-retry queue is journalled by appending. Re-queueing the same id
-# writes another line, so the file is compacted once it grows to several times
-# the live queue — the floor keeps small, healthy queues from compacting on
-# every pass.
-RUST_IMPORT_JOURNAL_COMPACT_FACTOR = 4
-RUST_IMPORT_JOURNAL_COMPACT_FLOOR = 512
 MAX_TASK_VECTOR_EXPORTS = 4
 TASK_VECTOR_EXPORT_LOGICAL_TIMEOUT_SECS = 10 * 60
 TASK_VECTOR_EXPORT_IDLE_TTL_SECS = 24 * 60 * 60
@@ -514,23 +503,9 @@ class HotColdManager:
             max_workers=1,
             thread_name_prefix="task-vector-export",
         )
-        self._pending_rust_deletes = set()
-        self._pending_rust_imports = set()
-        self._rust_import_journal_lines = 0
         # run_clustering calls helpers/properties that also acquire this lock.
         # Use RLock to avoid self-deadlock on nested acquisitions.
         self._lock = threading.RLock()
-
-        self._load_pending_rust_deletes()
-        self._load_pending_rust_imports()
-        if self._pending_rust_imports:
-            # Rust's debt counter lives in its process, not on disk, so a
-            # backlog that survived a restart is invisible to it until someone
-            # says so. Until it hears this, it would rank a knowably incomplete
-            # index and return results that quietly omit screenshots. Reported
-            # here rather than waiting for the next capture, which may be
-            # minutes away or, with the monitor paused, may never come.
-            self._report_import_debt()
 
         logger.info("[task_clustering] HotColdManager ready (lazy loading collections)")
 
@@ -618,14 +593,6 @@ class HotColdManager:
     @classmethod
     def _task_vector_export_dir(cls, export_id: str) -> str:
         return os.path.join(cls._migration_artifact_root(), export_id)
-
-    @classmethod
-    def _rust_delete_retry_path(cls) -> str:
-        return os.path.join(cls._migration_artifact_root(), "rust-delete-retry.json")
-
-    @classmethod
-    def _rust_import_retry_path(cls) -> str:
-        return os.path.join(cls._migration_artifact_root(), "rust-import-retry.json")
 
     @staticmethod
     def _validate_export_id(export_id: str) -> str:
@@ -940,329 +907,6 @@ class HotColdManager:
         shutil.rmtree(self._task_vector_export_dir(export_id) + ".tmp", ignore_errors=True)
         return state is not None
 
-    def _load_pending_rust_deletes(self) -> None:
-        path = self._rust_delete_retry_path()
-        try:
-            with open(path, "r", encoding="utf-8") as stream:
-                values = json.load(stream)
-            self._pending_rust_deletes = {
-                str(value) for value in values if str(value).isdigit() and int(value) > 0
-            }
-        except FileNotFoundError:
-            self._pending_rust_deletes = set()
-        except Exception:
-            logger.exception("failed to load pending Rust MiniLM deletions")
-            self._pending_rust_deletes = set()
-
-    def _persist_pending_rust_deletes(self) -> None:
-        path = self._rust_delete_retry_path()
-        try:
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            temp_path = path + ".tmp"
-            # The whole snapshot-write-replace sequence stays under the lock:
-            # concurrent writers would otherwise race on the same .tmp file
-            # (os.replace fails on Windows while the file is open).
-            with self._lock:
-                snapshot = sorted(self._pending_rust_deletes, key=int)
-                with open(temp_path, "w", encoding="utf-8") as stream:
-                    json.dump(snapshot, stream)
-                    stream.flush()
-                    os.fsync(stream.fileno())
-                os.replace(temp_path, path)
-        except Exception:
-            logger.exception("failed to persist pending Rust MiniLM deletions")
-
-    def _flush_pending_rust_deletes(self) -> None:
-        if not self._storage_client:
-            return
-        with self._lock:
-            pending = sorted(self._pending_rust_deletes, key=int)
-        if not pending:
-            return
-        for offset in range(0, len(pending), 128):
-            batch = pending[offset:offset + 128]
-            try:
-                # IPC happens outside the lock; the manager lock also guards
-                # Chroma operations and must not wait on pipe round-trips.
-                if not self._storage_client.delete_minilm_derived_embeddings(
-                    [int(value) for value in batch]
-                ):
-                    break
-                with self._lock:
-                    self._pending_rust_deletes.difference_update(batch)
-            except Exception:
-                logger.debug("Rust MiniLM delete retry failed", exc_info=True)
-                break
-        self._persist_pending_rust_deletes()
-
-    def _queue_rust_deletes(self, ids: List[str]) -> None:
-        with self._lock:
-            self._pending_rust_deletes.update(str(value) for value in ids)
-        self._persist_pending_rust_deletes()
-        self._flush_pending_rust_deletes()
-
-    # ---- Rust MiniLM import retry ----------------------------------------
-    #
-    # The mirror of the deletion queue above, and it exists for the same kind
-    # of reason. Deletions were made durable so Rust could never surface a
-    # screenshot the user removed. Insertions need durability now that Rust
-    # *serves* semantic retrieval: a mirror that is dropped and forgotten
-    # leaves a screenshot permanently unfindable, with nothing on either side
-    # recording that it went missing. Only ids are queued; the vector is read
-    # back from Chroma, which stays authoritative, so a retry can never write
-    # a vector that disagrees with the hot layer.
-    #
-    # The queue is stored as an append-only journal of ids, one per line,
-    # rather than as a rewritten JSON array. Queueing happens on the capture
-    # path, and the queue is large exactly when the mirror has been failing for
-    # a long time, so rewriting the whole file per screenshot would make the
-    # capture path slowest in the situation that already went wrong. Appending
-    # costs one small write regardless of how much is queued. Removals cannot
-    # be expressed by appending, so they compact the file instead — and that
-    # only happens when the queue actually shrank, which is progress.
-
-    def _load_pending_rust_imports(self) -> None:
-        path = self._rust_import_retry_path()
-        try:
-            with open(path, "r", encoding="utf-8") as stream:
-                raw = stream.read()
-            queued, lines = self._parse_rust_import_journal(raw)
-            self._pending_rust_imports = queued
-            self._rust_import_journal_lines = lines
-        except FileNotFoundError:
-            self._pending_rust_imports = set()
-            self._rust_import_journal_lines = 0
-        except Exception:
-            logger.exception("failed to load pending Rust MiniLM imports")
-            self._pending_rust_imports = set()
-            self._rust_import_journal_lines = 0
-
-    @staticmethod
-    def _parse_rust_import_journal(raw: str) -> Tuple[set, int]:
-        """Read the id journal, accepting the JSON array earlier builds wrote.
-
-        Returns the live queue and how many entries the file spent on it — the
-        two differ once an id has been appended more than once, which is what
-        the compaction threshold watches.
-        """
-        text = raw.strip()
-        if not text:
-            return set(), 0
-        values = json.loads(text) if text.startswith("[") else text.splitlines()
-        entries = [
-            str(value).strip()
-            for value in values
-            if str(value).strip().isdigit() and int(str(value).strip()) > 0
-        ]
-        return set(entries), len(entries)
-
-    def _append_pending_rust_imports(self, ids: List[str]) -> None:
-        """Record newly queued ids without rewriting what is already on disk."""
-        if not ids:
-            return
-        path = self._rust_import_retry_path()
-        try:
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            with self._lock:
-                with open(path, "a", encoding="utf-8") as stream:
-                    stream.write("".join(f"{value}\n" for value in ids))
-                    stream.flush()
-                    os.fsync(stream.fileno())
-                self._rust_import_journal_lines += len(ids)
-        except Exception:
-            logger.exception("failed to append pending Rust MiniLM imports")
-
-    def _compact_pending_rust_imports(self) -> None:
-        """Rewrite the journal so it holds exactly the live queue."""
-        path = self._rust_import_retry_path()
-        try:
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            temp_path = path + ".tmp"
-            # Same locking rule as the deletion queue: the snapshot, write and
-            # replace stay together, because os.replace fails on Windows while
-            # another writer still holds the same .tmp file open.
-            with self._lock:
-                snapshot = sorted(self._pending_rust_imports, key=int)
-                with open(temp_path, "w", encoding="utf-8") as stream:
-                    stream.write("".join(f"{value}\n" for value in snapshot))
-                    stream.flush()
-                    os.fsync(stream.fileno())
-                os.replace(temp_path, path)
-                self._rust_import_journal_lines = len(snapshot)
-        except Exception:
-            logger.exception("failed to compact pending Rust MiniLM imports")
-
-    def _pending_import_debt(self, excluding: Optional[List[str]] = None) -> int:
-        """Queued mirrors Rust does not have yet, ignoring a batch in flight."""
-        with self._lock:
-            if not excluding:
-                return len(self._pending_rust_imports)
-            return len(self._pending_rust_imports.difference(str(v) for v in excluding))
-
-    def _report_import_debt(self) -> None:
-        """Tell Rust how far behind its copy of the index is.
-
-        Rust's counter is process-global and starts at zero, so it cannot see a
-        queue that was loaded from disk at monitor startup, nor one that only
-        changed because rows were dropped rather than written. Left unreported,
-        it would rank against an index it wrongly believed complete — results
-        that look normal while quietly missing screenshots.
-        """
-        if not self._storage_client:
-            return
-        try:
-            self._storage_client.report_minilm_import_debt(self._pending_import_debt())
-        except Exception:
-            logger.debug("could not report the Rust MiniLM import debt", exc_info=True)
-
-    def _queue_rust_imports(self, ids: List[str]) -> None:
-        values = [str(value) for value in ids]
-        with self._lock:
-            was_empty = not self._pending_rust_imports
-            added = [value for value in values if value not in self._pending_rust_imports]
-            self._pending_rust_imports.update(added)
-            overflow = len(self._pending_rust_imports) - MAX_PENDING_RUST_IMPORTS
-            if overflow > 0:
-                # Screenshot ids are monotonic, so the newest entries are the
-                # largest. Reaching this cap means the mirror has been
-                # unreachable for a very long time; the queue stays non-empty
-                # either way, which is what keeps Rust retrieval standing down
-                # until the backlog is paid.
-                ordered = sorted(self._pending_rust_imports, key=int)
-                self._pending_rust_imports = set(ordered[overflow:])
-                logger.warning(
-                    "Rust MiniLM import queue exceeded %d entries; dropped %d oldest",
-                    MAX_PENDING_RUST_IMPORTS,
-                    overflow,
-                )
-        if was_empty:
-            # First loss after a healthy stretch. Worth a warning: from here on
-            # semantic retrieval is served by Python until the queue drains.
-            logger.warning(
-                "Rust MiniLM mirror failed for %d vector(s); queued for retry", len(values)
-            )
-        if overflow > 0:
-            # The queue shrank as well as grew, which appending cannot express.
-            self._compact_pending_rust_imports()
-        else:
-            self._append_pending_rust_imports(added)
-
-    def _settle_rust_imports(self, settled: set) -> None:
-        """Drop ids that no longer need mirroring and compact the journal."""
-        if not settled:
-            self._maybe_compact_rust_import_journal()
-            return
-        with self._lock:
-            self._pending_rust_imports.difference_update(settled)
-        self._compact_pending_rust_imports()
-
-    def _maybe_compact_rust_import_journal(self) -> None:
-        """Collapse a journal that repeated re-queueing has left mostly stale.
-
-        Appending the same id twice is harmless for correctness — the loader
-        deduplicates — but a queue that keeps failing the same rows would grow
-        the file without bound. Compacting once it is several times the live
-        set keeps the file proportional to the queue.
-        """
-        with self._lock:
-            live = len(self._pending_rust_imports)
-            lines = self._rust_import_journal_lines
-        if lines <= RUST_IMPORT_JOURNAL_COMPACT_FLOOR:
-            return
-        if lines < live * RUST_IMPORT_JOURNAL_COMPACT_FACTOR:
-            return
-        self._compact_pending_rust_imports()
-
-    def _flush_pending_rust_imports(self) -> None:
-        """Re-send queued mirrors, reading each vector back from Chroma."""
-        if not self._storage_client:
-            return
-        with self._lock:
-            pending = sorted(self._pending_rust_imports, key=int)
-        if not pending:
-            return
-
-        settled = set()
-        try:
-            collection = self.hot_collection
-            if collection is None:
-                return
-
-            for offset in range(0, len(pending), RUST_DUAL_WRITE_BATCH_SIZE):
-                batch = pending[offset:offset + RUST_DUAL_WRITE_BATCH_SIZE]
-                try:
-                    stored = collection.get(ids=batch, include=["embeddings"])
-                except Exception:
-                    logger.debug("Rust MiniLM import retry could not read Chroma", exc_info=True)
-                    break
-
-                found_ids = list(stored.get("ids") or [])
-                embeddings = stored.get("embeddings")
-                embeddings = [] if embeddings is None else list(embeddings)
-                records = [
-                    {
-                        "screenshot_id": int(doc_id),
-                        "embedding": np.asarray(vector, dtype=np.float32).tolist(),
-                    }
-                    for doc_id, vector in zip(found_ids, embeddings)
-                ]
-                # Ids Chroma no longer holds expired or were deleted while the
-                # queue waited. Rust has nothing to mirror for them, and the
-                # deletion queue owns removing anything it already has.
-                found = set(found_ids)
-                settled.update(value for value in batch if value not in found)
-
-                if not records:
-                    continue
-                try:
-                    outcome = self._storage_client.upsert_minilm_derived_embeddings(
-                        records,
-                        # Neither the batch in flight nor anything earlier
-                        # batches already settled is still owed. Counting them
-                        # would keep Rust standing down over a debt that is
-                        # being paid as this loop runs.
-                        pending_imports=self._pending_import_debt(
-                            excluding=batch + sorted(settled)
-                        ),
-                    )
-                except Exception:
-                    logger.debug("Rust MiniLM import retry failed", exc_info=True)
-                    break
-                if outcome.retry_ids is None:
-                    # The batch failed as a whole — a closed pipe, a locked
-                    # vault — so nothing is known about individual rows and
-                    # nothing settles. Later batches would fail the same way.
-                    logger.debug("Rust MiniLM import retry was rejected wholesale")
-                    break
-
-                sent = {str(record["screenshot_id"]) for record in records}
-                settled.update(sent.difference(outcome.retry_ids))
-                if outcome.dropped_ids:
-                    # Rust will never accept these: their screenshots are gone
-                    # from SQLite, or their vectors are malformed. Chroma keeps
-                    # documents for deleted screenshots until they age out, so
-                    # this is the expected fate of a queued id the user deletes.
-                    # Keeping them queued would hold Rust retrieval down for as
-                    # long as the queue lives, which is to say forever.
-                    logger.info(
-                        "Rust MiniLM mirror permanently rejected %d queued vector(s); dropping",
-                        len(outcome.dropped_ids),
-                    )
-                if len(outcome.retry_ids) == len(records):
-                    # Nothing in this batch got through. That reads as a
-                    # condition affecting every row rather than a bad row, so
-                    # stop instead of walking the rest of the backlog into it.
-                    break
-        finally:
-            self._settle_rust_imports(settled)
-            # Reported on every pass, including the ones that wrote nothing:
-            # rows that were dropped or found missing change the debt without
-            # any dual-write having carried the new number to Rust.
-            self._report_import_debt()
-
-        if not self._pending_import_debt():
-            logger.info("Rust MiniLM import queue drained")
-
     def upsert_task_vectors(self, records: List[Dict[str, Any]]) -> int:
         """Write Rust-generated MiniLM vectors to the authoritative hot layer."""
         if not isinstance(records, list) or not records:
@@ -1305,121 +949,16 @@ class HotColdManager:
         )
         return len(ids)
 
-    def _dual_write_rust(self, ids: List[str], vectors) -> None:
-        """Mirror to the Rust derived store; Chroma success remains authoritative.
-
-        A failure here is no longer allowed to vanish. Rust serves non-reranked
-        semantic retrieval from this store, so a vector that never arrives is a
-        screenshot that can never be found again by natural-language search.
-        Failed ids go to the durable retry queue, and the queue length travels
-        with every write so the Rust side can stand down until it is paid.
-
-        Only the rows that actually failed are queued, and only the ones that
-        could still succeed. A row Rust accepted does not need retrying, and a
-        row it rejected permanently never will — queueing either would inflate
-        the debt that keeps retrieval on Python.
-        """
-        if not self._storage_client or not ids:
-            return
-        for offset in range(0, len(ids), RUST_DUAL_WRITE_BATCH_SIZE):
-            batch_ids = ids[offset:offset + RUST_DUAL_WRITE_BATCH_SIZE]
-            batch_vectors = vectors[offset:offset + RUST_DUAL_WRITE_BATCH_SIZE]
-            records = [
-                {
-                    "screenshot_id": int(doc_id),
-                    "embedding": np.asarray(vector, dtype=np.float32).tolist(),
-                }
-                for doc_id, vector in zip(batch_ids, batch_vectors)
-            ]
-            try:
-                outcome = self._storage_client.upsert_minilm_derived_embeddings(
-                    records,
-                    pending_imports=self._pending_import_debt(excluding=batch_ids),
-                )
-            except Exception as e:
-                logger.debug("[task_clustering] Rust MiniLM dual-write failed: %s", e)
-                # No response at all: same standing as a wholesale rejection —
-                # nothing is known per row, so every id is assumed still owed.
-                outcome = None
-            if outcome is not None and outcome.delivered:
-                continue
-            dropped = outcome.dropped_ids if outcome is not None else []
-            if dropped:
-                logger.info(
-                    "[task_clustering] Rust MiniLM mirror permanently rejected %d vector(s)",
-                    len(dropped),
-                )
-            retry = (
-                [str(value) for value in batch_ids]
-                if outcome is None or outcome.retry_ids is None
-                else outcome.retry_ids
-            )
-            if retry:
-                self._queue_rust_imports(retry)
-
-    def add_snapshot(
-        self,
-        screenshot_id: int,
-        process_name: str,
-        window_title: str,
-        ocr_text: str,
-        timestamp: float,
-        category: str = "",
-    ):
-        """Encode and store a single snapshot in the hot layer.
-
-        Silently skips if the MiniLM model is not yet downloaded.
-        The timestamp is normalised to seconds (Unix epoch).
-        """
-        if not TaskEmbedder.is_model_available():
-            return  # model not downloaded yet, skip silently
-
-        combined = build_task_text(process_name, window_title, ocr_text)
-        if not combined.strip():
-            return
-
-        # Normalise timestamp to seconds — callers may pass milliseconds
-        if timestamp > 1e12:
-            timestamp = timestamp / 1000.0
-
-        doc_id = str(screenshot_id)
-        # Check for duplicate
-        try:
-            existing = self.hot_collection.get(ids=[doc_id])
-            if existing and existing["ids"]:
-                return
-        except Exception:
-            pass
-
-        vector = self._embedder.encode_single(combined)
-
-        metadata = {
-            "screenshot_id": screenshot_id,
-            "timestamp": timestamp,
-            "process_name": self._encrypt(process_name) if process_name else "",
-            "window_title": self._encrypt(window_title) if window_title else "",
-            "category": category or "",
-            "layer": "hot",
-        }
-
-        self.hot_collection.add(
-            ids=[doc_id],
-            embeddings=[vector.tolist()],
-            metadatas=[metadata],
-            documents=[self._encrypt(combined)],
-        )
-        self._dual_write_rust([doc_id], [vector])
-        self._flush_pending_rust_deletes()
-        self._flush_pending_rust_imports()
-
-        # Enqueue for smart cluster evaluation. Best-effort and O(1) — the
-        # actual scoring happens in a separate idle-aware worker so this stays
-        # off the OCR critical path.
-        if self._storage_client:
-            try:
-                self._storage_client.smart_cluster_enqueue_pending(screenshot_id)
-            except Exception as e:
-                logger.debug("[task_clustering] smart cluster enqueue failed (non-fatal): %s", e)
+    # M2.5 step 5 removed `_dual_write_rust` and `add_snapshot` from this class.
+    # Python no longer runs MiniLM on the capture path: Rust encodes each new
+    # screenshot on its idle-gated worker, commits the vector to its own store,
+    # and hands the finished row back through `upsert_task_vectors` above. The
+    # Smart Cluster pending enqueue moved with the encoder for the same reason —
+    # it belongs next to whoever wrote the vector the prefilter reads.
+    #
+    # What is left here is the hot layer as a *consumer*: clustering reads it,
+    # `compress_to_cold` ages it, and `_backfill_from_screenshots` still rebuilds
+    # it from SQLite when it is found empty.
 
     def get_hot_vectors(self, days: int = HOT_LAYER_DAYS) -> Tuple[np.ndarray, List[str], List[Dict]]:
         """Retrieve hot-layer vectors within the time window.
@@ -1554,14 +1093,16 @@ class HotColdManager:
                 except Exception as e:
                     logger.warning("Failed to archive cluster %s to cold: %s", cid, e)
 
-        # Remove expired hot vectors
+        # Remove expired hot vectors. Only this collection's own rows: since
+        # M2.5 step 5 the Rust semantic store keeps its own 30-day window
+        # against SQLite timestamps, so the deletions no longer have to be
+        # mirrored across. The two stores stop tracking each other.
         try:
             expired = self.hot_collection.get(
                 where={"timestamp": {"$lt": cutoff}},
             )
             if expired["ids"]:
                 self.hot_collection.delete(ids=expired["ids"])
-                self._queue_rust_deletes(expired["ids"])
                 logger.info("Removed %d expired vectors from hot layer", len(expired["ids"]))
         except Exception as e:
             logger.warning("Failed to clean expired hot vectors: %s", e)
@@ -1701,7 +1242,6 @@ class HotColdManager:
                         embeddings=vectors.tolist(),
                         metadatas=batch_metas,
                     )
-                    self._dual_write_rust(batch_ids, vectors)
                     added += len(batch_ids)
                     logger.info("Backfilled %d/%d (page offset %d)", added, total, offset)
                 except Exception as e:
@@ -1739,12 +1279,6 @@ class HotColdManager:
 
         Returns clustering results dict.
         """
-        # Periodic retry for the Rust mirror, deliberately outside the manager
-        # lock (it does pipe round-trips) and outside the capture path. Without
-        # it, a backlog left by an unreachable mirror would wait for the next
-        # screenshot; a paused monitor would never clear it at all.
-        self._flush_pending_rust_imports()
-
         with self._lock:
             logger.info("Starting clustering run (range=%s–%s) …",
                         start_time or "auto", end_time or "auto")

--- a/monitor/tests/test_minilm_migration.py
+++ b/monitor/tests/test_minilm_migration.py
@@ -70,45 +70,7 @@ class FakeClient:
 
 class FakeStorageClient:
     def __init__(self):
-        self.dual_writes = []
-        self.reported_pending = []
-        self.reported_debt = []
         self.pending = []
-        self.deletes = []
-        self.fail_deletes = False
-        self.fail_upserts = False
-        # screenshot ids the fake Rust side rejects and will never accept.
-        self.permanently_rejected = set()
-
-    def upsert_minilm_derived_embeddings(self, records, pending_imports=0):
-        self.reported_pending.append(pending_imports)
-        if self.fail_upserts:
-            return tc_storage_client.MinilmMirrorResult.whole_batch_failed()
-        accepted = [
-            record for record in records
-            if str(record["screenshot_id"]) not in self.permanently_rejected
-        ]
-        dropped = [
-            str(record["screenshot_id"]) for record in records
-            if str(record["screenshot_id"]) in self.permanently_rejected
-        ]
-        if accepted:
-            self.dual_writes.append(accepted)
-        return tc_storage_client.MinilmMirrorResult(
-            delivered=not dropped,
-            retry_ids=[],
-            dropped_ids=dropped,
-        )
-
-    def report_minilm_import_debt(self, pending_imports):
-        self.reported_debt.append(pending_imports)
-        return True
-
-    def delete_minilm_derived_embeddings(self, screenshot_ids):
-        if self.fail_deletes:
-            return False
-        self.deletes.append(screenshot_ids)
-        return True
 
     def encrypt_for_chromadb(self, text):
         return text
@@ -201,220 +163,66 @@ def test_export_snapshot_is_stable_ordered_and_vector_only():
         manager.export_task_vectors_page(snapshot["export_id"])
 
 
-def test_new_snapshot_dual_writes_after_chroma_success(monkeypatch):
+def test_a_mirrored_vector_lands_in_the_hot_layer_with_its_metadata():
+    """The Rust mirror is now the only writer of new hot-layer rows.
+
+    Metadata is the part worth pinning. Clustering selects hot vectors with a
+    `timestamp` filter and the reranker scores the stored document, so a row
+    that arrived with either one missing would be silently outside every
+    clustering window and unscoreable — visible months later as degraded
+    clustering, and never as an error.
+    """
     storage = FakeStorageClient()
     manager = tc.HotColdManager(FakeClient(), storage_client=storage)
-    vector = np.full((tc.EMBEDDING_DIM,), 0.5, dtype=np.float32)
-    monkeypatch.setattr(tc.TaskEmbedder, "is_model_available", staticmethod(lambda: True))
-    monkeypatch.setattr(manager._embedder, "encode_single", lambda _text: vector)
+    vector = [0.25] * tc.EMBEDDING_DIM
 
-    manager.add_snapshot(9, "app.exe", "Title", "OCR", 456.0, "work")
+    written = manager.upsert_task_vectors([{
+        "id": "9",
+        "embedding": vector,
+        "timestamp": 456.0,
+        "process_name": "app.exe",
+        "window_title": "Title",
+        "category": "work",
+        "document": "app.exe | Title | OCR",
+    }])
 
-    assert "9" in manager.hot_collection.rows
-    assert storage.dual_writes == [[{
+    assert written == 1
+    row = manager.hot_collection.rows["9"]
+    assert row["embedding"] == vector
+    assert row["document"] == "app.exe | Title | OCR"
+    assert row["metadata"] == {
         "screenshot_id": 9,
-        "embedding": vector.tolist(),
-    }]]
-    assert storage.pending == [9]
+        "timestamp": 456.0,
+        "process_name": "app.exe",
+        "window_title": "Title",
+        "category": "work",
+        "layer": "hot",
+    }
 
 
-def test_dual_write_chunks_large_backfill_pages():
-    storage = FakeStorageClient()
-    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
-    ids = [str(index) for index in range(1, 66)]
-    vectors = np.zeros((65, tc.EMBEDDING_DIM), dtype=np.float32)
+def test_the_capture_path_no_longer_encodes_or_mirrors_from_python():
+    """M2.5 step 5 left exactly one MiniLM encoder, and it is not this one.
 
-    manager._dual_write_rust(ids, vectors)
-
-    assert [len(batch) for batch in storage.dual_writes] == [32, 32, 1]
-
-
-def test_queued_rust_deletes_flush_and_survive_ipc_failure():
-    storage = FakeStorageClient()
-    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
-
-    manager._queue_rust_deletes(["12", "3"])
-    assert storage.deletes == [[3, 12]]
-    assert manager._pending_rust_deletes == set()
-
-    storage.fail_deletes = True
-    manager._queue_rust_deletes(["7"])
-    assert manager._pending_rust_deletes == {"7"}
-
-    # The retry file is the durable source: a fresh manager reloads the ids
-    # that were queued while IPC was failing.
-    restored = tc.HotColdManager(FakeClient(), storage_client=storage)
-    assert restored._pending_rust_deletes == {"7"}
-
-
-def test_failed_dual_write_is_queued_and_retried_from_chroma(monkeypatch):
-    # A mirror that fails must not be forgotten: Rust serves semantic
-    # retrieval from this store, so a dropped vector is a screenshot that can
-    # never be found again by natural-language search.
-    storage = FakeStorageClient()
-    storage.fail_upserts = True
-    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
-    vector = np.full((tc.EMBEDDING_DIM,), 0.25, dtype=np.float32)
-    monkeypatch.setattr(tc.TaskEmbedder, "is_model_available", staticmethod(lambda: True))
-    monkeypatch.setattr(manager._embedder, "encode_single", lambda _text: vector)
-
-    manager.add_snapshot(9, "app.exe", "Title", "OCR", 456.0, "work")
-
-    # Chroma stays authoritative and keeps the row; only the mirror is owed.
-    assert "9" in manager.hot_collection.rows
-    assert storage.dual_writes == []
-    assert manager._pending_rust_imports == {"9"}
-
-    # The queue is durable, so a monitor restart still owes the same vector.
-    restored = tc.HotColdManager(manager._client, storage_client=storage)
-    assert restored._pending_rust_imports == {"9"}
-
-    storage.fail_upserts = False
-    restored._flush_pending_rust_imports()
-
-    assert restored._pending_rust_imports == set()
-    assert storage.dual_writes == [[{
-        "screenshot_id": 9,
-        "embedding": vector.tolist(),
-    }]]
-
-
-def test_dual_write_reports_the_debt_that_excludes_the_batch_in_flight(monkeypatch):
-    # Rust stands down while this number is non-zero, so counting the batch
-    # currently being delivered would keep retrieval on Python forever.
-    storage = FakeStorageClient()
-    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
-    vector = np.full((tc.EMBEDDING_DIM,), 0.5, dtype=np.float32)
-    monkeypatch.setattr(tc.TaskEmbedder, "is_model_available", staticmethod(lambda: True))
-    monkeypatch.setattr(manager._embedder, "encode_single", lambda _text: vector)
-
-    manager.add_snapshot(4, "app.exe", "Title", "OCR", 456.0, "work")
-    assert storage.reported_pending == [0]
-
-    manager._queue_rust_imports(["11", "12"])
-    storage.reported_pending.clear()
-    manager._dual_write_rust(["13"], [vector])
-    assert storage.reported_pending == [2]
-
-
-def test_import_retry_forgets_ids_chroma_no_longer_holds():
-    # An expired or deleted screenshot has nothing left to mirror. Keeping it
-    # queued would hold semantic retrieval on Python indefinitely.
-    storage = FakeStorageClient()
-    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
-
-    manager._queue_rust_imports(["404"])
-    manager._flush_pending_rust_imports()
-
-    assert manager._pending_rust_imports == set()
-    assert storage.dual_writes == []
-
-
-def test_a_permanently_rejected_mirror_is_dropped_rather_than_retried_forever(monkeypatch):
-    # Chroma keeps documents for screenshots the user deleted until they age
-    # out, so a queued id can become one Rust rejects every single time. Left
-    # queued it would hold the debt above zero — and Rust retrieval switched
-    # off — for as long as the queue survives, which is to say forever.
-    storage = FakeStorageClient()
-    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
-    vector = np.full((tc.EMBEDDING_DIM,), 0.25, dtype=np.float32)
-    monkeypatch.setattr(tc.TaskEmbedder, "is_model_available", staticmethod(lambda: True))
-    monkeypatch.setattr(manager._embedder, "encode_single", lambda _text: vector)
-
-    manager.add_snapshot(3, "app.exe", "Title", "OCR", 456.0, "work")
-    manager.add_snapshot(4, "app.exe", "Title", "OCR", 457.0, "work")
-    # Screenshot 3 is deleted from SQLite while its mirror is queued.
-    storage.permanently_rejected.add("3")
-    manager._queue_rust_imports(["3", "4"])
-
-    manager._flush_pending_rust_imports()
-
-    # The poisoned row is gone and the healthy one in the same batch settled.
-    assert manager._pending_rust_imports == set()
-    # And Rust is told the debt is clear, so retrieval can come back.
-    assert storage.reported_debt[-1] == 0
-
-
-def test_only_the_rows_that_failed_are_queued_not_the_whole_batch(monkeypatch):
-    # The mirror is a batch call, but the debt gates a user-visible feature.
-    # Queueing rows Rust already accepted would overstate how far behind the
-    # index is and keep retrieval on Python longer than the facts justify.
-    storage = FakeStorageClient()
-    storage.permanently_rejected.add("21")
-    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
-    vector = np.full((tc.EMBEDDING_DIM,), 0.5, dtype=np.float32)
-
-    manager._dual_write_rust(["20", "21", "22"], [vector, vector, vector])
-
-    # 21 is permanently rejected, so it is dropped, not queued; 20 and 22 were
-    # accepted in the same call and are not owed at all.
-    assert manager._pending_rust_imports == set()
-    assert [record["screenshot_id"] for record in storage.dual_writes[0]] == [20, 22]
-
-
-def test_a_queue_that_survives_a_restart_is_reported_before_the_next_capture():
-    # Rust's debt counter is process-global and starts at zero. Without this
-    # report it would rank a knowably incomplete index until the next capture
-    # happens to write — which, with the monitor paused, may be never.
-    storage = FakeStorageClient()
-    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
-    manager._queue_rust_imports(["31", "32"])
-
-    storage.reported_debt.clear()
-    restored = tc.HotColdManager(manager._client, storage_client=storage)
-
-    assert restored._pending_rust_imports == {"31", "32"}
-    assert storage.reported_debt == [2]
-
-
-def test_a_flush_that_writes_nothing_still_reports_the_resulting_debt():
-    # Ids Chroma no longer holds settle without any dual-write carrying the new
-    # number across, so the flush has to report it itself.
-    storage = FakeStorageClient()
-    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
-    manager._queue_rust_imports(["404", "405"])
-
-    storage.reported_debt.clear()
-    manager._flush_pending_rust_imports()
-
-    assert manager._pending_rust_imports == set()
-    assert storage.dual_writes == []
-    assert storage.reported_debt == [0]
-
-
-def _journal_lines():
-    path = tc.HotColdManager._rust_import_retry_path()
-    try:
-        with open(path, "r", encoding="utf-8") as stream:
-            return [line.strip() for line in stream if line.strip()]
-    except FileNotFoundError:
-        return []
-
-
-def test_the_import_queue_is_journalled_by_appending_and_compacts_on_removal():
-    # Queueing happens on the capture path and the queue is largest exactly
-    # when the mirror has been failing, so growth must not cost a full rewrite.
-    storage = FakeStorageClient()
-    manager = tc.HotColdManager(FakeClient(), storage_client=storage)
-
-    manager._queue_rust_imports(["7"])
-    manager._queue_rust_imports(["8"])
-    assert _journal_lines() == ["7", "8"]
-
-    # Re-queueing an id already owed appends nothing.
-    manager._queue_rust_imports(["8"])
-    assert _journal_lines() == ["7", "8"]
-
-    # A removal cannot be appended, so it compacts instead.
-    manager._flush_pending_rust_imports()
-    assert _journal_lines() == []
-    assert manager._pending_rust_imports == set()
-
-    # The JSON array earlier builds wrote still loads.
-    with open(tc.HotColdManager._rust_import_retry_path(), "w", encoding="utf-8") as stream:
-        stream.write('["41", "42"]')
-    restored = tc.HotColdManager(manager._client, storage_client=storage)
-    assert restored._pending_rust_imports == {"41", "42"}
+    Named rather than merely deleted: reviving any of these would restore the
+    double encode the step removed, and would do it on the capture path rather
+    than while the machine is idle.
+    """
+    for retired in (
+        "add_snapshot",
+        "_dual_write_rust",
+        "_queue_rust_imports",
+        "_flush_pending_rust_imports",
+        "_queue_rust_deletes",
+        "_flush_pending_rust_deletes",
+        "_report_import_debt",
+    ):
+        assert not hasattr(tc.HotColdManager, retired), retired
+    for retired in (
+        "upsert_minilm_derived_embeddings",
+        "delete_minilm_derived_embeddings",
+        "report_minilm_import_debt",
+    ):
+        assert not hasattr(tc_storage_client.StorageClient, retired), retired
 
 
 def test_migration_commands_require_auth_and_dispatch_to_manager():

--- a/monitor/tests/test_storage_client_contracts.py
+++ b/monitor/tests/test_storage_client_contracts.py
@@ -121,59 +121,19 @@ def test_storage_client_smart_cluster_reverse_ipc_payload_contract():
     ]
 
 
-def test_minilm_mirror_result_separates_retryable_rows_from_permanent_ones():
-    # Rust stands down while any mirror is outstanding, so the caller has to
-    # tell a row worth queueing from one that would sit in the queue forever.
-    client = sc.StorageClient("test-pipe")
-    requests = _capture_requests(
-        client,
-        [
-            {"status": "success", "data": {"errors": []}},
-            {
-                "status": "success",
-                "data": {
-                    "errors": [
-                        {"screenshot_id": 5, "error": "AUTH_REQUIRED", "permanent": False},
-                        {"screenshot_id": 6, "error": "no active screenshot", "permanent": True},
-                        # An older Rust build that does not classify at all.
-                        {"screenshot_id": 7, "error": "something"},
-                    ]
-                },
-            },
-            {"status": "error", "error": "pipe closed"},
-        ],
-    )
-    record = {"screenshot_id": 5, "embedding": [0.5]}
+def test_the_retired_minilm_mirror_commands_are_not_retried_as_idempotent():
+    """M2.5 step 5 removed the Python→Rust MiniLM mirror in both directions.
 
-    clean = client.upsert_minilm_derived_embeddings([record], pending_imports=3)
-    assert clean.delivered is True
-    assert clean.retry_ids == [] and clean.dropped_ids == []
-
-    mixed = client.upsert_minilm_derived_embeddings([record])
-    assert mixed.delivered is False
-    # Unclassified rows are retried: wasting a retry is recoverable, dropping a
-    # vector that was only transiently rejected is not.
-    assert mixed.retry_ids == ["5", "7"]
-    assert mixed.dropped_ids == ["6"]
-
-    whole = client.upsert_minilm_derived_embeddings([record])
-    assert whole.delivered is False
-    # None, not [], because nothing is known about individual rows.
-    assert whole.retry_ids is None
-    assert whole.dropped_ids == []
-
-    assert requests[0] == {
-        "command": "upsert_minilm_derived_embeddings",
-        "records": [record],
-        "pending_imports": 3,
-    }
-
-
-def test_import_debt_report_carries_no_vectors():
-    # The whole point of this command is that it writes nothing: it exists so a
-    # queue loaded from disk at startup is visible to Rust before any capture.
-    client = sc.StorageClient("test-pipe")
-    requests = _capture_requests(client, [{"status": "success", "data": {"pending_imports": 4}}])
-
-    assert client.report_minilm_import_debt(4) is True
-    assert requests == [{"command": "report_minilm_import_debt", "pending_imports": 4}]
+    The retry set is the part that has to stay in step. A command listed there
+    is re-sent after a pipe failure, so a name left behind after its method was
+    deleted would keep promising retry semantics for a command nothing can
+    issue and the Rust side no longer answers.
+    """
+    for retired in (
+        "upsert_minilm_derived_embeddings",
+        "delete_minilm_derived_embeddings",
+        "report_minilm_import_debt",
+    ):
+        assert not hasattr(sc.StorageClient, retired), retired
+        assert retired not in sc.IDEMPOTENT_RETRY_COMMANDS, retired
+        assert retired not in sc.READ_RETRY_COMMANDS, retired

--- a/monitor/tests/test_task_clustering_concurrency.py
+++ b/monitor/tests/test_task_clustering_concurrency.py
@@ -2,48 +2,66 @@ import threading
 import time
 
 import numpy as np
+import pytest
 
 import task_clustering as tc
 
 
 class FakeCollection:
-    def __init__(self, run_entered, run_release):
-        self._run_entered = run_entered
-        self._run_release = run_release
-        self._first_range_get = True
-        self.add_calls = 0
+    """Minimal stand-in for a ChromaDB collection.
+
+    `rows` controls how many hot vectors the clustering fetch sees, which is
+    what decides whether `run_clustering` reaches the engine or falls into the
+    backfill branch.
+    """
+
+    def __init__(self, rows=12):
+        self.rows = rows
         self.upsert_calls = 0
+        self.upserted_ids = []
+        self.add_calls = 0
+        self.deleted_ids = []
 
     def get(self, ids=None, where=None, include=None):
-        if self._first_range_get and where is not None and include and "embeddings" in include:
-            self._first_range_get = False
-            self._run_entered.set()
-            self._run_release.wait(timeout=3.0)
-            return {"ids": [], "embeddings": [], "metadatas": []}
         if ids is not None:
             return {"ids": []}
-        return {"ids": [], "embeddings": [], "metadatas": []}
-
-    def add(self, ids, embeddings, metadatas, documents=None):
-        self.add_calls += len(ids)
-
-    def delete(self, ids):
-        return None
-
-    def upsert(self, ids, embeddings, metadatas, documents=None):
-        self.upsert_calls += len(ids)
+        if include and "embeddings" in include:
+            n = self.rows
+            now = time.time()
+            return {
+                "ids": [str(i) for i in range(1, n + 1)],
+                "embeddings": [[0.0] * tc.EMBEDDING_DIM for _ in range(n)],
+                "metadatas": [
+                    {
+                        "screenshot_id": i,
+                        "timestamp": now,
+                        "process_name": "code.exe",
+                        "window_title": "Editor",
+                        "category": "Development",
+                        "layer": "hot",
+                    }
+                    for i in range(1, n + 1)
+                ],
+            }
+        return {"ids": []}
 
     def count(self):
-        return 0
+        return self.rows
+
+    def upsert(self, ids, embeddings, metadatas, documents=None):
+        self.upsert_calls += 1
+        self.upserted_ids.extend(ids)
+
+    def add(self, ids, embeddings, metadatas, documents=None):
+        self.add_calls += 1
+
+    def delete(self, ids):
+        self.deleted_ids.extend(ids)
 
 
 class FakeClient:
     def __init__(self, collection):
         self._collection = collection
-        self._collections = {
-            "task_vectors": collection,
-            "task_centroids": collection,
-        }
 
     def get_or_create_collection(self, name, metadata=None):
         return self._collection
@@ -63,32 +81,66 @@ class FakeEmbedder:
         return np.zeros((len(texts), tc.EMBEDDING_DIM), dtype=np.float32)
 
 
-class FakeEngine:
+class BlockingEngine:
+    """Parks inside the engine run, which is where a real run spends longest.
+
+    PaCMAP + HDBSCAN operate on numpy arrays the fetch already materialised, so
+    the engine touches nothing shared — which is exactly why the manager lock
+    must not be held across it.
+    """
+
+    def __init__(self):
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.runs = 0
+
     def run(self, vectors, ids, metadatas, min_cluster_size, min_samples):
+        self.runs += 1
+        self.entered.set()
+        self.release.wait(timeout=10.0)
         return {"clusters": [], "noise_ids": []}
 
 
-def test_run_clustering_does_not_deadlock_the_rust_vector_mirror(monkeypatch):
-    """A clustering run and an incoming mirror must serialize, not deadlock.
-
-    Until M2.5 step 5 the concurrent writer here was `add_snapshot`, driven by
-    Python's own capture-path ingest queue. Rust owns that encode now, so the
-    writer that arrives mid-run is the `upsert_task_vectors` mirror — and it
-    arrives *more* readily than before, because both it and the clustering run
-    are gated on the machine being idle.
-    """
+def _manager(monkeypatch, collection, engine):
     monkeypatch.setattr(tc.TaskEmbedder, "is_model_available", staticmethod(lambda: True))
-    monkeypatch.setattr(tc.HotColdManager, "_encrypt", lambda self, text: text)
-
-    run_entered = threading.Event()
-    run_release = threading.Event()
-    collection = FakeCollection(run_entered, run_release)
     manager = tc.HotColdManager(FakeClient(collection))
     manager._embedder = FakeEmbedder()
-    manager._engine = FakeEngine()
+    manager._engine = engine
+    return manager
+
+
+def _mirror_record(doc_id="42"):
+    return {
+        "id": doc_id,
+        "embedding": [0.0] * tc.EMBEDDING_DIM,
+        "timestamp": time.time(),
+        "process_name": "code.exe",
+        "window_title": "Editor",
+        "category": "Development",
+        "document": "code.exe | Editor | hello",
+    }
+
+
+def test_mirror_completes_while_clustering_is_inside_the_engine(monkeypatch):
+    """The Rust vector mirror must not wait for a clustering run to finish.
+
+    `upsert_task_vectors` executes inside a named-pipe handler thread, and the
+    IPC server hands out only 8 of those. When `run_clustering` held the manager
+    lock across its whole body, each idle pass parked one more handler on that
+    lock for the rest of the run, and once the pool was gone every command on
+    the forward pipe — `status`, `search_nl`, the OCR post-process enqueue —
+    got "IPC server busy".
+
+    Serialising was never the harmful part; blocking for minutes was. So this
+    asserts the bound, not the ordering.
+    """
+    collection = FakeCollection()
+    engine = BlockingEngine()
+    manager = _manager(monkeypatch, collection, engine)
 
     run_error = []
     mirror_error = []
+    mirror_done = threading.Event()
 
     def run_worker():
         try:
@@ -98,40 +150,248 @@ def test_run_clustering_does_not_deadlock_the_rust_vector_mirror(monkeypatch):
 
     def mirror_worker():
         try:
-            manager.upsert_task_vectors([{
-                "id": "42",
-                "embedding": [0.0] * tc.EMBEDDING_DIM,
-                "timestamp": time.time(),
-                "process_name": "code.exe",
-                "window_title": "Editor",
-                "category": "Development",
-                "document": "code.exe | Editor | hello",
-            }])
+            manager.upsert_task_vectors([_mirror_record()])
         except Exception as exc:  # pragma: no cover
             mirror_error.append(exc)
+        finally:
+            mirror_done.set()
 
     run_thread = threading.Thread(target=run_worker, daemon=True)
     run_thread.start()
+    assert engine.entered.wait(timeout=5.0), "run_clustering never reached the engine"
 
-    assert run_entered.wait(timeout=1.0), "run_clustering did not reach blocking point"
+    threading.Thread(target=mirror_worker, daemon=True).start()
 
-    mirror_thread = threading.Thread(target=mirror_worker, daemon=True)
-    mirror_thread.start()
-
-    # The mirror should be blocked by the clustering lock before release.
-    time.sleep(0.15)
-    assert mirror_thread.is_alive(), "the mirror should block while clustering holds the lock"
-
-    run_release.set()
-
-    run_thread.join(timeout=2.0)
-    mirror_thread.join(timeout=2.0)
-
-    assert not run_thread.is_alive(), "run_clustering did not finish in time"
-    assert not mirror_thread.is_alive(), "the mirror remained blocked"
-    assert run_error == []
+    assert mirror_done.wait(timeout=2.0), (
+        "the mirror blocked while clustering was inside the engine — a pipe "
+        "handler thread would be parked here for the length of the run"
+    )
     assert mirror_error == []
     assert collection.upsert_calls == 1
+    assert collection.upserted_ids == ["42"]
+
+    # The run really was still in the engine while the mirror went through.
+    assert not engine.release.is_set()
+    assert engine.runs == 1
+
+    engine.release.set()
+    run_thread.join(timeout=5.0)
+    assert not run_thread.is_alive(), "run_clustering did not finish in time"
+    assert run_error == []
+
+
+def test_second_clustering_run_is_refused_rather_than_queued(monkeypatch):
+    """Two concurrent runs would double peak memory, so the guard refuses.
+
+    It has to refuse rather than block: a manual run arrives over IPC, and
+    parking that handler until a scheduled run finishes is the same pool
+    exhaustion by another route.
+    """
+    collection = FakeCollection()
+    engine = BlockingEngine()
+    manager = _manager(monkeypatch, collection, engine)
+
+    first_thread = threading.Thread(
+        target=lambda: manager.run_clustering(auto_compress=False), daemon=True
+    )
+    first_thread.start()
+    assert engine.entered.wait(timeout=5.0)
+
+    started = time.monotonic()
+    second = manager.run_clustering(auto_compress=False)
+    elapsed = time.monotonic() - started
+
+    assert second["status"] == "already_running"
+    assert elapsed < 1.0, "the second run waited instead of being refused"
+    assert engine.runs == 1, "the refused run must not reach the engine"
+
+    engine.release.set()
+    first_thread.join(timeout=5.0)
+    assert not first_thread.is_alive()
+
+
+def test_compress_to_cold_holds_the_lock_across_expiry_read_and_delete(monkeypatch):
+    """The expiry read and delete are a pair and used to be covered by the
+    run-wide lock. With that gone they need the manager lock explicitly, or a
+    mirror re-upserting one of those ids in between would have it deleted right
+    back out again.
+
+    The probe has to run on another thread: the manager lock is an RLock, so a
+    non-blocking acquire from the thread already holding it always succeeds and
+    would prove nothing.
+    """
+    collection = FakeCollection()
+    manager = _manager(monkeypatch, collection, BlockingEngine())
+
+    outcomes = []
+    real_get = collection.get
+
+    def probe():
+        acquired = manager._lock.acquire(blocking=False)
+        outcomes.append(acquired)
+        if acquired:
+            manager._lock.release()
+
+    def spying_get(ids=None, where=None, include=None):
+        # Only the expiry read carries a `where` with no `include`.
+        if where is not None and not include:
+            prober = threading.Thread(target=probe, daemon=True)
+            prober.start()
+            prober.join(timeout=2.0)
+        return real_get(ids=ids, where=where, include=include)
+
+    collection.get = spying_get
+    manager.compress_to_cold([])
+
+    assert outcomes, "the expiry read did not run"
+    assert outcomes == [False], (
+        "the expiry read/delete pair ran without the manager lock, so a mirror "
+        "can slip an id back in between them"
+    )
+
+
+class _FakeTokenizer:
+    def __init__(self, seq_len=4):
+        self.seq_len = seq_len
+
+    def __call__(self, texts, **_kwargs):
+        n = len(texts)
+        # The tokenizer call is where the window has to be, not the forward
+        # pass: the old `encode` read `self._model` *after* tokenising, so an
+        # unload landing here is what turned the next line into
+        # `'NoneType' object has no attribute ...`.
+        time.sleep(0.02)
+        return {
+            "input_ids": np.zeros((n, self.seq_len), dtype=np.int64),
+            "attention_mask": np.ones((n, self.seq_len), dtype=np.int64),
+        }
+
+
+class _FakeSession:
+    def __init__(self, seq_len=4):
+        self.seq_len = seq_len
+
+    def get_inputs(self):  # pragma: no cover - build_transformer_inputs is stubbed
+        return []
+
+    def run(self, _outputs, feeds):
+        n = feeds["n"]
+        time.sleep(0.005)
+        return [np.zeros((n, self.seq_len, tc.EMBEDDING_DIM), dtype=np.float32)]
+
+
+def test_encode_survives_an_unload_landing_mid_pass(monkeypatch):
+    """`run_clustering` unloads the model in its `finally` — worth ~479 MB on
+    the ONNX backend — and that unload no longer happens behind a lock that
+    keeps other users away.
+
+    Before `_acquire_runtime`, `encode` read `_is_onnx`, `_tokenizer` and
+    `_model` as three separate unguarded attribute loads. Against the real model
+    an interleaved unload failed the very first encode with
+    `'NoneType' object has no attribute 'get_inputs'`.
+    """
+    monkeypatch.setattr(
+        "onnx_utils.build_transformer_inputs",
+        lambda session, encoded: {"n": len(encoded["attention_mask"])},
+    )
+
+    def fake_load(self):
+        with self._lock:
+            if self._model is None:
+                self._tokenizer = _FakeTokenizer()
+                self._model = _FakeSession()
+                self._is_onnx = True
+
+    monkeypatch.setattr(tc.TaskEmbedder, "load", fake_load)
+    monkeypatch.setattr(tc.gc, "collect", lambda *a, **k: 0)
+
+    emb = tc.TaskEmbedder()
+    emb.unload()
+
+    texts = ["code.exe | Editor | hello"] * 3
+    failures = []
+    encodes = [0]
+    stop = threading.Event()
+
+    def encoder():
+        while not stop.is_set():
+            try:
+                out = emb.encode(list(texts))
+                assert out.shape == (len(texts), tc.EMBEDDING_DIM)
+                encodes[0] += 1
+            except Exception as exc:
+                failures.append(exc)
+                return
+
+    def unloader():
+        while not stop.is_set():
+            emb.unload()
+            time.sleep(0.001)
+
+    threads = [
+        threading.Thread(target=encoder, daemon=True),
+        threading.Thread(target=unloader, daemon=True),
+    ]
+    for t in threads:
+        t.start()
+    time.sleep(1.5)
+    stop.set()
+    for t in threads:
+        t.join(timeout=5.0)
+
+    assert not failures, f"unload tore the model down under a running encode: {failures[0]!r}"
+    assert encodes[0] > 0, "the encoder never completed a pass"
+
+    emb.unload()
+
+
+def test_upsert_reports_busy_instead_of_parking_a_handler_thread(monkeypatch):
+    """Belt and braces for the invariant above.
+
+    Once the clustering lock is narrowed nothing holds the manager lock long
+    enough for this to fire. If something ever does, a mirror must report it and
+    let Rust treat the batch as a best-effort miss, not sit in a pipe handler.
+    """
+    collection = FakeCollection()
+    manager = _manager(monkeypatch, collection, BlockingEngine())
+    monkeypatch.setattr(tc, "MANAGER_LOCK_BUSY_TIMEOUT_SECS", 0.1)
+
+    holding = threading.Event()
+    release = threading.Event()
+
+    def hog():
+        with manager._lock:
+            holding.set()
+            release.wait(timeout=5.0)
+
+    hog_thread = threading.Thread(target=hog, daemon=True)
+    hog_thread.start()
+    assert holding.wait(timeout=2.0)
+
+    started = time.monotonic()
+    with pytest.raises(tc.ManagerBusyError):
+        manager.upsert_task_vectors([_mirror_record()])
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 2.0, "the mirror waited far past its timeout"
+    assert collection.upsert_calls == 0
+
+    release.set()
+    hog_thread.join(timeout=5.0)
+
+
+def test_unload_collections_drops_the_handles(monkeypatch):
+    """It does not free the HNSW index — measured at 0.0 MB on chromadb 1.5.1 —
+    but it must still leave the manager able to rebuild a handle on demand.
+    """
+    collection = FakeCollection()
+    manager = _manager(monkeypatch, collection, BlockingEngine())
+
+    assert manager.hot_collection is collection
+    assert hasattr(manager, "_hot_collection")
+    manager.unload_collections()
+    assert not hasattr(manager, "_hot_collection")
+    assert manager.hot_collection is collection
 
 
 def test_scheduler_can_recover_after_failed_run(monkeypatch):
@@ -157,4 +417,25 @@ def test_scheduler_can_recover_after_failed_run(monkeypatch):
     assert first is False
     assert second is True
     assert scheduler.get_last_result()["status"] == "success"
+    assert scheduler.get_config()["running"] is False
+
+
+def test_scheduler_does_not_consume_its_interval_on_a_refused_run(monkeypatch):
+    """A run refused by the clustering guard is not a completed run. Recording
+    it as one would push the next scheduled attempt out by a whole interval.
+    """
+    monkeypatch.setattr(tc.TaskEmbedder, "is_model_available", staticmethod(lambda: True))
+
+    class RefusingManager:
+        def run_clustering(self, auto_compress=True, **_kwargs):
+            return {"clusters": [], "noise_ids": [], "status": "already_running"}
+
+    scheduler = tc.ClusteringScheduler(RefusingManager())
+    saves = []
+    scheduler._save_config = lambda: saves.append(True)
+    before = scheduler._last_run
+
+    assert scheduler._do_run() is False
+    assert scheduler._last_run == before
+    assert saves == []
     assert scheduler.get_config()["running"] is False

--- a/monitor/tests/test_task_clustering_concurrency.py
+++ b/monitor/tests/test_task_clustering_concurrency.py
@@ -12,6 +12,7 @@ class FakeCollection:
         self._run_release = run_release
         self._first_range_get = True
         self.add_calls = 0
+        self.upsert_calls = 0
 
     def get(self, ids=None, where=None, include=None):
         if self._first_range_get and where is not None and include and "embeddings" in include:
@@ -29,8 +30,8 @@ class FakeCollection:
     def delete(self, ids):
         return None
 
-    def upsert(self, ids, embeddings, metadatas):
-        return None
+    def upsert(self, ids, embeddings, metadatas, documents=None):
+        self.upsert_calls += len(ids)
 
     def count(self):
         return 0
@@ -67,8 +68,17 @@ class FakeEngine:
         return {"clusters": [], "noise_ids": []}
 
 
-def test_run_clustering_does_not_deadlock_add_snapshot(monkeypatch):
+def test_run_clustering_does_not_deadlock_the_rust_vector_mirror(monkeypatch):
+    """A clustering run and an incoming mirror must serialize, not deadlock.
+
+    Until M2.5 step 5 the concurrent writer here was `add_snapshot`, driven by
+    Python's own capture-path ingest queue. Rust owns that encode now, so the
+    writer that arrives mid-run is the `upsert_task_vectors` mirror — and it
+    arrives *more* readily than before, because both it and the clustering run
+    are gated on the machine being idle.
+    """
     monkeypatch.setattr(tc.TaskEmbedder, "is_model_available", staticmethod(lambda: True))
+    monkeypatch.setattr(tc.HotColdManager, "_encrypt", lambda self, text: text)
 
     run_entered = threading.Event()
     run_release = threading.Event()
@@ -78,7 +88,7 @@ def test_run_clustering_does_not_deadlock_add_snapshot(monkeypatch):
     manager._engine = FakeEngine()
 
     run_error = []
-    add_error = []
+    mirror_error = []
 
     def run_worker():
         try:
@@ -86,41 +96,42 @@ def test_run_clustering_does_not_deadlock_add_snapshot(monkeypatch):
         except Exception as exc:  # pragma: no cover
             run_error.append(exc)
 
-    def add_worker():
+    def mirror_worker():
         try:
-            manager.add_snapshot(
-                screenshot_id=42,
-                process_name="code.exe",
-                window_title="Editor",
-                ocr_text="hello",
-                timestamp=time.time(),
-                category="Development",
-            )
+            manager.upsert_task_vectors([{
+                "id": "42",
+                "embedding": [0.0] * tc.EMBEDDING_DIM,
+                "timestamp": time.time(),
+                "process_name": "code.exe",
+                "window_title": "Editor",
+                "category": "Development",
+                "document": "code.exe | Editor | hello",
+            }])
         except Exception as exc:  # pragma: no cover
-            add_error.append(exc)
+            mirror_error.append(exc)
 
     run_thread = threading.Thread(target=run_worker, daemon=True)
     run_thread.start()
 
     assert run_entered.wait(timeout=1.0), "run_clustering did not reach blocking point"
 
-    add_thread = threading.Thread(target=add_worker, daemon=True)
-    add_thread.start()
+    mirror_thread = threading.Thread(target=mirror_worker, daemon=True)
+    mirror_thread.start()
 
-    # add_snapshot should be blocked by clustering lock before release.
+    # The mirror should be blocked by the clustering lock before release.
     time.sleep(0.15)
-    assert add_thread.is_alive(), "add_snapshot should block while clustering holds lock"
+    assert mirror_thread.is_alive(), "the mirror should block while clustering holds the lock"
 
     run_release.set()
 
     run_thread.join(timeout=2.0)
-    add_thread.join(timeout=2.0)
+    mirror_thread.join(timeout=2.0)
 
     assert not run_thread.is_alive(), "run_clustering did not finish in time"
-    assert not add_thread.is_alive(), "add_snapshot remained blocked"
+    assert not mirror_thread.is_alive(), "the mirror remained blocked"
     assert run_error == []
-    assert add_error == []
-    assert collection.add_calls == 1
+    assert mirror_error == []
+    assert collection.upsert_calls == 1
 
 
 def test_scheduler_can_recover_after_failed_run(monkeypatch):

--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -1852,6 +1852,17 @@ pub(crate) async fn process_ocr_inner(
             error
         );
     }
+    // M2.5 step 5: record the semantic-index debt now, encode it later. The
+    // ledger row is what makes a missed capture observable; the encoding itself
+    // is idle-gated in `minilm_index`. A failure here is repaired by that
+    // worker's reconciliation pass, so it must not fail the OCR commit.
+    if let Err(error) = crate::minilm_index::enqueue_captured_screenshot(storage, screenshot_id) {
+        tracing::warn!(
+            "[SEMANTIC:INDEX] enqueue failed screenshot_id={}: {}",
+            screenshot_id,
+            error
+        );
+    }
     match enqueue_python_ocr_postprocess(
         app,
         screenshot_id,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod logging;
 mod maintenance;
 mod mcp_server;
 mod mcp_token;
+mod minilm_index;
 mod minilm_migration;
 #[allow(dead_code)]
 mod ml_contracts;
@@ -973,6 +974,15 @@ pub fn run() {
                                     storage::SEMANTIC_CACHE_IDLE_TTL,
                                 );
                             }
+                        });
+
+                        // M2.5 step 5: Rust owns MiniLM capture indexing and
+                        // retention. Strictly idle-gated, so this loop spends
+                        // most of a working day deciding to do nothing.
+                        let app_handle_semantic_index = app.handle().clone();
+                        tauri::async_runtime::spawn(async move {
+                            minilm_index::run_semantic_index_worker(app_handle_semantic_index)
+                                .await;
                         });
                     }
                 } else {

--- a/src-tauri/src/maintenance.rs
+++ b/src-tauri/src/maintenance.rs
@@ -75,9 +75,11 @@ pub fn get_maintenance_status() -> MaintenanceStatus {
 }
 
 /// Reverse-IPC commands that remain usable during maintenance: session/crypto
-/// helpers the migration itself depends on, read-only status, MiniLM
-/// dual-write mirroring, and NMH session bookkeeping. Everything that writes
-/// screenshots, OCR, or clustering state is rejected.
+/// helpers the migration itself depends on, read-only status, and NMH session
+/// bookkeeping. Everything that writes screenshots, OCR, or clustering state is
+/// rejected. The MiniLM mirror commands used to be allowed here because Python
+/// wrote vectors Rust had to accept even mid-migration; M2.5 step 5 removed
+/// them along with the Python-side writer.
 pub fn reverse_ipc_command_allowed(command: &str) -> bool {
     matches!(
         command,
@@ -89,8 +91,6 @@ pub fn reverse_ipc_command_allowed(command: &str) -> bool {
             | "decrypt_many_from_chromadb"
             | "screenshot_exists"
             | "get_screenshots_with_ocr_by_ids"
-            | "upsert_minilm_derived_embeddings"
-            | "delete_minilm_derived_embeddings"
             | "register_nmh"
             | "unregister_nmh"
     )
@@ -113,15 +113,21 @@ mod tests {
 
     #[test]
     fn reverse_ipc_allowlist_rejects_mutations() {
-        assert!(reverse_ipc_command_allowed(
-            "upsert_minilm_derived_embeddings"
-        ));
+        assert!(reverse_ipc_command_allowed("get_screenshots_with_ocr_by_ids"));
         assert!(reverse_ipc_command_allowed("get_auth_status"));
         assert!(!reverse_ipc_command_allowed("save_screenshot"));
         assert!(!reverse_ipc_command_allowed("save_extension_screenshot"));
         assert!(!reverse_ipc_command_allowed("commit_screenshot"));
         assert!(!reverse_ipc_command_allowed(
             "smart_cluster_record_assignment"
+        ));
+        // Retired with the Python-side mirror. Still named here so that
+        // re-adding either one is a deliberate edit rather than a revival.
+        assert!(!reverse_ipc_command_allowed(
+            "upsert_minilm_derived_embeddings"
+        ));
+        assert!(!reverse_ipc_command_allowed(
+            "delete_minilm_derived_embeddings"
         ));
     }
 }

--- a/src-tauri/src/minilm_index.rs
+++ b/src-tauri/src/minilm_index.rs
@@ -1,0 +1,860 @@
+//! M2.5 step 5 — Rust-owned MiniLM capture indexing, retention, and the Chroma
+//! mirror.
+//!
+//! Before this step the only writers of `semantic_text` rows were the M2.4
+//! migration and Python's reverse-IPC dual-write, and the only reaper was
+//! Python's hot-layer expiry mirroring its deletions back. `semantic_index =
+//! rust` therefore meant "Rust reads an index Python writes". This module makes
+//! Rust the writer:
+//!
+//! - the capture path enqueues a ledger job as soon as the OCR row commits, or
+//!   records a terminal "nothing to encode" row when the screenshot has no text
+//!   at all — the ledger is what remembers that decision, because the candidate
+//!   scan that repairs missed enqueues cannot read it out of ciphertext;
+//! - an idle-gated worker encodes the queue in small chunks and commits vector
+//!   plus ledger in the one transaction M2.3 already provides;
+//! - the same worker ages rows out on its own 30-day rule, which is the part
+//!   nothing else was doing: screenshot *deletion* has always been handled
+//!   transactionally by the schema triggers
+//!   (`cleanup_derived_index_on_screenshot_soft_delete`), but expiry on age was
+//!   only ever mirrored over from Python, and that mirror is gone;
+//! - each newly encoded vector is mirrored *to* Python, the M2.4 dual-write
+//!   reversed, so the Chroma `task_vectors` hot layer Milestone 4 clustering
+//!   still reads keeps being fed without Python running MiniLM itself.
+//!
+//! Two consequences are deliberate and are written down rather than smoothed
+//! over.
+//!
+//! **Indexing is strictly idle-gated, so search freshness regresses.** MiniLM is
+//! a 118 MB model; the roadmap's idle rule covers exactly this kind of
+//! background capture indexing. Python encoded inline on the post-process path,
+//! so a screenshot was searchable within seconds. Here it is searchable after
+//! the next idle window. That is a real regression in freshness and the
+//! backlog is reported as a number rather than hidden.
+//!
+//! **A backlog is no longer a reason to refuse to serve.** The step-4 read path
+//! stood down whenever the Rust store was known to be behind, which was correct
+//! while Python held a complete corpus to fall back to. Once Rust is the
+//! encoder, Chroma receives its rows from this mirror, so both stores are behind
+//! by exactly the same screenshots — handing the query to Python would cost the
+//! user the faster path and recover nothing. See `semantic_query.rs`.
+//!
+//! **The Chroma mirror is best-effort and a lost row is not re-sent.** Rust
+//! holds the authoritative copy, so a mirror that fails while the monitor is
+//! down costs that screenshot its place in unsupervised task clustering — not
+//! its findability by search. Python's `_backfill_from_screenshots` only rebuilds
+//! the hot layer when it is found *entirely* empty, so a partial gap is not
+//! repaired; the Smart Cluster prefilter, which falls back to a live encode for
+//! any id the collection lacks, is unaffected. Closing that gap belongs with
+//! Milestone 4, which is where `task_vectors` is actually consumed.
+
+use crate::credential_manager::CredentialManagerState;
+use crate::idle::IdleState;
+use crate::minilm_migration::{
+    build_minilm_task_text, minilm_job_spec, validate_minilm_vector, MINILM_OCR_SNIPPET_CHARS,
+};
+use crate::ml_protocol::MlSemanticModel;
+use crate::monitor::{authenticated_monitor_command, MonitorState};
+use crate::semantic_runtime::SemanticRuntimeState;
+use crate::storage::{
+    BackgroundReadError, BackgroundScreenshotSummary, DerivedEmbeddingWrite, DerivedIndexJobSpec,
+    DerivedIndexKind, StorageState,
+};
+use chrono::{Duration as ChronoDuration, Utc};
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::{AppHandle, Manager};
+
+/// Rust keeps the same 30-day window as the Chroma hot layer it replaced, but
+/// decides it against SQLite `created_at` rather than mirroring Python's
+/// expiry. Expressed as a SQLite datetime modifier and always bound as a
+/// parameter, never interpolated.
+pub const SEMANTIC_TEXT_RETENTION: &str = "-30 days";
+
+/// How often the worker asks whether the machine has gone idle. The check
+/// itself is one atomic load, so a short cadence costs nothing and keeps the
+/// queue moving early in an idle window rather than up to an hour into it.
+const POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Subjects encoded per pass. The whole batch goes through one `embed_text`
+/// call, and the ML protocol caps a batch at `MAX_SEMANTIC_BATCH` (32).
+const DRAIN_BATCH: usize = 16;
+
+/// Subjects per `embed_text` call. A claimed batch is encoded in chunks so the
+/// semantic worker's request gate is released between them. Foreground search
+/// shares that one worker, so a chunk is the longest a user query can be made to
+/// wait for it — and the idle gate is re-checked between chunks, which is also
+/// the longest encoding can keep running after the user comes back.
+const ENCODE_CHUNK: usize = 4;
+
+/// Encode attempts before a subject is left alone. A job that spends this
+/// budget stops being claimable and starts being counted as `exhausted` in the
+/// backend diagnostic, because nothing will retry it on its own.
+pub(crate) const MAX_ATTEMPTS: u32 = 5;
+
+/// Backoff between encode attempts. Idle windows are long; retrying a failing
+/// model load every minute inside one would burn the budget in five minutes.
+const RETRY_BACKOFF_MINUTES: i64 = 30;
+
+/// Deadline for one batch encode, including a cold model load. Background work,
+/// so it is generous next to the 5 s a user-facing query is allowed.
+const EMBED_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Ledger repairs and expiry deletions per pass. Bounded so one pass cannot
+/// hold the process-wide database mutex through a whole backlog.
+const MAINTENANCE_BATCH: u32 = 256;
+
+/// Records per `upsert_task_vectors` request. Python rejects a batch above 128
+/// outright; staying well under it keeps one mirror message small, since each
+/// record carries 384 floats plus the document text as JSON.
+const MIRROR_BATCH: usize = 32;
+
+/// Ledger reason recorded for a screenshot that is not part of the corpus.
+/// `minilm_sources` is the only place that can establish this, so it is the only
+/// place that writes it.
+const EMPTY_SOURCE_CODE: &str = "empty_source";
+const EMPTY_SOURCE_REASON: &str =
+    "process name, window title, and OCR text are all empty, so there is nothing to encode";
+
+/// One screenshot's MiniLM model input, the ledger identity derived from it,
+/// and the metadata the Chroma mirror has to carry.
+pub(crate) struct MinilmSource {
+    pub text: String,
+    pub spec: DerivedIndexJobSpec,
+    /// Kept from the same read that produced `text`. The mirror needs
+    /// process/title/timestamp/category, and re-reading them later would pay a
+    /// second round of CNG decryption for values already in hand.
+    pub summary: BackgroundScreenshotSummary,
+}
+
+/// The corpus decision for one page of screenshots.
+pub(crate) struct MinilmSources {
+    /// Screenshots with something to encode.
+    pub indexable: HashMap<i64, MinilmSource>,
+    /// Screenshots whose combined text is empty. Python skipped these, so they
+    /// are not part of the corpus and must not be counted as missing from it —
+    /// but that is a fact only this builder can establish, because the text it
+    /// judges lives in encrypted columns the candidate scan cannot read. Callers
+    /// record it through `exclude_derived_index_subject` so the scan stops
+    /// re-deciding it once a minute. The spec is built from the empty text, so a
+    /// screenshot that later gains text no longer matches the recorded contract.
+    pub excluded: HashMap<i64, DerivedIndexJobSpec>,
+}
+
+/// Rebuild the MiniLM model input for `ids` from SQLite.
+///
+/// Deliberately the same assembly the M2.4 migration used — same summary read,
+/// same insertion-ordered OCR prefix, same `process | title | OCR[:200]`
+/// contract — because the source fingerprint is what decides whether a stored
+/// vector is still valid. Two builders would eventually disagree about a
+/// screenshot and silently invalidate its row.
+pub(crate) fn minilm_sources(
+    storage: &StorageState,
+    ids: &[i64],
+) -> Result<MinilmSources, BackgroundReadError> {
+    if ids.is_empty() {
+        return Ok(MinilmSources {
+            indexable: HashMap::new(),
+            excluded: HashMap::new(),
+        });
+    }
+    let summaries = storage.get_screenshot_summaries_by_ids_silent(ids)?;
+    let ocr = storage.get_ocr_text_prefixes_by_screenshot_ids_silent(ids, MINILM_OCR_SNIPPET_CHARS)?;
+    let mut indexable = HashMap::with_capacity(summaries.len());
+    let mut excluded = HashMap::new();
+    for summary in summaries {
+        let text = build_minilm_task_text(
+            summary.process_name.as_deref().unwrap_or(""),
+            summary.window_title.as_deref().unwrap_or(""),
+            ocr.get(&summary.id).map(String::as_str).unwrap_or(""),
+        );
+        let spec = minilm_job_spec(summary.id, &text);
+        if text.trim().is_empty() {
+            excluded.insert(summary.id, spec);
+            continue;
+        }
+        indexable.insert(
+            summary.id,
+            MinilmSource {
+                text,
+                spec,
+                summary,
+            },
+        );
+    }
+    Ok(MinilmSources {
+        indexable,
+        excluded,
+    })
+}
+
+/// Queue one freshly captured screenshot for semantic indexing.
+///
+/// Called from the OCR commit path so the ledger records the debt immediately,
+/// while the encoding itself waits for an idle window. A screenshot with no text
+/// at all gets a terminal ledger row instead of a queued one, which is what
+/// keeps the worker's repair scan from selecting it again for the rest of the
+/// retention window.
+///
+/// A failure here is recoverable and not worth failing the capture over: the
+/// worker's reconciliation pass finds any screenshot that has an OCR row and no
+/// ledger row, which is exactly what a missed enqueue leaves behind.
+pub fn enqueue_captured_screenshot(
+    storage: &StorageState,
+    screenshot_id: i64,
+) -> Result<(), String> {
+    let sources = minilm_sources(storage, &[screenshot_id]).map_err(|error| error.to_string())?;
+    if let Some(source) = sources.indexable.get(&screenshot_id) {
+        storage.ensure_derived_index_job(&source.spec)?;
+        return Ok(());
+    }
+    if let Some(spec) = sources.excluded.get(&screenshot_id) {
+        storage.exclude_derived_index_subject(spec, EMPTY_SOURCE_CODE, EMPTY_SOURCE_REASON)?;
+    }
+    Ok(())
+}
+
+/// Idle-gated capture indexing, retention, and repair.
+pub async fn run_semantic_index_worker(app: AppHandle) {
+    let mut ticker = tokio::time::interval(POLL_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        ticker.tick().await;
+        if let Err(error) = run_pass(&app).await {
+            tracing::warn!("[SEMANTIC:INDEX] idle pass failed: {error}");
+        }
+    }
+}
+
+/// Whether background semantic work may run right now.
+///
+/// The idle gate is the whole point of the step-5 scheduling decision: a
+/// 118 MB model load and a batch of transformer forward passes must never land
+/// while someone is using the machine. Maintenance mode is checked too, because
+/// a migration rewriting the derived store would race these writes.
+fn may_run(app: &AppHandle) -> bool {
+    if crate::maintenance::is_active() {
+        return false;
+    }
+    app.state::<Arc<IdleState>>()
+        .is_idle
+        .load(Ordering::Relaxed)
+}
+
+async fn run_pass(app: &AppHandle) -> Result<(), String> {
+    if !may_run(app) {
+        return Ok(());
+    }
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+    // Every read below decrypts OCR text, so a locked session can do nothing
+    // but wait. Bailing here keeps the ledger untouched rather than marking a
+    // batch `waiting_for_auth` on every tick of a locked machine.
+    if !storage.is_session_valid() {
+        return Ok(());
+    }
+
+    // Expiry first: a subject about to age out should not be encoded on its way
+    // out the door.
+    reap_expired(storage.clone()).await?;
+    reconcile_missing(storage.clone()).await?;
+    drain_queue(app, storage).await
+}
+
+/// Delete rows that aged out of the retention window.
+///
+/// Deletion with the screenshot is already transactional in the schema, so what
+/// this adds is expiry on age — the job Python's hot-layer expiry used to do for
+/// Rust by mirroring its own deletions across. The query also sweeps subjects
+/// with no live screenshot at all, which after the triggers is a safety net for
+/// a row that predates them rather than the normal path.
+async fn reap_expired(storage: Arc<StorageState>) -> Result<(), String> {
+    let removed = tokio::task::spawn_blocking(move || -> Result<usize, String> {
+        let subjects = storage
+            .list_expired_semantic_text_subjects(SEMANTIC_TEXT_RETENTION, MAINTENANCE_BATCH)?;
+        let mut removed = 0usize;
+        for subject in subjects {
+            if storage.delete_derived_index_subject(DerivedIndexKind::SemanticText, &subject)? {
+                removed += 1;
+            }
+        }
+        Ok(removed)
+    })
+    .await
+    .map_err(|error| format!("reap task failed: {error}"))??;
+    if removed > 0 {
+        tracing::info!("[SEMANTIC:INDEX] expired {removed} semantic vector(s)");
+    }
+    Ok(())
+}
+
+/// Queue screenshots that should have a vector but have no ledger row.
+///
+/// This is the repair path for an enqueue that never ran: the capture happened
+/// while the session was locked, or the process died between the OCR commit and
+/// the enqueue. It is bounded to the retention window, so it never turns into a
+/// full-history backfill — M2.4 established that the corpus is the hot layer,
+/// not every screenshot ever taken.
+///
+/// The candidate query can only over-approximate the corpus, because it decides
+/// membership from ciphertext. Whatever it hands over that turns out to have no
+/// text is recorded as excluded rather than silently dropped: a silent drop
+/// would hand the same screenshot back on the next pass, forever, and once
+/// enough of them accumulated they would fill the query's `LIMIT` and starve the
+/// repair of screenshots that really are missing a vector.
+async fn reconcile_missing(storage: Arc<StorageState>) -> Result<(), String> {
+    let (queued, excluded) =
+        tokio::task::spawn_blocking(move || -> Result<(usize, usize), String> {
+            let ids = storage
+                .list_semantic_text_index_candidates(SEMANTIC_TEXT_RETENTION, MAINTENANCE_BATCH)?;
+            if ids.is_empty() {
+                return Ok((0, 0));
+            }
+            let sources = minilm_sources(&storage, &ids).map_err(|error| error.to_string())?;
+            let mut queued = 0usize;
+            for source in sources.indexable.values() {
+                match storage.ensure_derived_index_job(&source.spec) {
+                    Ok(_) => queued += 1,
+                    // A screenshot deleted between the candidate query and here.
+                    Err(error) => tracing::debug!(
+                        "[SEMANTIC:INDEX] skipped repair enqueue for {}: {error}",
+                        source.spec.subject_key
+                    ),
+                }
+            }
+            let mut excluded = 0usize;
+            for spec in sources.excluded.values() {
+                match storage.exclude_derived_index_subject(
+                    spec,
+                    EMPTY_SOURCE_CODE,
+                    EMPTY_SOURCE_REASON,
+                ) {
+                    Ok(true) => excluded += 1,
+                    // Deleted between the candidate query and here; the
+                    // lifecycle triggers already removed its rows.
+                    Ok(false) => {}
+                    Err(error) => tracing::debug!(
+                        "[SEMANTIC:INDEX] could not record exclusion for {}: {error}",
+                        spec.subject_key
+                    ),
+                }
+            }
+            Ok((queued, excluded))
+        })
+        .await
+        .map_err(|error| format!("reconcile task failed: {error}"))??;
+    if queued > 0 {
+        tracing::info!("[SEMANTIC:INDEX] repaired {queued} missing ledger row(s)");
+    }
+    if excluded > 0 {
+        tracing::info!("[SEMANTIC:INDEX] excluded {excluded} screenshot(s) with no text to encode");
+    }
+    Ok(())
+}
+
+/// One claimed job: its ledger identity, its model input, the metadata the
+/// mirror will need, and the lease that authorizes the commit.
+struct ClaimedJob {
+    spec: DerivedIndexJobSpec,
+    text: String,
+    summary: BackgroundScreenshotSummary,
+    lease_token: String,
+}
+
+/// One screenshot that became query-visible in this pass, in the shape the
+/// Chroma mirror sends.
+struct IndexedSubject {
+    id: i64,
+    vector: Vec<f32>,
+    text: String,
+    summary: BackgroundScreenshotSummary,
+}
+
+async fn drain_queue(app: &AppHandle, storage: Arc<StorageState>) -> Result<(), String> {
+    let claimed = claim_batch(storage.clone()).await?;
+    if claimed.is_empty() {
+        return Ok(());
+    }
+    let semantic = app.state::<Arc<SemanticRuntimeState>>().inner().clone();
+    let mut pending: VecDeque<ClaimedJob> = claimed.into();
+    let mut indexed: Vec<IndexedSubject> = Vec::new();
+    let mut failure: Option<String> = None;
+    while !pending.is_empty() {
+        // The user may have come back since the claim, or since the previous
+        // chunk. Release the rest of the leases without charging the retry
+        // budget — nothing failed, the window just closed.
+        if !may_run(app) {
+            release_claims(
+                storage.clone(),
+                Vec::from(std::mem::take(&mut pending)),
+                "idle_lost",
+                "system left idle before encoding",
+            )
+            .await;
+            break;
+        }
+        let chunk: Vec<ClaimedJob> = pending.drain(..ENCODE_CHUNK.min(pending.len())).collect();
+        match encode_chunk(app, &semantic, storage.clone(), chunk).await {
+            Ok(mut encoded) => indexed.append(&mut encoded),
+            Err(error) => {
+                // Whatever broke the worker will break every remaining chunk the
+                // same way, and charging the retry budget for an attempt that was
+                // never made would spend it on the worker's behalf.
+                if !pending.is_empty() {
+                    release_claims(
+                        storage.clone(),
+                        Vec::from(std::mem::take(&mut pending)),
+                        "batch_aborted",
+                        "an earlier chunk of the same pass failed to encode",
+                    )
+                    .await;
+                }
+                failure = Some(error);
+                break;
+            }
+        }
+    }
+
+    if !indexed.is_empty() {
+        tracing::info!("[SEMANTIC:INDEX] indexed {} screenshot(s)", indexed.len());
+        mirror_to_chroma(app, &indexed).await;
+    }
+    match failure {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+/// Encode and commit one chunk. The chunk's leases are consumed either way:
+/// success commits them, failure charges the retry budget with a backoff.
+async fn encode_chunk(
+    app: &AppHandle,
+    semantic: &Arc<SemanticRuntimeState>,
+    storage: Arc<StorageState>,
+    claimed: Vec<ClaimedJob>,
+) -> Result<Vec<IndexedSubject>, String> {
+    let texts: Vec<String> = claimed.iter().map(|job| job.text.clone()).collect();
+    let embedded = semantic
+        .embed_text(
+            app.clone(),
+            MlSemanticModel::MinilmL12,
+            texts,
+            EMBED_TIMEOUT,
+            // MiniLM has no approved DirectML parity; asking for it only costs
+            // a provider negotiation before the worker falls back to CPU.
+            false,
+        )
+        .await;
+
+    let vectors = match embedded {
+        Ok(result) if result.vectors.len() == claimed.len() => result.vectors,
+        Ok(result) => {
+            let error = format!(
+                "semantic worker returned {} vectors for {} inputs",
+                result.vectors.len(),
+                claimed.len()
+            );
+            fail_claims(storage, claimed, "embed_mismatch", &error).await;
+            return Err(error);
+        }
+        Err(error) => {
+            fail_claims(storage, claimed, "embed_failed", &error).await;
+            return Err(format!("embed failed: {error}"));
+        }
+    };
+
+    commit_batch(storage, claimed, vectors).await
+}
+
+/// Claim up to one batch, rebuilding each job's source text from SQLite.
+///
+/// The text is rebuilt rather than trusted from the ledger because a job queued
+/// at capture time may have been overtaken by a re-OCR: its stored fingerprint
+/// would then describe text that no longer exists. Such a job is re-queued
+/// against the current source instead of being encoded against a stale one.
+async fn claim_batch(storage: Arc<StorageState>) -> Result<Vec<ClaimedJob>, String> {
+    tokio::task::spawn_blocking(move || -> Result<Vec<ClaimedJob>, String> {
+        let jobs = storage.claimable_derived_index_jobs(
+            DerivedIndexKind::SemanticText,
+            MAX_ATTEMPTS,
+            DRAIN_BATCH as u32,
+        )?;
+        if jobs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut ids = Vec::with_capacity(jobs.len());
+        for job in &jobs {
+            match job.spec.subject_key.parse::<i64>() {
+                Ok(id) => ids.push(id),
+                Err(error) => tracing::warn!(
+                    "[SEMANTIC:INDEX] ignoring job with non-numeric subject '{}': {error}",
+                    job.spec.subject_key
+                ),
+            }
+        }
+        let sources = minilm_sources(&storage, &ids).map_err(|error| error.to_string())?;
+
+        let mut claimed = Vec::with_capacity(jobs.len());
+        for job in jobs {
+            let Ok(id) = job.spec.subject_key.parse::<i64>() else {
+                continue;
+            };
+            let Some(source) = sources.indexable.get(&id) else {
+                // Nothing to encode. Either the screenshot lost its text, and
+                // the exclusion has to be recorded or the repair scan will hand
+                // it straight back, or the screenshot itself is gone and the row
+                // goes with it.
+                let recorded = match sources.excluded.get(&id) {
+                    Some(spec) => storage
+                        .exclude_derived_index_subject(
+                            spec,
+                            EMPTY_SOURCE_CODE,
+                            EMPTY_SOURCE_REASON,
+                        )
+                        .unwrap_or(false),
+                    None => false,
+                };
+                if !recorded {
+                    let _ = storage.delete_derived_index_subject(
+                        DerivedIndexKind::SemanticText,
+                        &job.spec.subject_key,
+                    );
+                }
+                continue;
+            };
+            if source.spec != job.spec {
+                // Re-queue against the current source. `ensure_derived_index_job`
+                // replaces the contract; the next pass claims the fresh row.
+                let _ = storage.ensure_derived_index_job(&source.spec);
+                continue;
+            }
+            match storage.mark_derived_index_job_processing(&job.spec) {
+                Ok(lease_token) => claimed.push(ClaimedJob {
+                    spec: job.spec,
+                    text: source.text.clone(),
+                    summary: source.summary.clone(),
+                    lease_token,
+                }),
+                // Lost the race to another claimant, or the row moved on.
+                Err(error) => tracing::debug!(
+                    "[SEMANTIC:INDEX] could not claim {}: {error}",
+                    job.spec.subject_key
+                ),
+            }
+        }
+        Ok(claimed)
+    })
+    .await
+    .map_err(|error| format!("claim task failed: {error}"))?
+}
+
+/// Commit the encoded batch, returning the subjects that became query-visible.
+async fn commit_batch(
+    storage: Arc<StorageState>,
+    claimed: Vec<ClaimedJob>,
+    vectors: Vec<Vec<f32>>,
+) -> Result<Vec<IndexedSubject>, String> {
+    tokio::task::spawn_blocking(move || {
+        let mut indexed = Vec::with_capacity(claimed.len());
+        for (job, vector) in claimed.into_iter().zip(vectors) {
+            if let Err(error) = validate_minilm_vector(&vector) {
+                // A zero or non-finite vector would poison every cosine score
+                // it touches. Discard rather than retry: the input is stable,
+                // so the next attempt produces the same bad vector.
+                let _ = storage.mark_derived_index_job_discarded(
+                    &job.spec,
+                    &job.lease_token,
+                    "invalid_vector",
+                    &error,
+                );
+                tracing::warn!(
+                    "[SEMANTIC:INDEX] discarded {}: {error}",
+                    job.spec.subject_key
+                );
+                continue;
+            }
+            let write = DerivedEmbeddingWrite {
+                job: job.spec.clone(),
+                lease_token: job.lease_token.clone(),
+                vector: vector.clone(),
+            };
+            match storage.commit_derived_embedding(&write) {
+                Ok(()) => {
+                    let id = job.summary.id;
+                    // Smart Cluster scoring used to be queued by Python's
+                    // `add_snapshot`, right after it wrote the vector. Same
+                    // position, new writer: the prefilter needs the vector
+                    // to exist before the entry is worth anything.
+                    if let Err(error) = storage.enqueue_smart_cluster_pending(id) {
+                        tracing::debug!(
+                            "[SEMANTIC:INDEX] smart cluster enqueue failed for {id}: {error}"
+                        );
+                    }
+                    indexed.push(IndexedSubject {
+                        id,
+                        vector,
+                        text: job.text,
+                        summary: job.summary,
+                    });
+                }
+                Err(error) => tracing::warn!(
+                    "[SEMANTIC:INDEX] commit failed for {}: {error}",
+                    job.spec.subject_key
+                ),
+            }
+        }
+        Ok(indexed)
+    })
+    .await
+    .map_err(|error| format!("commit task failed: {error}"))?
+}
+
+/// Hand claimed jobs back without charging the retry budget.
+async fn release_claims(
+    storage: Arc<StorageState>,
+    claimed: Vec<ClaimedJob>,
+    reason_code: &'static str,
+    reason: &'static str,
+) {
+    let _ = tokio::task::spawn_blocking(move || {
+        for job in claimed {
+            let _ =
+                storage.requeue_derived_index_job(&job.spec, &job.lease_token, reason_code, reason);
+        }
+    })
+    .await;
+}
+
+/// Record an encode failure against the retry budget with a backoff.
+async fn fail_claims(
+    storage: Arc<StorageState>,
+    claimed: Vec<ClaimedJob>,
+    error_code: &'static str,
+    error: &str,
+) {
+    let next_retry_at = (Utc::now() + ChronoDuration::minutes(RETRY_BACKOFF_MINUTES))
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string();
+    let error = error.to_string();
+    let _ = tokio::task::spawn_blocking(move || {
+        for job in claimed {
+            let _ = storage.mark_derived_index_job_failed(
+                &job.spec,
+                &job.lease_token,
+                error_code,
+                &error,
+                Some(&next_retry_at),
+            );
+        }
+    })
+    .await;
+}
+
+/// Mirror newly indexed vectors into Python's Chroma hot layer.
+///
+/// The M2.4 dual-write with its direction reversed. Milestone 4 task clustering
+/// still reads `task_vectors`, and Python no longer runs MiniLM, so without this
+/// the clustering corpus would stop growing. It reuses `upsert_task_vectors` —
+/// the command the M2.4 rollback path already established for "write a
+/// Rust-produced vector into the hot layer" — rather than inventing a second
+/// ingest contract for the same write.
+///
+/// The full row is sent, not just the vector. `add_snapshot` used to write the
+/// metadata and the document alongside it, and both are load-bearing: clustering
+/// selects hot vectors by `timestamp`, so a row that arrived without one would
+/// be silently outside every window, and the reranker scores the stored document
+/// text. Python encrypts the process name, window title, and document on its
+/// side exactly as it did when it built them itself.
+///
+/// Best-effort on purpose: Rust holds the authoritative copy, and a mirror lost
+/// here degrades unsupervised clustering rather than making a screenshot
+/// unfindable by search.
+async fn mirror_to_chroma(app: &AppHandle, indexed: &[IndexedSubject]) {
+    if indexed.is_empty() {
+        return;
+    }
+    let credential = app.state::<Arc<CredentialManagerState>>();
+    let monitor = app.state::<MonitorState>();
+    for chunk in indexed.chunks(MIRROR_BATCH) {
+        let records: Vec<serde_json::Value> = chunk.iter().map(mirror_record).collect();
+        let request = serde_json::json!({
+            "command": "upsert_task_vectors",
+            "records": records,
+        });
+        match authenticated_monitor_command(&credential, &monitor, request).await {
+            // Python reports a refused command in the response body rather than
+            // as a transport error, so an `error` field is the failure that
+            // actually shows up in practice: clustering disabled, the vault
+            // locked, or the monitor still starting.
+            Ok(response) => {
+                if let Some(error) = response.get("error").and_then(|value| value.as_str()) {
+                    tracing::debug!(
+                        "[SEMANTIC:INDEX] chroma mirror rejected {} vector(s): {error}",
+                        chunk.len()
+                    );
+                }
+            }
+            Err(error) => {
+                tracing::debug!(
+                    "[SEMANTIC:INDEX] chroma mirror deferred for {} vector(s): {error}",
+                    chunk.len()
+                );
+                // A transport failure applies to the pipe, not to this batch,
+                // so the remaining chunks would fail the same way.
+                return;
+            }
+        }
+    }
+}
+
+/// One `upsert_task_vectors` record, field-for-field what `add_snapshot` used
+/// to write into the hot layer for the same screenshot.
+fn mirror_record(subject: &IndexedSubject) -> serde_json::Value {
+    serde_json::json!({
+        "id": subject.id.to_string(),
+        "embedding": subject.vector,
+        // Seconds since the epoch, which is what `screenshots.created_at`
+        // yields here and what Chroma's `timestamp` metadata has always held.
+        "timestamp": subject.summary.timestamp.unwrap_or(0),
+        "process_name": subject.summary.process_name.clone().unwrap_or_default(),
+        "window_title": subject.summary.window_title.clone().unwrap_or_default(),
+        "category": subject.summary.category.clone().unwrap_or_default(),
+        // The encoder input doubles as the stored document, as it did when
+        // Python built both from one `build_task_text` call.
+        "document": subject.text,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retention_is_a_bound_sqlite_modifier_not_an_interpolated_one() {
+        // Both queries bind this as a parameter. A literal that ever stopped
+        // being a constant would otherwise be a SQL injection point in a
+        // datetime modifier, which is easy to miss.
+        assert!(SEMANTIC_TEXT_RETENTION.starts_with('-'));
+        assert!(SEMANTIC_TEXT_RETENTION.ends_with(" days"));
+    }
+
+    #[test]
+    fn a_batch_fits_the_protocol_limit() {
+        // Each chunk of the claimed batch goes through one `embed_text` call.
+        assert!(ENCODE_CHUNK <= crate::ml_protocol::MAX_SEMANTIC_BATCH);
+        assert!(ENCODE_CHUNK <= DRAIN_BATCH);
+        assert!(DRAIN_BATCH <= crate::ml_protocol::MAX_SEMANTIC_BATCH);
+    }
+
+    #[test]
+    fn a_screenshot_with_nothing_to_encode_is_outside_the_corpus() {
+        // The rule the candidate scan cannot express: it sees that a screenshot
+        // has OCR rows, not that they decrypt to nothing. A process name of ""
+        // happens whenever the foreground window belongs to a process this one
+        // cannot open, which on Windows includes every elevated window.
+        assert!(build_minilm_task_text("", "", "").is_empty());
+        assert!(build_minilm_task_text("", "", "   ").trim().is_empty());
+        assert!(!build_minilm_task_text("proc.exe", "", "").trim().is_empty());
+        assert!(!build_minilm_task_text("", "Title", "").trim().is_empty());
+        assert!(!build_minilm_task_text("", "", "text").trim().is_empty());
+    }
+
+    #[test]
+    fn an_exclusion_is_fingerprinted_so_regained_text_reclaims_it() {
+        // The exclusion is recorded against the empty source, which is what lets
+        // `ensure_derived_index_job` treat a screenshot that later gains text as
+        // an ordinary source change rather than as something already settled.
+        let empty = minilm_job_spec(1, &build_minilm_task_text("", "", ""));
+        let with_text = minilm_job_spec(1, &build_minilm_task_text("proc.exe", "", ""));
+        assert_eq!(empty.subject_key, with_text.subject_key);
+        assert_ne!(empty.source_fingerprint, with_text.source_fingerprint);
+    }
+
+    #[test]
+    fn the_retry_budget_and_backoff_outlast_a_single_idle_window() {
+        // A failing model load must not spend all five attempts inside one
+        // night of idleness, which would leave the subject `exhausted` by
+        // morning over a transient fault.
+        assert!(MAX_ATTEMPTS >= 3);
+        assert!(RETRY_BACKOFF_MINUTES >= 15);
+    }
+
+    fn indexed(id: i64) -> IndexedSubject {
+        IndexedSubject {
+            id,
+            vector: vec![0.5; crate::minilm_migration::MINILM_DIMENSIONS],
+            text: "proc.exe | Title | OCR".to_string(),
+            summary: BackgroundScreenshotSummary {
+                id,
+                window_title: Some("Title".to_string()),
+                process_name: Some("proc.exe".to_string()),
+                timestamp: Some(1_700_000_000),
+                category: Some("work".to_string()),
+            },
+        }
+    }
+
+    #[test]
+    fn a_mirror_record_carries_every_field_add_snapshot_used_to_write() {
+        // `upsert_task_vectors` reads exactly these keys. A vector arriving
+        // without `timestamp` would land outside every clustering window, and
+        // one without `document` would leave the reranker nothing to score —
+        // both silent, both only visible as degraded clustering months later.
+        let record = mirror_record(&indexed(42));
+        let mut keys: Vec<&str> = record
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "category",
+                "document",
+                "embedding",
+                "id",
+                "process_name",
+                "timestamp",
+                "window_title",
+            ]
+        );
+        // Python parses the id with `str.isdigit()`, so it has to be a string.
+        assert_eq!(record["id"], "42");
+        assert_eq!(record["timestamp"], 1_700_000_000);
+        assert_eq!(record["process_name"], "proc.exe");
+        assert_eq!(record["window_title"], "Title");
+        assert_eq!(record["category"], "work");
+        assert_eq!(record["document"], "proc.exe | Title | OCR");
+        assert_eq!(
+            record["embedding"].as_array().unwrap().len(),
+            crate::minilm_migration::MINILM_DIMENSIONS
+        );
+    }
+
+    #[test]
+    fn absent_metadata_mirrors_as_empty_strings_rather_than_null() {
+        // Python calls `str(...)` on each of these, so a JSON null would reach
+        // Chroma as the literal text "None".
+        let mut subject = indexed(7);
+        subject.summary.process_name = None;
+        subject.summary.window_title = None;
+        subject.summary.category = None;
+        subject.summary.timestamp = None;
+        let record = mirror_record(&subject);
+        assert_eq!(record["process_name"], "");
+        assert_eq!(record["window_title"], "");
+        assert_eq!(record["category"], "");
+        assert_eq!(record["timestamp"], 0);
+    }
+
+    #[test]
+    fn one_mirror_request_stays_inside_the_python_batch_limit() {
+        // `upsert_task_vectors` raises above 128 records, and a raised batch
+        // would lose the whole chunk rather than degrade.
+        assert!(MIRROR_BATCH <= 128);
+        assert!(DRAIN_BATCH <= MIRROR_BATCH);
+    }
+}

--- a/src-tauri/src/minilm_migration.rs
+++ b/src-tauri/src/minilm_migration.rs
@@ -17,9 +17,8 @@
 use crate::credential_manager::CredentialManagerState;
 use crate::monitor::{authenticated_monitor_command, MonitorState};
 use crate::storage::{
-    BackgroundReadError, BackgroundScreenshotSummary, DerivedEmbeddingWrite, DerivedIndexJobSpec,
-    DerivedIndexJobStatus, DerivedIndexKind, EnsureDerivedIndexJobResult, MinilmMigrationPageRow,
-    MinilmMigrationRunRecord, StorageState,
+    BackgroundReadError, BackgroundScreenshotSummary, DerivedIndexJobSpec, DerivedIndexJobStatus,
+    DerivedIndexKind, MinilmMigrationPageRow, MinilmMigrationRunRecord, StorageState,
 };
 use base64::Engine as _;
 use chrono::Utc;
@@ -255,7 +254,7 @@ pub fn minilm_source_fingerprint(text: &str) -> String {
     format!("{:x}", digest.finalize())
 }
 
-fn minilm_spec(screenshot_id: i64, text: &str) -> DerivedIndexJobSpec {
+pub(crate) fn minilm_job_spec(screenshot_id: i64, text: &str) -> DerivedIndexJobSpec {
     DerivedIndexJobSpec {
         index_kind: DerivedIndexKind::SemanticText,
         subject_key: screenshot_id.to_string(),
@@ -278,13 +277,13 @@ fn source_rows(
                 summary.window_title.as_deref().unwrap_or(""),
                 ocr.get(&summary.id).map(String::as_str).unwrap_or(""),
             );
-            let spec = minilm_spec(summary.id, &text);
+            let spec = minilm_job_spec(summary.id, &text);
             SourceRow { text, spec }
         })
         .collect()
 }
 
-fn validate_vector(vector: &[f32]) -> Result<(), String> {
+pub(crate) fn validate_minilm_vector(vector: &[f32]) -> Result<(), String> {
     if vector.len() != MINILM_DIMENSIONS {
         return Err(format!(
             "Expected {MINILM_DIMENSIONS} dimensions, got {}",
@@ -420,13 +419,6 @@ async fn background_read_with_auth_retry<T>(
             Err(BackgroundReadError::AuthRequired) => continue,
             Err(BackgroundReadError::Other(error)) => return Err(error),
         }
-    }
-}
-
-fn background_error(error: BackgroundReadError) -> String {
-    match error {
-        BackgroundReadError::AuthRequired => "AUTH_REQUIRED".to_string(),
-        BackgroundReadError::Other(error) => error,
     }
 }
 
@@ -711,7 +703,7 @@ async fn copy_chroma_hot_layer(
                     continue;
                 }
             };
-            if let Err(error) = validate_vector(&vector) {
+            if let Err(error) = validate_minilm_vector(&vector) {
                 unmappable_total += 1;
                 record_error(
                     &storage,
@@ -1214,101 +1206,6 @@ pub fn list_minilm_rebuild_errors(
     }))
 }
 
-/// Why one Python dual-write row could not be mirrored, and — the part the
-/// caller actually acts on — whether retrying it could ever succeed.
-///
-/// Python keeps a durable retry queue for failed mirrors, and the Rust read
-/// path stands down while that queue is non-empty. A row Rust will reject
-/// forever (its screenshot was deleted, its vector is malformed) would
-/// therefore stall the queue and disable Rust retrieval permanently, so the
-/// two kinds of failure have to be distinguishable over the wire.
-pub(crate) struct ImportRejection {
-    /// True when no amount of retrying changes the outcome, so the caller
-    /// should drop the row rather than queue it.
-    pub permanent: bool,
-    pub message: String,
-}
-
-impl ImportRejection {
-    fn permanent(message: impl Into<String>) -> Self {
-        Self {
-            permanent: true,
-            message: message.into(),
-        }
-    }
-
-    /// The store, the session or the source read failed. The same row may well
-    /// succeed once the session is valid again or the writer stops contending.
-    fn transient(message: impl Into<String>) -> Self {
-        Self {
-            permanent: false,
-            message: message.into(),
-        }
-    }
-}
-
-/// Best-effort Python→Rust dual-write for newly produced MiniLM vectors. The
-/// caller-provided metadata is deliberately ignored; source text and its
-/// fingerprint are rehydrated from SQLite.
-pub(crate) fn import_minilm_vector_from_python(
-    storage: &StorageState,
-    screenshot_id: i64,
-    vector: Vec<f32>,
-) -> Result<EnsureDerivedIndexJobResult, ImportRejection> {
-    if screenshot_id <= 0 {
-        return Err(ImportRejection::permanent("screenshot_id must be positive"));
-    }
-    // A vector of the wrong width, or one carrying non-finite values, is a
-    // property of the payload rather than of the moment it arrived.
-    validate_vector(&vector).map_err(ImportRejection::permanent)?;
-    let summaries = storage
-        .get_screenshot_summaries_by_ids_silent(&[screenshot_id])
-        .map_err(|error| ImportRejection::transient(background_error(error)))?;
-    let ocr = storage
-        .get_ocr_text_prefixes_by_screenshot_ids_silent(&[screenshot_id], MINILM_OCR_SNIPPET_CHARS)
-        .map_err(|error| ImportRejection::transient(background_error(error)))?;
-    let mut sources = source_rows(summaries, &ocr);
-    // Chroma keeps documents for screenshots the user has already deleted —
-    // Python only prunes the hot layer on age — so this is the expected fate of
-    // any queued id that gets deleted before its mirror lands, not an anomaly.
-    let source = sources
-        .pop()
-        .ok_or_else(|| {
-            ImportRejection::permanent("No active SQLite screenshot maps to screenshot_id")
-        })?;
-    if source.text.is_empty() {
-        return Err(ImportRejection::permanent(
-            "SQLite source produces an empty MiniLM input",
-        ));
-    }
-    let ensured = storage
-        .ensure_derived_index_job(&source.spec)
-        .map_err(ImportRejection::transient)?;
-    if matches!(
-        ensured,
-        EnsureDerivedIndexJobResult::Queued | EnsureDerivedIndexJobResult::Requeued
-    ) {
-        let lease = storage
-            .mark_derived_index_job_processing(&source.spec)
-            .map_err(ImportRejection::transient)?;
-        if let Err(error) = storage.commit_derived_embedding(&DerivedEmbeddingWrite {
-            job: source.spec.clone(),
-            lease_token: lease.clone(),
-            vector,
-        }) {
-            let _ = storage.mark_derived_index_job_failed(
-                &source.spec,
-                &lease,
-                "rust_store_write_failed",
-                &error,
-                None,
-            );
-            return Err(ImportRejection::transient(error));
-        }
-    }
-    Ok(ensured)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1333,7 +1230,7 @@ mod tests {
 
     #[test]
     fn spec_records_vector_space_contract_not_one_runtime_artifact() {
-        let spec = minilm_spec(7, "proc | title | OCR");
+        let spec = minilm_job_spec(7, "proc | title | OCR");
         assert_eq!(spec.model_revision, MINILM_VECTOR_SPACE_REVISION);
         assert_eq!(spec.model_revision, "minilm-l12-vector-space-v1");
         assert!(!spec
@@ -1353,12 +1250,12 @@ mod tests {
 
     #[test]
     fn vector_validation_rejects_wrong_shape_non_finite_and_zero_vectors() {
-        assert!(validate_vector(&vec![0.25; MINILM_DIMENSIONS]).is_ok());
-        assert!(validate_vector(&vec![0.25; 10]).is_err());
+        assert!(validate_minilm_vector(&vec![0.25; MINILM_DIMENSIONS]).is_ok());
+        assert!(validate_minilm_vector(&vec![0.25; 10]).is_err());
         let mut invalid = vec![0.25; MINILM_DIMENSIONS];
         invalid[3] = f32::NAN;
-        assert!(validate_vector(&invalid).is_err());
-        assert!(validate_vector(&vec![0.0; MINILM_DIMENSIONS])
+        assert!(validate_minilm_vector(&invalid).is_err());
+        assert!(validate_minilm_vector(&vec![0.0; MINILM_DIMENSIONS])
             .unwrap_err()
             .contains("zero vector"));
     }

--- a/src-tauri/src/reverse_ipc.rs
+++ b/src-tauri/src/reverse_ipc.rs
@@ -965,157 +965,16 @@ fn process_request(
             }
         }
 
-        "upsert_minilm_derived_embeddings" => {
-            if !storage.is_session_valid() {
-                return StorageResponse::error("AUTH_REQUIRED");
-            }
-            let Some(records) = req.get("records").and_then(|value| value.as_array()) else {
-                return StorageResponse::error("records must be an array");
-            };
-            if records.len() > 128 {
-                return StorageResponse::error("MiniLM dual-write batch exceeds 128 records");
-            }
-            // How many vectors Python has written to Chroma but not yet
-            // mirrored here, excluding this batch. Absent means Python predates
-            // this contract and reports nothing, which reads as no known debt.
-            let reported_pending = req
-                .get("pending_imports")
-                .and_then(|value| value.as_u64())
-                .unwrap_or(0);
-            let mut completed = 0_u64;
-            let mut already_current = 0_u64;
-            let mut errors = Vec::new();
-            // Rows Rust will never accept, however often Python offers them.
-            // Counted separately because Python must drop these instead of
-            // queueing them; a permanently rejected row left in the retry queue
-            // would hold the Rust read path down for as long as the queue lives.
-            let mut permanent = 0_u64;
-            for record in records {
-                let screenshot_id = record
-                    .get("screenshot_id")
-                    .and_then(|value| value.as_i64())
-                    .unwrap_or(0);
-                let vector: Vec<f32> =
-                    match record.get("embedding").cloned().map(serde_json::from_value) {
-                        Some(Ok(vector)) => vector,
-                        Some(Err(error)) => {
-                            permanent += 1;
-                            errors.push(serde_json::json!({
-                                "screenshot_id": screenshot_id,
-                                "error": format!("invalid embedding: {error}"),
-                                "permanent": true,
-                            }));
-                            continue;
-                        }
-                        None => {
-                            permanent += 1;
-                            errors.push(serde_json::json!({
-                                "screenshot_id": screenshot_id,
-                                "error": "embedding is required",
-                                "permanent": true,
-                            }));
-                            continue;
-                        }
-                    };
-                match crate::minilm_migration::import_minilm_vector_from_python(
-                    storage,
-                    screenshot_id,
-                    vector,
-                ) {
-                    Ok(crate::storage::EnsureDerivedIndexJobResult::Queued)
-                    | Ok(crate::storage::EnsureDerivedIndexJobResult::Requeued) => completed += 1,
-                    Ok(_) => already_current += 1,
-                    Err(rejection) => {
-                        if rejection.permanent {
-                            permanent += 1;
-                        }
-                        errors.push(serde_json::json!({
-                            "screenshot_id": screenshot_id,
-                            "error": rejection.message,
-                            "permanent": rejection.permanent,
-                        }));
-                    }
-                }
-            }
-            // The Rust read path refuses to serve while any mirror is
-            // outstanding, so a dropped or rejected row degrades into "Python
-            // answers the query" rather than "the ranking quietly misses
-            // screenshots". Transiently rejected rows count too: Python requeues
-            // them, but it may not write again for a while, and until it does
-            // its report would understate the gap. Permanently rejected rows do
-            // not count — Python drops them, so they are never coming, and
-            // holding the read path down for a row that can never arrive would
-            // disable Rust retrieval forever rather than until the queue drains.
-            let outstanding = (errors.len() as u64).saturating_sub(permanent);
-            crate::semantic_query::note_pending_imports(
-                reported_pending.saturating_add(outstanding),
-            );
-            StorageResponse::success(serde_json::json!({
-                "completed": completed,
-                "already_current": already_current,
-                "errors": errors,
-            }))
-        }
-
-        // Python's durable mirror queue survives a monitor restart, but the Rust
-        // debt counter is process-global and starts at zero, so after an app
-        // restart Rust would believe a knowably incomplete index was complete
-        // and rank against it. Python reports the queue it just loaded — and the
-        // queue it is left holding after every retry pass — through this command,
-        // which writes nothing.
-        "report_minilm_import_debt" => {
-            if !storage.is_session_valid() {
-                return StorageResponse::error("AUTH_REQUIRED");
-            }
-            let Some(pending) = req.get("pending_imports").and_then(|value| value.as_u64()) else {
-                return StorageResponse::error("pending_imports must be a non-negative integer");
-            };
-            crate::semantic_query::note_pending_imports(pending);
-            StorageResponse::success(serde_json::json!({ "pending_imports": pending }))
-        }
-
-        "delete_minilm_derived_embeddings" => {
-            if !storage.is_session_valid() {
-                return StorageResponse::error("AUTH_REQUIRED");
-            }
-            let Some(ids) = req.get("screenshot_ids").and_then(|value| value.as_array()) else {
-                return StorageResponse::error("screenshot_ids must be an array");
-            };
-            if ids.len() > 128 {
-                return StorageResponse::error("MiniLM delete batch exceeds 128 records");
-            }
-            let mut deleted = 0_u64;
-            let mut errors = Vec::new();
-            for value in ids {
-                let screenshot_id = value.as_i64().unwrap_or(0);
-                if screenshot_id <= 0 {
-                    errors.push(serde_json::json!({
-                        "screenshot_id": screenshot_id,
-                        "error": "screenshot_id must be positive",
-                    }));
-                    continue;
-                }
-                match storage.delete_derived_index_subject(
-                    crate::storage::DerivedIndexKind::SemanticText,
-                    &screenshot_id.to_string(),
-                ) {
-                    Ok(true) => deleted += 1,
-                    Ok(false) => {}
-                    Err(error) => errors.push(serde_json::json!({
-                        "screenshot_id": screenshot_id,
-                        "error": error,
-                    })),
-                }
-            }
-            if errors.is_empty() {
-                StorageResponse::success(serde_json::json!({ "deleted": deleted }))
-            } else {
-                StorageResponse::error(&format!(
-                    "Failed to delete {} MiniLM rows",
-                    errors.len()
-                ))
-            }
-        }
+        // M2.5 step 5 retired three MiniLM mirror commands that lived here:
+        // `upsert_minilm_derived_embeddings`, `report_minilm_import_debt`, and
+        // `delete_minilm_derived_embeddings`. All three existed because Python
+        // owned MiniLM inference and Rust held a copy that could fall behind.
+        // Rust is now the only encoder, mirrors *to* Chroma through
+        // `upsert_task_vectors`, and expires its own rows against SQLite
+        // timestamps, so there is nothing left for Python to write or report
+        // here. Removing them rather than leaving them inert matters: a handler
+        // that still accepts vectors is a second writer for a store that is
+        // supposed to have exactly one.
 
         // ============ Smart Cluster reverse IPC ============
         "get_idle_state" => {

--- a/src-tauri/src/semantic_query.rs
+++ b/src-tauri/src/semantic_query.rs
@@ -6,42 +6,37 @@
 //! that proved this path is gone (see the M2.5 retirement block); what remains
 //! is the read path itself and the observable fallback the enum rule requires.
 //!
-//! Two scope limits are deliberate and documented in the roadmap:
+//! One scope limit is deliberate and documented in the roadmap: **reranked
+//! queries stay on Python.** `enable_rerank = true` — which is every Smart
+//! Cluster calibration query — is not routed here. Python's `query_by_text`
+//! fuses retrieval and reranking into one call and the ML protocol has no
+//! standalone rerank operation, so serving the prefilter from Rust would need a
+//! Rust→Python rerank bridge living for exactly one release. Calibration moves
+//! with the reranker at M2.5 step 6.
 //!
-//! - **Reranked queries stay on Python.** `enable_rerank = true` — which is
-//!   every Smart Cluster calibration query — is not routed here. Python's
-//!   `query_by_text` fuses retrieval and reranking into one call and the ML
-//!   protocol has no standalone rerank operation, so serving the prefilter from
-//!   Rust would need a Rust→Python rerank bridge living for exactly one
-//!   release. Calibration moves with the reranker at M2.5 step 6.
-//! - **Rust reads an index Python still writes.** Nothing on the Rust capture
-//!   path encodes a new screenshot yet; `semantic_text` rows come from the M2.4
-//!   migration and Python's reverse-IPC dual-write. M2.5 step 5 closes that.
-//!
-//! Because Python owns the writes, coverage is the failure mode that matters:
-//! ranking an incomplete corpus returns plausible results with screenshots
-//! silently missing from them, which no user can detect. Three things can leave
-//! the local index short of the corpus, and each has its own refusal:
+//! Coverage is the failure mode this path has to reason about: ranking an
+//! incomplete corpus returns plausible results with screenshots silently
+//! missing from them, which no user can detect. Two things still mean the local
+//! store is a *prefix* of a corpus somebody else holds in full, and each keeps
+//! its refusal:
 //!
 //! - The M2.4 migration has not finished. It commits page by page and its rows
 //!   become query-visible immediately, so an interrupted run leaves a partial —
-//!   not empty — index. The once-per-revision sentinel gates this.
-//! - Python wrote a vector to Chroma that never reached the Rust store. The
-//!   dual-write is therefore durable on the Python side (a failed mirror is
-//!   queued and retried, exactly as expired-row deletions already were), and
-//!   Python reports the size of that outstanding queue both on every write and
-//!   once at startup, when it loads the queue back off disk.
+//!   not empty — index while Chroma still has the rest. The once-per-revision
+//!   sentinel gates this.
 //! - The store is empty outright, which is the unmigrated machine.
 //!
-//! While any of those hold, this module refuses to serve, so an index known to
-//! be behind Chroma sends the query to Python instead of ranking a corpus with
-//! holes in it.
-//!
-//! Only mirrors that can still arrive count as debt. A row Rust rejects
-//! permanently — its screenshot was deleted, and Chroma keeps documents for
-//! deleted screenshots until they age out — is dropped by Python rather than
-//! queued, because a row that is never coming would otherwise hold retrieval on
-//! Python for as long as the queue survives, which is forever.
+//! What no longer refuses is a capture-indexing backlog, and the reason is not
+//! that idle gating would trip it nightly. Through M2.5 step 4 the refusal was
+//! right because Python was the encoder: a vector it had written to Chroma and
+//! not yet mirrored was genuinely present in one store and absent from the
+//! other, so handing the query over recovered it. Step 5 makes Rust the only
+//! MiniLM encoder and reverses the mirror, so Chroma now receives its rows
+//! *from* this store. A screenshot waiting in the ledger is missing from both
+//! sides equally, and sending the query to Python would cost the user the faster
+//! path while recovering nothing. The backlog is therefore reported rather than
+//! acted on — a number in the backend diagnostic, alongside the count of jobs
+//! whose retry budget is spent and which will not clear themselves.
 //!
 //! Every refusal to serve from Rust falls back to Python and records why, so a
 //! user whose index is empty or whose worker is broken sees results rather than
@@ -54,13 +49,19 @@ use crate::semantic_runtime::SemanticRuntimeState;
 use crate::storage::{BackgroundScreenshotSummary, DerivedIndexKind, StorageState};
 use serde::Serialize;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Manager};
 
 /// User-initiated search is foreground work: deadline-bound, never idle-gated.
 /// Matches the deadline the shadow harness measured this path under.
+///
+/// The budget covers the wait for the semantic worker as well as the encode.
+/// Idle-gated capture indexing shares that one worker on a far more generous
+/// budget of its own, so a query that arrives mid-batch queues behind it; being
+/// refused here after five seconds and answered by Python is the point, since
+/// the alternative is a search box that hangs for as long as the batch runs.
 const QUERY_EMBED_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// `rust_shadow` was retired with the step-4 cutover: nothing can enter shadow
@@ -118,13 +119,19 @@ pub struct SemanticBackendStatus {
     pub last_fallback_reason: Option<String>,
     /// Rust retrieval attempts that fell back since process start.
     pub fallback_count: u64,
-    /// Vectors Python has written to Chroma but not yet mirrored into the Rust
-    /// store, as last reported by Python's dual-write. Non-zero means the Rust
-    /// index is knowably behind and retrieval is served from Python.
-    pub pending_imports: u64,
     /// Query-visible `semantic_text` vectors held locally. `None` when the
     /// database could not be read (locked, or not yet initialized).
     pub indexed_vectors: Option<u64>,
+    /// Screenshots captured but not yet encoded, waiting for an idle window.
+    /// Ordinary operation rather than a fault — reported so the freshness cost
+    /// of idle gating is visible instead of merely felt.
+    pub index_backlog: Option<u64>,
+    /// Queued screenshots whose encode retry budget is spent. Unlike the
+    /// backlog, nothing clears these on its own.
+    pub index_stalled: Option<u64>,
+    /// Age in seconds of the oldest screenshot still waiting to be encoded.
+    /// `None` when nothing is waiting.
+    pub index_backlog_age_secs: Option<i64>,
 }
 
 #[derive(Debug, Default)]
@@ -135,22 +142,6 @@ struct BackendObservations {
 }
 
 static OBSERVATIONS: RwLock<Option<BackendObservations>> = RwLock::new(None);
-
-/// Outstanding dual-write debt as last reported by Python. Process-global
-/// because the reverse-IPC handler that receives it carries no `AppHandle`.
-/// Starting at zero is the honest default: before Python has said anything,
-/// nothing is known to be missing.
-static PENDING_IMPORTS: AtomicU64 = AtomicU64::new(0);
-
-/// Record how many vectors Python still owes the Rust store. Called from the
-/// reverse-IPC dual-write handler on every batch Python delivers.
-pub fn note_pending_imports(pending: u64) {
-    PENDING_IMPORTS.store(pending, Ordering::Relaxed);
-}
-
-fn pending_imports() -> u64 {
-    PENDING_IMPORTS.load(Ordering::Relaxed)
-}
 
 /// Caches the one-way transition of the M2.4 migration sentinel.
 ///
@@ -226,18 +217,30 @@ pub fn backend_status(storage: Option<&StorageState>) -> SemanticBackendStatus {
         ),
         None => (None, None, 0),
     };
+    // One ledger read for all three depth figures. Absent when the database is
+    // locked or uninitialized, which is honestly "not known" rather than zero.
+    let backlog = storage.and_then(|storage| {
+        storage
+            .derived_index_backlog(
+                DerivedIndexKind::SemanticText,
+                crate::minilm_index::MAX_ATTEMPTS,
+            )
+            .ok()
+    });
     SemanticBackendStatus {
         semantic_index: semantic_index_backend(),
         semantic_runtime: semantic_runtime_backend(),
         last_query_backend,
         last_fallback_reason,
         fallback_count,
-        pending_imports: pending_imports(),
         indexed_vectors: storage.and_then(|storage| {
             storage
                 .count_query_visible_embeddings(DerivedIndexKind::SemanticText)
                 .ok()
         }),
+        index_backlog: backlog.map(|backlog| backlog.claimable),
+        index_stalled: backlog.map(|backlog| backlog.exhausted),
+        index_backlog_age_secs: backlog.and_then(|backlog| backlog.oldest_claimable_age_secs),
     }
 }
 
@@ -283,17 +286,6 @@ pub async fn try_rust_nl_query(app: &AppHandle, query: &str, n_results: u32) -> 
     // not maintenance-gated. So this refusal costs the user nothing.
     if crate::maintenance::is_active() {
         return fell_back("maintenance_in_progress");
-    }
-    // Python has written vectors to Chroma that never reached the Rust store.
-    // Serving here would rank a corpus with known holes and show the user a
-    // plausible page that is quietly missing screenshots — the one failure
-    // this path cannot make observable after the fact. Python's queue drains
-    // on the next capture or clustering pass, so this is self-clearing.
-    let pending = pending_imports();
-    if pending > 0 {
-        return fell_back(&format!(
-            "index_incomplete: {pending} vector(s) awaiting mirror"
-        ));
     }
     // The M2.4 copy has not finished, so whatever is in the store is a prefix of
     // the corpus rather than the corpus. Read on a blocking thread: it takes the
@@ -608,18 +600,38 @@ mod tests {
     }
 
     #[test]
-    fn outstanding_dual_write_debt_is_reported_and_clears() {
+    fn an_indexing_backlog_is_reported_but_is_not_a_refusal() {
         let _guard = OBSERVATION_LOCK
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        note_pending_imports(0);
-        assert_eq!(backend_status(None).pending_imports, 0);
-        note_pending_imports(17);
-        assert_eq!(backend_status(None).pending_imports, 17);
-        // Python reports the remaining queue on every write, so a drained
-        // queue restores the Rust path without a restart.
-        note_pending_imports(0);
-        assert_eq!(backend_status(None).pending_imports, 0);
+        // Step 5 removed the only refusal that a backlog could trigger. Rust is
+        // now the sole MiniLM encoder and Chroma is fed from this store, so a
+        // screenshot waiting in the ledger is missing from Python too; standing
+        // down would cost the faster path and recover nothing. The depth stays
+        // visible in the diagnostic, which is where the freshness cost of idle
+        // gating shows up.
+        let reasons = [
+            "maintenance_in_progress",
+            "migration_incomplete",
+            "rust_index_empty",
+        ];
+        for reason in reasons {
+            observe_fallback(reason);
+        }
+        let status = backend_status(None);
+        assert!(
+            !status
+                .last_fallback_reason
+                .as_deref()
+                .unwrap_or("")
+                .contains("index_incomplete"),
+            "a backlog must not be spelled as a fallback reason anymore"
+        );
+        // Nothing was read from a database, so the depths are unknown rather
+        // than zero — reporting zero would claim a complete index.
+        assert_eq!(status.index_backlog, None);
+        assert_eq!(status.index_stalled, None);
+        assert_eq!(status.index_backlog_age_secs, None);
     }
 
     fn scored(subject_key: &str, score: f32) -> crate::storage::ScoredSubject {

--- a/src-tauri/src/semantic_runtime.rs
+++ b/src-tauri/src/semantic_runtime.rs
@@ -327,10 +327,13 @@ impl SemanticRuntimeState {
         timeout: Duration,
         prefer_directml: bool,
     ) -> Result<MlResponse, String> {
-        let _request_guard = self.request_gate.lock().await;
-        // One deadline spans provider selection, the first attempt, and any CPU
-        // fallback, so the caller never waits materially longer than its own timeout.
+        // One deadline spans the wait for the worker, provider selection, the
+        // first attempt, and any CPU fallback, so the caller never waits
+        // materially longer than its own timeout. It is computed before the gate
+        // is taken because the wait for the gate is the longest of those steps.
         let deadline = Instant::now() + timeout;
+        let _request_guard =
+            acquire_request_slot(&self.request_gate, deadline, request.request_id()).await?;
         let model = request_model(&request);
         let provider = match self.select_provider(&app, prefer_directml, model).await {
             Ok(provider) => provider,
@@ -803,6 +806,33 @@ impl Drop for SemanticRuntimeState {
     fn drop(&mut self) {
         self.stop();
     }
+}
+
+/// Wait for exclusive use of the single semantic worker, inside the caller's own
+/// deadline.
+///
+/// Background capture indexing and foreground search share this worker, and the
+/// background batch runs on a far more generous budget than a user query does.
+/// An unbounded wait here would therefore let a 5 s search hang for the length
+/// of a background batch — its own budget would never start counting, and it
+/// could not fall back to Python either, because nothing had failed yet.
+///
+/// Losing the wait is deliberately not recorded as a worker failure and does not
+/// restart anything: the worker is healthy, it is busy. The caller sees a
+/// `timeout` error and decides what to do with it.
+async fn acquire_request_slot(
+    gate: &tokio::sync::Mutex<()>,
+    deadline: Instant,
+    request_id: u64,
+) -> Result<tokio::sync::MutexGuard<'_, ()>, String> {
+    tokio::time::timeout_at(tokio::time::Instant::from_std(deadline), gate.lock())
+        .await
+        .map_err(|_| {
+            format!(
+                "timeout: semantic request {request_id} gave up waiting for the semantic worker \
+                 to finish another request"
+            )
+        })
 }
 
 fn request_model(request: &MlRequest) -> Option<MlSemanticModel> {
@@ -1309,6 +1339,39 @@ mod tests {
             MlRequest::EmbedText { timeout_ms, .. } => assert_eq!(timeout_ms, 1_500),
             other => panic!("unexpected request variant: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn a_busy_worker_is_refused_inside_the_deadline_rather_than_waited_out() {
+        // The regression this guards: the gate used to be taken before the
+        // deadline existed, so a query with a 5 s budget queued behind a
+        // background batch with a 120 s one waited the full batch out. Nothing
+        // downstream could rescue it, because no failure had been observed yet.
+        let gate = tokio::sync::Mutex::new(());
+        let held = gate.lock().await;
+        let deadline = Instant::now() + Duration::from_millis(50);
+        let started = Instant::now();
+        let error = acquire_request_slot(&gate, deadline, 7)
+            .await
+            .expect_err("a held gate must not be waited out past the deadline");
+        assert_eq!(split_error(&error).0, "timeout");
+        assert!(error.contains("request 7"), "{error}");
+        assert!(started.elapsed() < Duration::from_secs(2), "returned late");
+        drop(held);
+
+        // A free gate is handed over without consuming any of the budget.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        assert!(acquire_request_slot(&gate, deadline, 8).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn a_deadline_that_has_already_passed_never_blocks() {
+        let gate = tokio::sync::Mutex::new(());
+        let _held = gate.lock().await;
+        let error = acquire_request_slot(&gate, Instant::now(), 9)
+            .await
+            .expect_err("an expired deadline cannot acquire a held gate");
+        assert_eq!(split_error(&error).0, "timeout");
     }
 
     #[test]

--- a/src-tauri/src/storage/derived_index.rs
+++ b/src-tauri/src/storage/derived_index.rs
@@ -129,6 +129,21 @@ pub enum EnsureDerivedIndexJobResult {
     AlreadyProcessing,
 }
 
+/// Ledger depth for one index kind.
+///
+/// Under idle gating a non-zero `claimable` is ordinary operation — captures
+/// waiting for the next idle window — so the read path reports it instead of
+/// acting on it. `exhausted` is the number that cannot clear itself: those
+/// subjects stay missing from search until someone intervenes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DerivedIndexBacklog {
+    pub claimable: u64,
+    pub exhausted: u64,
+    /// Age of the oldest claimable row by ledger update time. `None` when the
+    /// queue is empty.
+    pub oldest_claimable_age_secs: Option<i64>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DerivedIndexGeneration {
     pub index_kind: DerivedIndexKind,
@@ -838,73 +853,321 @@ impl StorageState {
         let guard = self.get_connection_named("list_derived_index_jobs")?;
         let conn = guard.as_ref().ok_or("Database not initialized")?;
         let mut statement = conn
-            .prepare(
+            .prepare(&format!(
                 r#"
-                SELECT subject_key, status, error_code, error, attempts,
-                       next_retry_at, model_id, model_revision,
-                       embedding_version, source_fingerprint, updated_at
+                SELECT {JOB_ROW_COLUMNS}
                 FROM derived_index_jobs
                 WHERE index_kind = ?1 AND (?2 IS NULL OR status = ?2)
                 ORDER BY updated_at, subject_key
                 LIMIT ?3 OFFSET ?4
-                "#,
-            )
+                "#
+            ))
             .map_err(|error| format!("Failed to prepare derived job query: {error}"))?;
         let rows = statement
             .query_map(
                 params![index_kind.as_str(), status_text, limit, offset],
-                |row| {
-                    Ok((
-                        row.get::<_, String>(0)?,
-                        row.get::<_, String>(1)?,
-                        row.get::<_, Option<String>>(2)?,
-                        row.get::<_, Option<String>>(3)?,
-                        row.get::<_, i64>(4)?,
-                        row.get::<_, Option<String>>(5)?,
-                        row.get::<_, String>(6)?,
-                        row.get::<_, String>(7)?,
-                        row.get::<_, i64>(8)?,
-                        row.get::<_, String>(9)?,
-                        row.get::<_, String>(10)?,
-                    ))
-                },
+                read_job_row,
             )
             .map_err(|error| format!("Failed to query derived jobs: {error}"))?;
         rows.map(|row| {
-            let (
-                subject_key,
-                status,
-                error_code,
-                error,
-                attempts,
-                next_retry_at,
-                model_id,
-                model_revision,
-                embedding_version,
-                source_fingerprint,
-                updated_at,
-            ) = row.map_err(|db_error| format!("Failed to read derived job row: {db_error}"))?;
-            Ok(DerivedIndexJobRecord {
-                spec: DerivedIndexJobSpec {
-                    index_kind,
-                    subject_key,
-                    model_id,
-                    model_revision,
-                    embedding_version: u32::try_from(embedding_version).map_err(|_| {
-                        format!("Invalid stored embedding version: {embedding_version}")
-                    })?,
-                    source_fingerprint,
-                },
-                status: DerivedIndexJobStatus::from_db(&status)?,
-                error_code,
-                error,
-                attempts: u32::try_from(attempts)
-                    .map_err(|_| format!("Invalid stored attempts: {attempts}"))?,
-                next_retry_at,
-                updated_at,
-            })
+            let row = row.map_err(|db_error| format!("Failed to read derived job row: {db_error}"))?;
+            job_record_from_row(index_kind, row)
         })
         .collect()
+    }
+
+    /// Ledger rows a worker may claim right now: never started, parked on a
+    /// locked session, or failed with the backoff elapsed and retry budget
+    /// intact. Deliberately narrower than [`Self::list_derived_index_jobs`],
+    /// which reports every row whether or not anything can be done with it.
+    ///
+    /// Oldest first, so a backlog drains in capture order rather than starving
+    /// whatever was queued while the machine was busy.
+    pub fn claimable_derived_index_jobs(
+        &self,
+        index_kind: DerivedIndexKind,
+        max_attempts: u32,
+        limit: u32,
+    ) -> Result<Vec<DerivedIndexJobRecord>, String> {
+        let limit = limit.clamp(1, 10_000);
+        let guard = self.get_connection_named("claimable_derived_index_jobs")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        let mut statement = conn
+            .prepare(&format!(
+                r#"
+                SELECT {JOB_ROW_COLUMNS}
+                FROM derived_index_jobs
+                WHERE index_kind = ?1
+                  AND {CLAIMABLE_JOB_PREDICATE}
+                  AND (next_retry_at IS NULL OR next_retry_at <= CURRENT_TIMESTAMP)
+                ORDER BY updated_at, subject_key
+                LIMIT ?3
+                "#
+            ))
+            .map_err(|error| format!("Failed to prepare claimable job query: {error}"))?;
+        let rows = statement
+            .query_map(params![index_kind.as_str(), max_attempts, limit], read_job_row)
+            .map_err(|error| format!("Failed to query claimable derived jobs: {error}"))?;
+        rows.map(|row| {
+            let row =
+                row.map_err(|db_error| format!("Failed to read claimable job row: {db_error}"))?;
+            job_record_from_row(index_kind, row)
+        })
+        .collect()
+    }
+
+    /// Ledger depth, for the read path's backend diagnostic.
+    ///
+    /// `claimable` is ordinary operation under idle gating and is reported, not
+    /// acted on. `exhausted` is the number that cannot clear itself: a job whose
+    /// retry budget is spent stays missing from search until someone looks.
+    pub fn derived_index_backlog(
+        &self,
+        index_kind: DerivedIndexKind,
+        max_attempts: u32,
+    ) -> Result<DerivedIndexBacklog, String> {
+        let guard = self.get_connection_named("derived_index_backlog")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        conn.query_row(
+            &format!(
+                r#"
+                SELECT
+                    COALESCE(SUM(CASE WHEN {CLAIMABLE_JOB_PREDICATE} THEN 1 ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN status = 'failed' AND attempts >= ?2
+                                      THEN 1 ELSE 0 END), 0),
+                    CAST((julianday('now') - julianday(
+                        MIN(CASE WHEN {CLAIMABLE_JOB_PREDICATE} THEN updated_at END)
+                    )) * 86400 AS INTEGER)
+                FROM derived_index_jobs
+                WHERE index_kind = ?1
+                "#
+            ),
+            params![index_kind.as_str(), max_attempts],
+            |row| {
+                Ok(DerivedIndexBacklog {
+                    claimable: row.get::<_, i64>(0)?.max(0) as u64,
+                    exhausted: row.get::<_, i64>(1)?.max(0) as u64,
+                    oldest_claimable_age_secs: row.get::<_, Option<i64>>(2)?,
+                })
+            },
+        )
+        .map_err(|error| format!("Failed to read derived index backlog: {error}"))
+    }
+
+    /// Screenshots that should have a `semantic_text` vector but have no ledger
+    /// row at all, newest first.
+    ///
+    /// This is the repair path for an enqueue that never happened — the capture
+    /// ran while the session was locked, or the process died between the OCR
+    /// commit and the enqueue. It deliberately does not look for rows whose
+    /// *fingerprint* went stale, because deciding that requires decrypting and
+    /// rebuilding the source text of every screenshot; a model or contract
+    /// change is handled by [`Self::invalidate_derived_index_model`] instead.
+    ///
+    /// The `EXISTS` clause is an over-approximation of corpus membership, and
+    /// knowingly so: whether a screenshot has any text to encode depends on the
+    /// contents of `ocr_results.text_enc`, `screenshots.process_name_enc`, and
+    /// `screenshots.window_title_enc`, and an empty string is indistinguishable
+    /// from a full one in ciphertext. `minilm_sources` applies the real rule
+    /// after decryption and records what it rules out through
+    /// [`Self::exclude_derived_index_subject`], which is what keeps a screenshot
+    /// with nothing to encode from being handed back here on every pass.
+    ///
+    /// `retention_modifier` is a SQLite datetime modifier such as `-30 days`,
+    /// bound as a parameter. Screenshots older than it are outside the window
+    /// this index keeps at all, so they are not candidates.
+    pub fn list_semantic_text_index_candidates(
+        &self,
+        retention_modifier: &str,
+        limit: u32,
+    ) -> Result<Vec<i64>, String> {
+        let limit = limit.clamp(1, 10_000);
+        let guard = self.get_connection_named("list_semantic_text_index_candidates")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        let mut statement = conn
+            .prepare(
+                r#"
+                SELECT s.id
+                FROM screenshots s
+                WHERE s.is_deleted = 0
+                  AND s.created_at >= datetime('now', ?1)
+                  AND EXISTS (
+                      SELECT 1 FROM ocr_results o
+                      WHERE o.screenshot_id = s.id AND o.is_deleted = 0
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM derived_index_jobs j
+                      WHERE j.index_kind = 'semantic_text'
+                        AND j.subject_key = CAST(s.id AS TEXT)
+                  )
+                ORDER BY s.created_at DESC, s.id DESC
+                LIMIT ?2
+                "#,
+            )
+            .map_err(|error| format!("Failed to prepare index candidate query: {error}"))?;
+        let rows = statement
+            .query_map(params![retention_modifier, limit], |row| row.get::<_, i64>(0))
+            .map_err(|error| format!("Failed to query index candidates: {error}"))?;
+        rows.collect::<rusqlite::Result<Vec<i64>>>()
+            .map_err(|error| format!("Failed to read index candidate row: {error}"))
+    }
+
+    /// Subjects the semantic index should no longer hold: aged out of the
+    /// retention window, or with no live screenshot behind them.
+    ///
+    /// Ageing is the part that needs a query. Deletion is already handled
+    /// transactionally by `cleanup_derived_index_on_screenshot_soft_delete` and
+    /// its hard-delete twin, and [`Self::ensure_derived_index_job`] refuses to
+    /// queue work for a subject that is not live, so the `s.id IS NULL` branch
+    /// cannot be produced through the normal APIs. It is kept because a row that
+    /// arrived some other way — a database written before those triggers — has
+    /// no `created_at` to age against and would otherwise never be reclaimed.
+    pub fn list_expired_semantic_text_subjects(
+        &self,
+        retention_modifier: &str,
+        limit: u32,
+    ) -> Result<Vec<String>, String> {
+        let limit = limit.clamp(1, 10_000);
+        let guard = self.get_connection_named("list_expired_semantic_text_subjects")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        let mut statement = conn
+            .prepare(
+                r#"
+                SELECT t.subject_key
+                FROM (
+                    SELECT subject_key FROM derived_index_jobs
+                    WHERE index_kind = 'semantic_text'
+                    UNION
+                    SELECT subject_key FROM derived_embeddings
+                    WHERE index_kind = 'semantic_text'
+                ) t
+                LEFT JOIN screenshots s
+                    ON s.id = CAST(t.subject_key AS INTEGER) AND s.is_deleted = 0
+                WHERE s.id IS NULL OR s.created_at < datetime('now', ?1)
+                LIMIT ?2
+                "#,
+            )
+            .map_err(|error| format!("Failed to prepare expired subject query: {error}"))?;
+        let rows = statement
+            .query_map(params![retention_modifier, limit], |row| {
+                row.get::<_, String>(0)
+            })
+            .map_err(|error| format!("Failed to query expired subjects: {error}"))?;
+        rows.collect::<rusqlite::Result<Vec<String>>>()
+            .map_err(|error| format!("Failed to read expired subject row: {error}"))
+    }
+
+    /// Records that a subject has nothing to index, so the repair scan stops
+    /// selecting it.
+    ///
+    /// [`Self::list_semantic_text_index_candidates`] decides corpus membership
+    /// from SQL alone — a live screenshot inside the retention window with at
+    /// least one OCR row — because the text that really decides it lives in
+    /// encrypted columns no predicate can read. `minilm_sources` applies the
+    /// real rule and drops screenshots whose process name, window title, and
+    /// OCR text are all empty. Nothing used to record that decision, so such a
+    /// screenshot was re-selected, re-decrypted, and re-dropped on every pass,
+    /// and enough of them would crowd genuinely missing screenshots out of the
+    /// scan's `LIMIT`.
+    ///
+    /// The row is terminal in the same sense as `discarded`: not claimable, not
+    /// counted as backlog, and not revived by a model contract change. It is
+    /// fingerprinted against the empty source, so a screenshot that later gains
+    /// text no longer matches it and [`Self::ensure_derived_index_job`] queues
+    /// fresh work for it like it would for any other source change. Expiry
+    /// reclaims the row with its screenshot.
+    ///
+    /// Returns `false` when the subject is no longer active: the lifecycle
+    /// triggers have already removed its rows and there is nothing to record.
+    pub fn exclude_derived_index_subject(
+        &self,
+        spec: &DerivedIndexJobSpec,
+        error_code: &str,
+        error: &str,
+    ) -> Result<bool, String> {
+        validate_job_spec(spec)?;
+        validate_required_text("error_code", error_code, MAX_METADATA_BYTES)?;
+        validate_required_text("error", error, MAX_METADATA_BYTES)?;
+        let mut guard = self.get_connection_named("exclude_derived_index_subject")?;
+        let conn = guard.as_mut().ok_or("Database not initialized")?;
+        let epoch_before = if spec.index_kind == DerivedIndexKind::SemanticText {
+            Some(read_derived_data_epoch(conn, DerivedIndexKind::SemanticText)?)
+        } else {
+            None
+        };
+        let tx = conn
+            .transaction()
+            .map_err(|error| format!("Failed to start derived exclusion transaction: {error}"))?;
+        if !derived_subject_is_active(&tx, spec.index_kind, &spec.subject_key)? {
+            return Ok(false);
+        }
+        // A row that already describes this exact empty source is left alone.
+        // The M2.4 migration deliberately copies a legacy Chroma vector for a
+        // screenshot whose current SQLite text is empty — it cannot be
+        // recomputed from nothing — and stamps it with this same fingerprint.
+        let contract_matches: Option<bool> = tx
+            .query_row(
+                r#"
+                SELECT model_id = ?3 AND model_revision = ?4
+                       AND embedding_version = ?5 AND source_fingerprint = ?6
+                FROM derived_index_jobs
+                WHERE index_kind = ?1 AND subject_key = ?2
+                "#,
+                params![
+                    spec.index_kind.as_str(),
+                    spec.subject_key,
+                    spec.model_id,
+                    spec.model_revision,
+                    spec.embedding_version,
+                    spec.source_fingerprint,
+                ],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|error| format!("Failed to inspect derived index job: {error}"))?;
+        if contract_matches == Some(true) {
+            return Ok(true);
+        }
+        // Any vector still held describes a source that no longer exists, so it
+        // must not stay query-visible.
+        tx.execute(
+            "DELETE FROM derived_embeddings WHERE index_kind = ?1 AND subject_key = ?2",
+            params![spec.index_kind.as_str(), spec.subject_key],
+        )
+        .map_err(|error| format!("Failed to drop an excluded subject's vector: {error}"))?;
+        tx.execute(
+            r#"
+            INSERT INTO derived_index_jobs (
+                index_kind, subject_key, status, attempts, error_code, error,
+                model_id, model_revision, embedding_version, source_fingerprint,
+                updated_at
+            ) VALUES (?1, ?2, 'discarded', 0, ?7, ?8, ?3, ?4, ?5, ?6, CURRENT_TIMESTAMP)
+            ON CONFLICT(index_kind, subject_key) DO UPDATE SET
+                status = 'discarded', attempts = 0, error_code = ?7, error = ?8,
+                next_retry_at = NULL, lease_token = NULL,
+                model_id = ?3, model_revision = ?4,
+                embedding_version = ?5, source_fingerprint = ?6,
+                updated_at = CURRENT_TIMESTAMP
+            "#,
+            params![
+                spec.index_kind.as_str(),
+                spec.subject_key,
+                spec.model_id,
+                spec.model_revision,
+                spec.embedding_version,
+                spec.source_fingerprint,
+                error_code,
+                error,
+            ],
+        )
+        .map_err(|error| format!("Failed to record a derived index exclusion: {error}"))?;
+        tx.commit()
+            .map_err(|error| format!("Failed to commit a derived exclusion: {error}"))?;
+        if let Some(epoch_before) = epoch_before {
+            let epoch_after = read_derived_data_epoch(conn, DerivedIndexKind::SemanticText)?;
+            self.note_semantic_cache_removal(&spec.subject_key, epoch_before, epoch_after);
+        }
+        Ok(true)
     }
 
     /// Deletes both the cached vector and its ledger row in one transaction.
@@ -1440,6 +1703,85 @@ type RawSnapshotMetadata = (
     Option<i64>,
     Option<i64>,
 );
+
+/// The `derived_index_jobs` projection shared by every ledger read, so the
+/// column list and [`read_job_row`] cannot drift apart.
+const JOB_ROW_COLUMNS: &str = "subject_key, status, error_code, error, attempts, \
+     next_retry_at, model_id, model_revision, embedding_version, source_fingerprint, \
+     updated_at";
+
+/// One definition of "a worker could still pick this up", with `?2` bound to
+/// the retry budget. `waiting_for_auth` counts because the session it stalled
+/// on may have been unlocked since.
+const CLAIMABLE_JOB_PREDICATE: &str = "(status IN ('pending', 'waiting_for_auth') \
+     OR (status = 'failed' AND attempts < ?2))";
+
+type JobRow = (
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    i64,
+    Option<String>,
+    String,
+    String,
+    i64,
+    String,
+    String,
+);
+
+fn read_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<JobRow> {
+    Ok((
+        row.get(0)?,
+        row.get(1)?,
+        row.get(2)?,
+        row.get(3)?,
+        row.get(4)?,
+        row.get(5)?,
+        row.get(6)?,
+        row.get(7)?,
+        row.get(8)?,
+        row.get(9)?,
+        row.get(10)?,
+    ))
+}
+
+fn job_record_from_row(
+    index_kind: DerivedIndexKind,
+    row: JobRow,
+) -> Result<DerivedIndexJobRecord, String> {
+    let (
+        subject_key,
+        status,
+        error_code,
+        error,
+        attempts,
+        next_retry_at,
+        model_id,
+        model_revision,
+        embedding_version,
+        source_fingerprint,
+        updated_at,
+    ) = row;
+    Ok(DerivedIndexJobRecord {
+        spec: DerivedIndexJobSpec {
+            index_kind,
+            subject_key,
+            model_id,
+            model_revision,
+            embedding_version: u32::try_from(embedding_version)
+                .map_err(|_| format!("Invalid stored embedding version: {embedding_version}"))?,
+            source_fingerprint,
+        },
+        status: DerivedIndexJobStatus::from_db(&status)?,
+        error_code,
+        error,
+        attempts: u32::try_from(attempts)
+            .map_err(|_| format!("Invalid stored attempts: {attempts}"))?,
+        next_retry_at,
+        updated_at,
+    })
+}
 
 pub(super) fn derived_subject_is_active(
     conn: &rusqlite::Connection,
@@ -2612,6 +2954,335 @@ mod tests {
             .unwrap();
         assert_eq!(processing.status, DerivedIndexJobStatus::Processing);
         assert_eq!(processing.attempts, 0);
+    }
+
+    /// Give a screenshot a `created_at` the retention queries can reason about.
+    fn backdate_screenshot(storage: &StorageState, id: i64, modifier: &str) {
+        let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+        guard
+            .as_ref()
+            .unwrap()
+            .execute(
+                "UPDATE screenshots SET created_at = datetime('now', ?2) WHERE id = ?1",
+                params![id, modifier],
+            )
+            .unwrap();
+    }
+
+    fn insert_screenshot_with_ocr(storage: &StorageState, id: i64) {
+        let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+        let conn = guard.as_ref().unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO screenshots (id, image_path, image_hash) VALUES (?1, ?2, ?3)",
+            params![id, format!("{id}.enc"), format!("hash-{id}")],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO ocr_results (screenshot_id, text, text_hash) VALUES (?1, ?2, ?3)",
+            params![id, format!("text-{id}"), format!("text-hash-{id}")],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn only_jobs_a_worker_could_actually_pick_up_are_claimable() {
+        let (_temp, storage) = test_storage();
+
+        // Never started.
+        let pending = job(DerivedIndexKind::SemanticText, "1");
+        ensure_active_subject(&storage, &pending);
+        storage.upsert_derived_index_job(&pending).unwrap();
+
+        // Already leased by someone else.
+        let processing = job(DerivedIndexKind::SemanticText, "2");
+        queue_and_claim(&storage, &processing);
+
+        // Failed with the budget intact and the backoff elapsed.
+        let retryable = job(DerivedIndexKind::SemanticText, "3");
+        let lease = queue_and_claim(&storage, &retryable);
+        storage
+            .mark_derived_index_job_failed(&retryable, &lease, "embed_failed", "boom", None)
+            .unwrap();
+
+        // Failed with the backoff still running.
+        let backing_off = job(DerivedIndexKind::SemanticText, "4");
+        let lease = queue_and_claim(&storage, &backing_off);
+        storage
+            .mark_derived_index_job_failed(
+                &backing_off,
+                &lease,
+                "embed_failed",
+                "boom",
+                Some("9999-12-31 23:59:59"),
+            )
+            .unwrap();
+
+        let claimable = storage
+            .claimable_derived_index_jobs(DerivedIndexKind::SemanticText, 5, 100)
+            .unwrap();
+        let subjects: Vec<&str> = claimable
+            .iter()
+            .map(|record| record.spec.subject_key.as_str())
+            .collect();
+        assert_eq!(subjects, vec!["1", "3"]);
+
+        // A spent retry budget stops the job being claimable: nothing picks it
+        // up again on its own, which is what the diagnostic calls stalled.
+        let starved: Vec<String> = storage
+            .claimable_derived_index_jobs(DerivedIndexKind::SemanticText, 1, 100)
+            .unwrap()
+            .into_iter()
+            .map(|record| record.spec.subject_key)
+            .collect();
+        assert_eq!(starved, vec!["1".to_string()]);
+
+        let backlog = storage
+            .derived_index_backlog(DerivedIndexKind::SemanticText, 1)
+            .unwrap();
+        // Only the never-started job is still claimable at a budget of one; both
+        // failures have spent it, and a spent budget is what `exhausted` counts.
+        // The leased job is neither: someone is holding it right now.
+        assert_eq!(backlog.claimable, 1);
+        assert_eq!(backlog.exhausted, 2);
+        assert!(backlog.oldest_claimable_age_secs.is_some());
+
+        // With the real budget the retryable failure is claimable again, and so
+        // is the one still inside its backoff: this figure is queue depth, not
+        // what a worker could lease this instant. Nothing is stalled.
+        let generous = storage
+            .derived_index_backlog(DerivedIndexKind::SemanticText, 5)
+            .unwrap();
+        assert_eq!(generous.claimable, 3);
+        assert_eq!(generous.exhausted, 0);
+
+        // A different index kind must not leak into either number.
+        let clip = storage
+            .derived_index_backlog(DerivedIndexKind::ClipImage, 5)
+            .unwrap();
+        assert_eq!(clip, DerivedIndexBacklog::default());
+    }
+
+    #[test]
+    fn index_candidates_are_screenshots_with_text_no_ledger_row_and_inside_retention() {
+        let (_temp, storage) = test_storage();
+        for id in [10, 11, 12, 13] {
+            insert_screenshot_with_ocr(&storage, id);
+        }
+        // 11 already has a ledger row, 12 aged out, 13 was deleted.
+        let queued = job(DerivedIndexKind::SemanticText, "11");
+        storage.upsert_derived_index_job(&queued).unwrap();
+        backdate_screenshot(&storage, 12, "-40 days");
+        {
+            let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+            guard
+                .as_ref()
+                .unwrap()
+                .execute("UPDATE screenshots SET is_deleted = 1 WHERE id = 13", [])
+                .unwrap();
+        }
+        // A screenshot with no OCR row at all is not part of the corpus.
+        {
+            let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+            guard
+                .as_ref()
+                .unwrap()
+                .execute(
+                    "INSERT INTO screenshots (id, image_path, image_hash) VALUES (14, '14.enc', 'hash-14')",
+                    [],
+                )
+                .unwrap();
+        }
+
+        let candidates = storage
+            .list_semantic_text_index_candidates("-30 days", 100)
+            .unwrap();
+        assert_eq!(candidates, vec![10]);
+    }
+
+    /// The candidate scan can only over-approximate the corpus, so the ledger has
+    /// to remember what the decrypting builder ruled out. Without this the same
+    /// screenshot is handed back, re-decrypted, and re-dropped on every pass, and
+    /// once enough of them accumulate they fill the scan's `LIMIT` and the repair
+    /// path stops reaching screenshots that really are missing a vector.
+    #[test]
+    fn an_excluded_subject_leaves_the_repair_scan_for_good() {
+        let (_temp, storage) = test_storage();
+        insert_screenshot_with_ocr(&storage, 30);
+        insert_screenshot_with_ocr(&storage, 31);
+        assert_eq!(
+            storage
+                .list_semantic_text_index_candidates("-30 days", 100)
+                .unwrap(),
+            vec![31, 30]
+        );
+
+        let empty = job(DerivedIndexKind::SemanticText, "30");
+        assert!(storage
+            .exclude_derived_index_subject(&empty, "empty_source", "nothing to encode")
+            .unwrap());
+
+        // Out of the scan, and out of both worker-facing projections: nothing
+        // will lease it, and it is neither queue depth nor a stalled job.
+        assert_eq!(
+            storage
+                .list_semantic_text_index_candidates("-30 days", 100)
+                .unwrap(),
+            vec![31]
+        );
+        assert!(storage
+            .claimable_derived_index_jobs(DerivedIndexKind::SemanticText, 5, 100)
+            .unwrap()
+            .is_empty());
+        let backlog = storage
+            .derived_index_backlog(DerivedIndexKind::SemanticText, 5)
+            .unwrap();
+        assert_eq!(backlog.claimable, 0);
+        assert_eq!(backlog.exhausted, 0);
+
+        // Repeating the decision is a no-op rather than a second row.
+        assert!(storage
+            .exclude_derived_index_subject(&empty, "empty_source", "nothing to encode")
+            .unwrap());
+        let record = storage
+            .get_derived_index_job(DerivedIndexKind::SemanticText, "30")
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.status, DerivedIndexJobStatus::Discarded);
+        assert_eq!(record.attempts, 0);
+        assert_eq!(record.error_code.as_deref(), Some("empty_source"));
+    }
+
+    #[test]
+    fn regaining_text_reclaims_an_excluded_subject() {
+        let (_temp, storage) = test_storage();
+        let empty = job(DerivedIndexKind::SemanticText, "32");
+        ensure_active_subject(&storage, &empty);
+        assert!(storage
+            .exclude_derived_index_subject(&empty, "empty_source", "nothing to encode")
+            .unwrap());
+
+        // The exclusion is fingerprinted against the empty source, so a
+        // re-OCR that produces text is an ordinary source change and not
+        // something the ledger has already settled.
+        let mut with_text = empty.clone();
+        with_text.source_fingerprint = "source-32-with-text".to_string();
+        assert_eq!(
+            storage.ensure_derived_index_job(&with_text).unwrap(),
+            EnsureDerivedIndexJobResult::Requeued
+        );
+        let claimable: Vec<String> = storage
+            .claimable_derived_index_jobs(DerivedIndexKind::SemanticText, 5, 100)
+            .unwrap()
+            .into_iter()
+            .map(|record| record.spec.subject_key)
+            .collect();
+        assert_eq!(claimable, vec!["32".to_string()]);
+    }
+
+    #[test]
+    fn an_exclusion_drops_a_vector_whose_source_is_gone_but_spares_a_matching_one() {
+        let (_temp, storage) = test_storage();
+        // A vector encoded from text that has since disappeared cannot stay
+        // query-visible: it would keep ranking against a source nothing holds.
+        let stale = job(DerivedIndexKind::SemanticText, "33");
+        commit_vector(&storage, stale.clone(), vec![1.0, 0.0]).unwrap();
+        let mut now_empty = stale.clone();
+        now_empty.source_fingerprint = "source-33-empty".to_string();
+        assert!(storage
+            .exclude_derived_index_subject(&now_empty, "empty_source", "nothing to encode")
+            .unwrap());
+        assert!(storage
+            .get_query_visible_embedding(DerivedIndexKind::SemanticText, "33")
+            .unwrap()
+            .is_none());
+
+        // The M2.4 migration deliberately copies a legacy Chroma vector for a
+        // screenshot whose current text is empty, stamped with exactly this
+        // fingerprint. It cannot be recomputed, so excluding must not touch it.
+        let legacy = job(DerivedIndexKind::SemanticText, "34");
+        commit_vector(&storage, legacy.clone(), vec![0.0, 1.0]).unwrap();
+        assert!(storage
+            .exclude_derived_index_subject(&legacy, "empty_source", "nothing to encode")
+            .unwrap());
+        assert!(storage
+            .get_query_visible_embedding(DerivedIndexKind::SemanticText, "34")
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn a_deleted_screenshot_is_reported_rather_than_recorded_as_excluded() {
+        let (_temp, storage) = test_storage();
+        // Nothing to record: the lifecycle triggers already removed the rows,
+        // and inserting one would resurrect a subject the schema retired.
+        let gone = job(DerivedIndexKind::SemanticText, "35");
+        assert!(!storage
+            .exclude_derived_index_subject(&gone, "empty_source", "nothing to encode")
+            .unwrap());
+        assert!(storage
+            .get_derived_index_job(DerivedIndexKind::SemanticText, "35")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn expiry_reaps_aged_subjects_and_leaves_the_rest_alone() {
+        let (_temp, storage) = test_storage();
+        for id in [20, 21] {
+            let spec = job(DerivedIndexKind::SemanticText, &id.to_string());
+            commit_vector(&storage, spec, vec![1.0, 0.0]).unwrap();
+        }
+        backdate_screenshot(&storage, 20, "-40 days");
+
+        let expired = storage
+            .list_expired_semantic_text_subjects("-30 days", 100)
+            .unwrap();
+        assert_eq!(expired, vec!["20".to_string()]);
+
+        assert!(storage
+            .delete_derived_index_subject(DerivedIndexKind::SemanticText, "20")
+            .unwrap());
+        assert!(storage
+            .list_expired_semantic_text_subjects("-30 days", 100)
+            .unwrap()
+            .is_empty());
+        // The row still inside the window survives the sweep.
+        assert!(storage
+            .get_query_visible_embedding(DerivedIndexKind::SemanticText, "21")
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn expiry_also_sweeps_a_ledger_row_whose_screenshot_is_gone() {
+        // The schema triggers already delete derived rows with their screenshot,
+        // and `ensure_derived_index_job` refuses to queue work for a subject that
+        // is not live, so this branch cannot be reached through the normal APIs
+        // at all. It is a safety net for a row that arrived some other way — a
+        // database written before those triggers existed — which is otherwise
+        // invisible and never ages out, because ageing is decided against a
+        // screenshot row that no longer exists.
+        let (_temp, storage) = test_storage();
+        {
+            let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+            guard
+                .as_ref()
+                .unwrap()
+                .execute(
+                    "INSERT INTO derived_index_jobs
+                       (index_kind, subject_key, model_id, model_revision,
+                        embedding_version, source_fingerprint, status)
+                     VALUES ('semantic_text', '999', 'model-a', 'revision-1', 1,
+                             'source-999', 'pending')",
+                    [],
+                )
+                .unwrap();
+        }
+
+        let expired = storage
+            .list_expired_semantic_text_subjects("-30 days", 100)
+            .unwrap();
+        assert_eq!(expired, vec!["999".to_string()]);
     }
 
     #[test]

--- a/src-tauri/src/storage/minilm_migration.rs
+++ b/src-tauri/src/storage/minilm_migration.rs
@@ -926,47 +926,4 @@ mod tests {
             .unwrap();
         assert!(storage.is_minilm_auto_migration_done("revision-1").unwrap());
     }
-
-    // The two tests below cover `crate::minilm_migration`'s dual-write entry
-    // point rather than this module's. They live here because that is where the
-    // `StorageState` test fixture is: the type's connection field is private to
-    // the storage module, and a permanently-vs-transiently rejected mirror is
-    // exactly a storage-level distinction.
-
-    #[test]
-    fn a_malformed_dual_write_row_is_rejected_permanently_not_queued_forever() {
-        // Python queues every failed mirror durably, and the Rust read path
-        // stands down while that queue is non-empty. A row whose payload can
-        // never become valid must therefore be reported as permanent, or it
-        // would hold semantic retrieval on Python for the life of the queue.
-        use crate::minilm_migration::{import_minilm_vector_from_python, MINILM_DIMENSIONS};
-        let storage = test_storage();
-
-        let rejection = import_minilm_vector_from_python(&storage, 0, vec![0.25; MINILM_DIMENSIONS])
-            .err()
-            .expect("a non-positive screenshot id is rejected");
-        assert!(rejection.permanent, "{}", rejection.message);
-
-        let rejection = import_minilm_vector_from_python(&storage, 5, vec![0.25; 10])
-            .err()
-            .expect("a wrong-width vector is rejected");
-        assert!(rejection.permanent, "{}", rejection.message);
-    }
-
-    #[test]
-    fn a_locked_session_is_transient_so_the_mirror_is_retried_after_unlock() {
-        // The opposite mistake: treating a locked vault as permanent would make
-        // Python drop vectors it will never write again, leaving the index
-        // silently short with nothing recording the loss.
-        use crate::minilm_migration::{import_minilm_vector_from_python, MINILM_DIMENSIONS};
-        let storage = test_storage();
-        assert!(!storage.is_session_valid());
-
-        let rejection =
-            import_minilm_vector_from_python(&storage, 5, vec![0.25; MINILM_DIMENSIONS])
-                .err()
-                .expect("a locked session cannot read the source row");
-        assert!(!rejection.permanent, "{}", rejection.message);
-        assert_eq!(rejection.message, "AUTH_REQUIRED");
-    }
 }

--- a/src/components/settings/advanced/InferenceCards.jsx
+++ b/src/components/settings/advanced/InferenceCards.jsx
@@ -243,7 +243,11 @@ export function SemanticBackendCard({ config, status, statusLoading, onToggleRus
   const { t } = useTranslation();
   const backend = status?.backend;
   const usesRustIndex = (config.semantic_index || 'rust') === 'rust';
-  const pending = backend?.pending_imports ?? 0;
+  // Captures waiting for an idle window to be encoded. Ordinary operation, not
+  // a fault, so it is shown plainly; only a stalled job — one whose retry
+  // budget is spent and which nothing will pick up again — gets a warning.
+  const backlog = backend?.index_backlog ?? 0;
+  const stalled = backend?.index_stalled ?? 0;
 
   const servedLabel = {
     rust: t('settings.advanced.semantic_backend.served_rust'),
@@ -290,8 +294,14 @@ export function SemanticBackendCard({ config, status, statusLoading, onToggleRus
             <span className="text-ide-text text-right">{servedLabel}</span>
             <span className="text-ide-muted">{t('settings.advanced.semantic_backend.indexed')}</span>
             <span className="text-ide-text text-right">{backend?.indexed_vectors ?? '—'}</span>
-            <span className="text-ide-muted">{t('settings.advanced.semantic_backend.pending')}</span>
-            <span className={`text-right ${pending ? 'text-ide-warning' : 'text-ide-text'}`}>{pending}</span>
+            <span className="text-ide-muted">{t('settings.advanced.semantic_backend.backlog')}</span>
+            <span className="text-ide-text text-right">{backend?.index_backlog ?? '—'}</span>
+            {stalled > 0 && (
+              <>
+                <span className="text-ide-muted">{t('settings.advanced.semantic_backend.stalled')}</span>
+                <span className="text-ide-warning text-right">{stalled}</span>
+              </>
+            )}
             <span className="text-ide-muted">{t('settings.advanced.semantic_backend.fallbacks')}</span>
             <span className="text-ide-text text-right">{backend?.fallback_count ?? 0}</span>
           </div>
@@ -301,9 +311,14 @@ export function SemanticBackendCard({ config, status, statusLoading, onToggleRus
               {t('settings.advanced.semantic_backend.last_reason')}: {backend.last_fallback_reason}
             </p>
           )}
-          {pending > 0 && (
+          {backlog > 0 && (
+            <p className="text-[11px] text-ide-muted leading-snug">
+              {t('settings.advanced.semantic_backend.backlog_hint')}
+            </p>
+          )}
+          {stalled > 0 && (
             <p className="text-[11px] text-ide-warning-muted leading-snug">
-              {t('settings.advanced.semantic_backend.pending_hint')}
+              {t('settings.advanced.semantic_backend.stalled_hint')}
             </p>
           )}
         </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -302,10 +302,12 @@
         "served_python": "Python",
         "served_unknown": "No query since startup",
         "indexed": "Vectors indexed locally",
-        "pending": "Vectors awaiting mirror",
+        "backlog": "Screenshots awaiting indexing",
+        "stalled": "Screenshots that failed indexing",
         "fallbacks": "Fallbacks",
         "last_reason": "Last fallback reason",
-        "pending_hint": "Some vectors have not reached the local index yet. Until they do, retrieval is served by Python so that results cannot silently omit screenshots."
+        "backlog_hint": "Semantic indexing runs only while the computer is idle, so screenshots captured during active use become searchable by natural language after the next idle period.",
+        "stalled_hint": "These screenshots exhausted their indexing retries and will not be picked up again on their own. They stay out of natural-language search until indexing is rebuilt."
       },
       "onnx": {
         "title": "ONNX Inference (Experimental)",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -302,10 +302,12 @@
         "served_python": "Python",
         "served_unknown": "本次启动后尚未检索",
         "indexed": "本地已索引向量",
-        "pending": "待补写向量",
+        "backlog": "等待索引的截图",
+        "stalled": "索引失败的截图",
         "fallbacks": "回退次数",
         "last_reason": "上次回退原因",
-        "pending_hint": "有向量尚未从 Python 同步到本地索引，在补齐之前检索会交给 Python 完成，以免结果里静默地漏掉截图。"
+        "backlog_hint": "语义索引只在电脑空闲时进行，因此使用期间截取的画面要等到下一个空闲时段才能被自然语言检索到。",
+        "stalled_hint": "这些截图已经用完索引重试次数，不会再被自动处理，在重建索引之前它们不会出现在自然语言检索结果里。"
       },
       "onnx": {
         "title": "ONNX 推理 (测试性)",


### PR DESCRIPTION
## Summary

- implement Rust-native MiniLM vector indexing for capture text directly within \minilm_index.rs\ and \derived_index.rs\
- remove Python-side MiniLM dual-write and Chroma vector storage logic during capture ingestion and task clustering
- update reverse IPC and storage client interfaces to support Rust MiniLM index status, query routing, and maintenance operations
- update frontend inference diagnostic cards (\InferenceCards.jsx\) and i18n locales to reflect Rust-native MiniLM indexing state
- update \python-removal-roadmap.md\ to document the completion of capture-side MiniLM vector indexing cutover

## Notes

- Python monitor continues to manage OCR box extraction while passing text payloads directly to Rust for ONNX MiniLM vector embedding.
- Derived index vector tables are updated synchronously in Rust during capture processing, eliminating Chroma persistent dual-write overhead.