### PR TITLE
test: fix flaky index-health assertion racing the state update

### DIFF
--- a/src/components/settings/useStorageManagementController.test.js
+++ b/src/components/settings/useStorageManagementController.test.js
@@ -60,12 +60,14 @@ describe('useStorageManagementController', () => {
       monitorStatus: 'stopped',
     }));
 
-    await waitFor(() => expect(getIndexHealth).toHaveBeenCalledWith({ refreshVector: false }));
-    expect(result.current.indexHealth).toMatchObject({
+    // Wait on the state, not on the call: the call is recorded synchronously
+    // during mount, so waiting on it can return before the response is applied.
+    await waitFor(() => expect(result.current.indexHealth).toMatchObject({
       monitor_available: false,
       screenshots_count: 12,
       ocr_rows_count: 34,
-    });
+    }));
+    expect(getIndexHealth).toHaveBeenCalledWith({ refreshVector: false });
   });
 
   it('does not request vector refresh from the overview refresh when the monitor is stopped', async () => {


### PR DESCRIPTION
## What broke

The frontend CI run on `main` (post-#152) failed on
`useStorageManagementController > loads index health diagnostics even when the
monitor is stopped`:

```
AssertionError: expected null to match object { monitor_available: false, …(2) }
```

This is not a regression from #152. That PR touched `rerank.rs`,
`minilm_index.rs`, `smart_cluster_scoring.rs` and `NlClusterView.jsx`, none of
which are on this test's path. The test has been flaky since it was written.

## Why it is flaky

The test synchronized on the wrong event:

```js
await waitFor(() => expect(getIndexHealth).toHaveBeenCalledWith({ refreshVector: false }));
expect(result.current.indexHealth).toMatchObject({ ... });
```

`getIndexHealth` is invoked synchronously from the mount effect, so its call
record exists the moment `renderHook` returns and `waitFor` resolves on its
first check. But `indexHealth` is only set after that promise resolves and
React commits the update. The test waits for the request to go out and then
asserts on the response having come back.

Whether it passes comes down to scheduling order: React schedules the commit on
a MessageChannel task, while Testing Library's `asyncWrapper` settles on a
`setTimeout(0)`. Node makes no ordering guarantee between the two, which is why
it passes locally and fails under CI load.

Confirmed by re-running the test with the mocked response delayed by 5 ms,
which reproduces the CI output verbatim, `expected null to match object`
included.

## The fix

Wait on the state, and check the call arguments afterwards — at that point the
call has necessarily happened, so no coverage is lost.

Verified with response delays of 0 ms, 5 ms and 60 ms; all pass. Full suite:
21 files, 82 tests, green.
