### PR TITLE
fix: avoid cold-start diagnostic lock contention

### DIFF
--- a/src-tauri/src/clip_index.rs
+++ b/src-tauri/src/clip_index.rs
@@ -20,8 +20,8 @@ use chrono::{Duration as ChronoDuration, Utc};
 use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
 
 /// How often the worker asks whether the machine has gone idle.
@@ -1184,6 +1184,47 @@ pub struct ClipBackfillOffer {
     /// counts an unknown screenshot size as 1080p.
     pub estimated_seconds: u64,
     pub migration_status: Option<String>,
+    /// The migration is ready to inspect, but the full-history census was
+    /// deferred until the machine is idle or the user explicitly refreshes.
+    pub diagnostics_deferred: bool,
+}
+
+const BACKFILL_OFFER_CACHE_TTL: Duration = Duration::from_secs(30);
+
+struct CachedClipBackfillOffer {
+    loaded_at: Instant,
+    offer: ClipBackfillOffer,
+}
+
+static BACKFILL_OFFER_CACHE: OnceLock<tokio::sync::Mutex<Option<CachedClipBackfillOffer>>> =
+    OnceLock::new();
+
+fn terminal_backfill_offer(migration_settled: bool, decision: Option<String>) -> ClipBackfillOffer {
+    ClipBackfillOffer {
+        migration_settled,
+        decision,
+        should_ask: false,
+        never_indexed: 0,
+        stalled: 0,
+        skipped_deleted: 0,
+        failed_imports: 0,
+        estimated_seconds: 0,
+        migration_status: None,
+        diagnostics_deferred: false,
+    }
+}
+
+fn deferred_backfill_offer() -> ClipBackfillOffer {
+    ClipBackfillOffer {
+        diagnostics_deferred: true,
+        ..terminal_backfill_offer(true, None)
+    }
+}
+
+async fn invalidate_backfill_offer_cache() {
+    if let Some(cache) = BACKFILL_OFFER_CACHE.get() {
+        *cache.lock().await = None;
+    }
 }
 
 /// Encode cost, fitted to the 2026-08-04 measurements in the roadmap.
@@ -1213,13 +1254,46 @@ const RUN_LEVEL_CODE: &str = diagnostic_code::RUN_FAILED;
 
 /// What a backfill would cost and what it would fix, for the dialog that asks.
 #[tauri::command]
-pub async fn get_clip_backfill_offer(app: AppHandle) -> Result<ClipBackfillOffer, String> {
+pub async fn get_clip_backfill_offer(
+    app: AppHandle,
+    allow_expensive: Option<bool>,
+) -> Result<ClipBackfillOffer, String> {
+    let allow_expensive = allow_expensive.unwrap_or(false);
+    let requested_at = Instant::now();
+    let cache = BACKFILL_OFFER_CACHE.get_or_init(|| tokio::sync::Mutex::new(None));
+    let mut cache_guard = cache.lock().await;
+    if let Some(cached) = cache_guard.as_ref() {
+        let cache_ttl = if cached.offer.diagnostics_deferred || !cached.offer.migration_settled {
+            Duration::from_secs(5)
+        } else {
+            BACKFILL_OFFER_CACHE_TTL
+        };
+        let satisfies_request = !allow_expensive || !cached.offer.diagnostics_deferred;
+        if satisfies_request
+            && (cached.loaded_at >= requested_at || cached.loaded_at.elapsed() < cache_ttl)
+        {
+            return Ok(cached.offer.clone());
+        }
+    }
+
+    let machine_is_idle = app
+        .state::<Arc<IdleState>>()
+        .is_idle
+        .load(Ordering::Relaxed);
+    let load_expensive_diagnostics = allow_expensive || machine_is_idle;
     let storage = app.state::<Arc<StorageState>>().inner().clone();
-    tokio::task::spawn_blocking(move || {
+    let offer = tokio::task::spawn_blocking(move || -> Result<ClipBackfillOffer, String> {
         let migration_settled = crate::clip_query::migration_settled(&storage);
         let decision = storage
             .get_backfill_decision(DerivedIndexKind::ClipImage)
             .unwrap_or(None);
+        if !migration_settled || decision.is_some() {
+            return Ok(terminal_backfill_offer(migration_settled, decision));
+        }
+        if !load_expensive_diagnostics {
+            return Ok(deferred_backfill_offer());
+        }
+
         let work = storage
             .clip_image_backfill_work(ASSUMED_MEGAPIXELS)
             .unwrap_or_default();
@@ -1267,10 +1341,16 @@ pub async fn get_clip_backfill_offer(app: AppHandle) -> Result<ClipBackfillOffer
             failed_imports,
             estimated_seconds,
             migration_status: run.map(|run| run.status),
+            diagnostics_deferred: false,
         })
     })
     .await
-    .map_err(|error| format!("backfill offer task failed: {error}"))?
+    .map_err(|error| format!("backfill offer task failed: {error}"))??;
+    *cache_guard = Some(CachedClipBackfillOffer {
+        loaded_at: Instant::now(),
+        offer: offer.clone(),
+    });
+    Ok(offer)
 }
 
 /// Record the user's answer to that offer.
@@ -1298,7 +1378,8 @@ pub async fn set_clip_backfill_decision(
     .await
     .map_err(|error| format!("backfill decision task failed: {error}"))??;
     tracing::info!("[CLIP:INDEX] backfill {decision} by the user");
-    get_clip_backfill_offer(app).await
+    invalidate_backfill_offer_cache().await;
+    get_clip_backfill_offer(app, Some(false)).await
 }
 
 #[cfg(test)]
@@ -1354,6 +1435,24 @@ mod tests {
                 "{width}x{height}: predicted {predicted:.3}s against {measured:.3}s measured"
             );
         }
+    }
+
+    #[test]
+    fn terminal_backfill_states_do_not_request_full_history_diagnostics() {
+        let migrating = terminal_backfill_offer(false, None);
+        assert!(!migrating.migration_settled);
+        assert!(!migrating.should_ask);
+        assert_eq!(migrating.never_indexed, 0);
+
+        let decided = terminal_backfill_offer(true, Some(BACKFILL_DECLINED.to_string()));
+        assert_eq!(decided.decision.as_deref(), Some(BACKFILL_DECLINED));
+        assert!(!decided.should_ask);
+        assert_eq!(decided.estimated_seconds, 0);
+
+        let deferred = deferred_backfill_offer();
+        assert!(deferred.migration_settled);
+        assert!(deferred.diagnostics_deferred);
+        assert!(!deferred.should_ask);
     }
 
     #[test]

--- a/src-tauri/src/clip_query.rs
+++ b/src-tauri/src/clip_query.rs
@@ -165,6 +165,19 @@ pub fn observe_python_served() {
 }
 
 pub fn backend_status(storage: Option<&StorageState>) -> ClipBackendStatus {
+    backend_status_impl(storage, true)
+}
+
+pub(crate) fn backend_status_without_vector_count(
+    storage: Option<&StorageState>,
+) -> ClipBackendStatus {
+    backend_status_impl(storage, false)
+}
+
+fn backend_status_impl(
+    storage: Option<&StorageState>,
+    include_vector_count: bool,
+) -> ClipBackendStatus {
     let guard = OBSERVATIONS
         .read()
         .unwrap_or_else(|error| error.into_inner());
@@ -187,11 +200,15 @@ pub fn backend_status(storage: Option<&StorageState>) -> ClipBackendStatus {
         last_query_backend,
         last_fallback_reason,
         fallback_count,
-        indexed_vectors: storage.and_then(|storage| {
-            storage
-                .count_query_visible_embeddings(DerivedIndexKind::ClipImage)
-                .ok()
-        }),
+        indexed_vectors: include_vector_count
+            .then(|| {
+                storage.and_then(|storage| {
+                    storage
+                        .count_query_visible_embeddings(DerivedIndexKind::ClipImage)
+                        .ok()
+                })
+            })
+            .flatten(),
         index_backlog: backlog.map(|backlog| backlog.claimable),
         index_stalled: backlog.map(|backlog| backlog.exhausted),
         index_backlog_age_secs: backlog.and_then(|backlog| backlog.oldest_claimable_age_secs),

--- a/src-tauri/src/commands/migration.rs
+++ b/src-tauri/src/commands/migration.rs
@@ -67,12 +67,24 @@ pub async fn storage_get_startup_vacuum_status(
         });
     }
 
-    let needs_vacuum = state.check_startup_vacuum_needed()?;
+    let state = state.inner().clone();
+    let needs_vacuum = tokio::task::spawn_blocking(move || state.check_startup_vacuum_needed())
+        .await
+        .map_err(|error| format!("Startup VACUUM status task failed: {error}"))??;
 
     Ok(StartupVacuumStatus {
         needs_vacuum,
         in_progress,
     })
+}
+
+/// Reports only whether a startup or manual VACUUM currently owns the database.
+///
+/// This is the settings-page probe. It is an atomic read and deliberately does
+/// not inspect the startup sentinel or acquire the database mutex.
+#[tauri::command]
+pub fn storage_is_startup_vacuum_in_progress(state: tauri::State<'_, Arc<StorageState>>) -> bool {
+    state.is_startup_vacuum_in_progress()
 }
 
 /// Runs the one-time startup VACUUM when required.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1217,6 +1217,7 @@ pub fn run() {
             commands::storage::storage_get_categories_from_db,
             commands::storage::storage_batch_get_categories,
             commands::migration::storage_get_startup_vacuum_status,
+            commands::migration::storage_is_startup_vacuum_in_progress,
             commands::migration::storage_run_startup_vacuum_if_needed,
             commands::migration::storage_run_manual_vacuum,
             commands::migration::storage_check_hmac_migration_status,

--- a/src-tauri/src/ml_runtime.rs
+++ b/src-tauri/src/ml_runtime.rs
@@ -951,11 +951,15 @@ fn assign_kill_on_close_job(child: &Child) -> Result<MlJobHandle, String> {
 }
 
 #[tauri::command]
-pub fn get_ml_ocr_status(
+pub async fn get_ml_ocr_status(
     state: tauri::State<'_, Arc<MlRuntimeState>>,
     storage: tauri::State<'_, Arc<crate::storage::StorageState>>,
-) -> MlRuntimeStatus {
-    state.status(storage.count_failed_ocr().unwrap_or(0))
+) -> Result<MlRuntimeStatus, String> {
+    let state = state.inner().clone();
+    let storage = storage.inner().clone();
+    tokio::task::spawn_blocking(move || state.status(storage.count_failed_ocr().unwrap_or(0)))
+        .await
+        .map_err(|error| format!("OCR status task failed: {error}"))
 }
 
 #[tauri::command]

--- a/src-tauri/src/semantic_query.rs
+++ b/src-tauri/src/semantic_query.rs
@@ -235,6 +235,19 @@ pub fn observe_python_served() {
 }
 
 pub fn backend_status(storage: Option<&StorageState>) -> SemanticBackendStatus {
+    backend_status_impl(storage, true)
+}
+
+pub(crate) fn backend_status_without_vector_count(
+    storage: Option<&StorageState>,
+) -> SemanticBackendStatus {
+    backend_status_impl(storage, false)
+}
+
+fn backend_status_impl(
+    storage: Option<&StorageState>,
+    include_vector_count: bool,
+) -> SemanticBackendStatus {
     let guard = OBSERVATIONS
         .read()
         .unwrap_or_else(|error| error.into_inner());
@@ -262,11 +275,15 @@ pub fn backend_status(storage: Option<&StorageState>) -> SemanticBackendStatus {
         last_query_backend,
         last_fallback_reason,
         fallback_count,
-        indexed_vectors: storage.and_then(|storage| {
-            storage
-                .count_query_visible_embeddings(DerivedIndexKind::SemanticText)
-                .ok()
-        }),
+        indexed_vectors: include_vector_count
+            .then(|| {
+                storage.and_then(|storage| {
+                    storage
+                        .count_query_visible_embeddings(DerivedIndexKind::SemanticText)
+                        .ok()
+                })
+            })
+            .flatten(),
         index_backlog: backlog.map(|backlog| backlog.claimable),
         index_stalled: backlog.map(|backlog| backlog.exhausted),
         index_backlog_age_secs: backlog.and_then(|backlog| backlog.oldest_claimable_age_secs),

--- a/src-tauri/src/semantic_runtime.rs
+++ b/src-tauri/src/semantic_runtime.rs
@@ -17,7 +17,7 @@ use std::os::windows::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tauri::AppHandle;
 use windows::Win32::Foundation::{CloseHandle, HANDLE};
@@ -65,6 +65,19 @@ pub struct SemanticRuntimeStatus {
     /// one field could not tell which of the two it described.
     pub clip_backend: crate::clip_query::ClipBackendStatus,
 }
+
+const BACKEND_DIAGNOSTIC_CACHE_TTL: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+struct CachedBackendDiagnostics {
+    loaded_at: Instant,
+    includes_vector_counts: bool,
+    semantic: crate::semantic_query::SemanticBackendStatus,
+    clip: crate::clip_query::ClipBackendStatus,
+}
+
+static BACKEND_DIAGNOSTIC_CACHE: OnceLock<tokio::sync::Mutex<Option<CachedBackendDiagnostics>>> =
+    OnceLock::new();
 
 #[derive(Debug)]
 pub struct SemanticEmbeddingResult {
@@ -1272,6 +1285,7 @@ pub async fn get_ml_semantic_status(
     storage: tauri::State<'_, Arc<crate::storage::StorageState>>,
     index_run: tauri::State<'_, Arc<crate::minilm_index::SemanticIndexRunState>>,
     clip_run: tauri::State<'_, Arc<crate::clip_index::ClipIndexRunState>>,
+    refresh_diagnostics: Option<bool>,
 ) -> Result<SemanticRuntimeStatus, String> {
     let mut status = state.status();
     // Read before the blocking call below, so a run that finishes while the
@@ -1288,18 +1302,45 @@ pub async fn get_ml_semantic_status(
     // command in this codebase that touches storage keeps that wait off the
     // thread dispatching IPC. A synchronous command here would freeze the UI
     // for as long as a vacuum or a migration page holds the lock.
+    let include_vector_counts = refresh_diagnostics.unwrap_or(false);
+    let requested_at = Instant::now();
+    let cache = BACKEND_DIAGNOSTIC_CACHE.get_or_init(|| tokio::sync::Mutex::new(None));
+    let mut cache_guard = cache.lock().await;
+    if let Some(cached) = cache_guard.as_ref() {
+        let satisfies_request = cached.includes_vector_counts || !include_vector_counts;
+        let completed_after_request = cached.loaded_at >= requested_at;
+        let fresh = cached.loaded_at.elapsed() < BACKEND_DIAGNOSTIC_CACHE_TTL;
+        if satisfies_request && (completed_after_request || (!include_vector_counts && fresh)) {
+            status.backend = cached.semantic.clone();
+            status.backend.index_run_active = run_active;
+            status.clip_backend = cached.clip.clone();
+            status.clip_backend.index_run_active = clip_run_active;
+            return Ok(status);
+        }
+    }
+
     let storage = storage.inner().clone();
-    // One hop onto a blocking thread for both diagnostics rather than two: each
-    // takes the process-wide database mutex, and a settings dialog refreshing
-    // this every few seconds should not queue for it twice.
     let (semantic_backend, clip_backend) = tokio::task::spawn_blocking(move || {
-        (
-            crate::semantic_query::backend_status(Some(storage.as_ref())),
-            crate::clip_query::backend_status(Some(storage.as_ref())),
-        )
+        if include_vector_counts {
+            (
+                crate::semantic_query::backend_status(Some(storage.as_ref())),
+                crate::clip_query::backend_status(Some(storage.as_ref())),
+            )
+        } else {
+            (
+                crate::semantic_query::backend_status_without_vector_count(Some(storage.as_ref())),
+                crate::clip_query::backend_status_without_vector_count(Some(storage.as_ref())),
+            )
+        }
     })
     .await
     .map_err(|error| format!("Failed to read semantic backend status: {error}"))?;
+    *cache_guard = Some(CachedBackendDiagnostics {
+        loaded_at: Instant::now(),
+        includes_vector_counts: include_vector_counts,
+        semantic: semantic_backend.clone(),
+        clip: clip_backend.clone(),
+    });
     status.backend = semantic_backend;
     status.backend.index_run_active = run_active;
     status.clip_backend = clip_backend;

--- a/src-tauri/src/storage/derived_index.rs
+++ b/src-tauri/src/storage/derived_index.rs
@@ -807,7 +807,7 @@ impl StorageState {
         let conn = guard.as_ref().ok_or("Database not initialized")?;
         let count: i64 = conn
             .query_row(
-                &visible_embedding_aggregate_sql(),
+                &visible_embedding_count_sql(),
                 [index_kind.as_str()],
                 |row| row.get(0),
             )
@@ -2139,6 +2139,15 @@ fn visible_embedding_exists_sql() -> String {
         SELECT 1
         {VISIBLE_EMBEDDING_SOURCE}
         LIMIT 1
+        "#
+    )
+}
+
+fn visible_embedding_count_sql() -> String {
+    format!(
+        r#"
+        SELECT COUNT(*)
+        {VISIBLE_EMBEDDING_SOURCE}
         "#
     )
 }

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -119,6 +119,8 @@ pub struct StorageState {
 struct NamedConnectionGuard<'a> {
     guard: std::sync::MutexGuard<'a, Option<Connection>>,
     lock_holder: &'a Mutex<&'static str>,
+    caller: &'static str,
+    acquired_at: std::time::Instant,
 }
 
 impl Deref for NamedConnectionGuard<'_> {
@@ -137,6 +139,14 @@ impl DerefMut for NamedConnectionGuard<'_> {
 
 impl Drop for NamedConnectionGuard<'_> {
     fn drop(&mut self) {
+        let hold_duration = self.acquired_at.elapsed();
+        if hold_duration.as_secs() >= 1 {
+            tracing::warn!(
+                "[DIAG:DB] Mutex hold took {:?} for '{}'",
+                hold_duration,
+                self.caller
+            );
+        }
         if let Ok(mut holder) = self.lock_holder.lock() {
             *holder = "";
         }
@@ -246,24 +256,26 @@ impl StorageState {
         let current_holder = self.lock_holder.lock().ok().map(|g| *g).unwrap_or("?");
         let guard = self.db.lock().unwrap_or_else(|e| e.into_inner());
         let wait_dur = wait_start.elapsed();
+        if guard.is_none() {
+            return Err("Database not initialized".to_string());
+        }
         // Update lock holder to current caller
         if let Ok(mut h) = self.lock_holder.lock() {
             *h = caller;
         }
         if wait_dur.as_secs() >= 10 {
             tracing::warn!(
-                "[DIAG:DB] Mutex wait took {:?} for '{}' (was held by '{}')",
+                "[DIAG:DB] Mutex wait took {:?} for '{}' (holder at wait start: '{}')",
                 wait_dur,
                 caller,
                 current_holder
             );
         }
-        if guard.is_none() {
-            return Err("Database not initialized".to_string());
-        }
         Ok(NamedConnectionGuard {
             guard,
             lock_holder: &self.lock_holder,
+            caller,
+            acquired_at: std::time::Instant::now(),
         })
     }
 

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -623,7 +623,6 @@ impl StorageState {
     pub fn check_startup_vacuum_needed(&self) -> Result<bool, String> {
         let guard = self.get_connection_named("startup_vacuum_check")?;
         let conn = guard.as_ref().unwrap();
-        Self::set_auto_vacuum_incremental(conn)?;
         Ok(Self::is_startup_vacuum_pending(conn))
     }
 

--- a/src/components/ClipBackfillDialog.jsx
+++ b/src/components/ClipBackfillDialog.jsx
@@ -78,7 +78,10 @@ export default function ClipBackfillDialog() {
       // settled migration with no work is terminal too. `should_ask` alone is
       // not a stop signal: it is also false while the migration is unfinished,
       // and a failed refresh returns no offer at all; both cases must retry.
-      if (next?.decision || (next?.migration_settled && !next.should_ask)) return;
+      if (
+        next?.decision
+        || (next?.migration_settled && !next.should_ask && !next.diagnostics_deferred)
+      ) return;
       timer = setTimeout(tick, POLL_MS);
     };
     tick();

--- a/src/components/ClipBackfillDialog.test.jsx
+++ b/src/components/ClipBackfillDialog.test.jsx
@@ -33,6 +33,7 @@ const offer = (overrides = {}) => ({
   failed_imports: 0,
   estimated_seconds: 3 * 3600 + 30 * 60,
   migration_status: 'completed_with_errors',
+  diagnostics_deferred: false,
   ...overrides,
 });
 
@@ -111,6 +112,28 @@ describe('ClipBackfillDialog', () => {
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(15000);
+    });
+
+    expect(getClipBackfillOffer).toHaveBeenCalledTimes(2);
+    expect(screen.getByText(/clipBackfill\.lead.*1200/)).toBeInTheDocument();
+  });
+
+  it('keeps polling while the expensive census waits for idle time', async () => {
+    vi.useFakeTimers();
+    getClipBackfillOffer
+      .mockResolvedValueOnce(offer({
+        should_ask: false,
+        never_indexed: 0,
+        diagnostics_deferred: true,
+      }))
+      .mockResolvedValueOnce(offer());
+    render(<ClipBackfillDialog />);
+    await settle();
+
+    await act(async () => {
+      vi.advanceTimersByTime(15000);
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
     expect(getClipBackfillOffer).toHaveBeenCalledTimes(2);

--- a/src/components/settings/useAdvancedSectionController.js
+++ b/src/components/settings/useAdvancedSectionController.js
@@ -41,6 +41,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
   const [clipBackfillBusy, setClipBackfillBusy] = useState(false);
   const [semanticIndexProgress, setSemanticIndexProgress] = useState(null);
   const [semanticIndexStopping, setSemanticIndexStopping] = useState(false);
+  const mlOcrStatusRequestRef = useRef(null);
 
   const saveConfig = async (newConfig) => {
     const previousConfig = config;
@@ -97,8 +98,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
 
   const refreshVacuumRunningStatus = async () => {
     try {
-      const status = await invoke('storage_get_startup_vacuum_status');
-      setVacuumRunning(Boolean(status?.in_progress));
+      setVacuumRunning(Boolean(await invoke('storage_is_startup_vacuum_in_progress')));
     } catch {
       setVacuumRunning(false);
     }
@@ -131,15 +131,23 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     refreshVacuumRunningStatus();
   }, []);
 
-  const refreshMlOcrStatus = async () => {
+  const refreshMlOcrStatus = () => {
+    if (mlOcrStatusRequestRef.current) return mlOcrStatusRequestRef.current;
+
     setMlOcrStatusLoading(true);
-    try {
-      setMlOcrStatus(await invoke('get_ml_ocr_status'));
-    } catch (err) {
-      console.warn('Failed to read Rust ML OCR status:', err);
-    } finally {
-      setMlOcrStatusLoading(false);
-    }
+    const request = (async () => {
+      try {
+        setMlOcrStatus(await invoke('get_ml_ocr_status'));
+      } catch (err) {
+        console.warn('Failed to read Rust ML OCR status:', err);
+      } finally {
+        setMlOcrStatusLoading(false);
+      }
+    })();
+    mlOcrStatusRequestRef.current = request.finally(() => {
+      mlOcrStatusRequestRef.current = null;
+    });
+    return mlOcrStatusRequestRef.current;
   };
 
   const refreshRustOcrModelStatus = async () => {
@@ -167,10 +175,10 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
   const ownsRun = useRef(false);
   const ownsClipRun = useRef(false);
 
-  const readSemanticStatus = async ({ quiet = false } = {}) => {
+  const readSemanticStatus = async ({ quiet = false, refreshDiagnostics = false } = {}) => {
     if (!quiet) setSemanticStatusLoading(true);
     try {
-      const status = await invoke('get_ml_semantic_status');
+      const status = await invoke('get_ml_semantic_status', { refreshDiagnostics });
       setSemanticStatus(status);
       if (!ownsRun.current) {
         const active = Boolean(status?.backend?.index_run_active);
@@ -192,10 +200,16 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
   // The refresh button hands its click event to whatever it calls, so the
   // public wrapper takes no arguments rather than letting an event object
   // arrive where the options object belongs.
-  const refreshSemanticStatus = () => readSemanticStatus();
+  const refreshSemanticStatus = async () => {
+    const [status] = await Promise.all([
+      readSemanticStatus({ refreshDiagnostics: true }),
+      refreshClipBackfill(true),
+    ]);
+    return status;
+  };
 
   useEffect(() => {
-    refreshSemanticStatus();
+    readSemanticStatus();
   }, []);
 
   /**
@@ -372,9 +386,9 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     }
   };
 
-  const refreshClipBackfill = async () => {
+  const refreshClipBackfill = async (allowExpensive = false) => {
     try {
-      setClipBackfill(await getClipBackfillOffer());
+      setClipBackfill(await getClipBackfillOffer(allowExpensive));
     } catch (err) {
       console.warn('Failed to read the CLIP backfill offer:', err);
     }
@@ -396,9 +410,17 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
   }, []);
 
   useEffect(() => {
-    refreshMlOcrStatus();
-    const timer = window.setInterval(refreshMlOcrStatus, 5000);
-    return () => window.clearInterval(timer);
+    let cancelled = false;
+    let timer = null;
+    const poll = async () => {
+      await refreshMlOcrStatus();
+      if (!cancelled) timer = window.setTimeout(poll, 5000);
+    };
+    poll();
+    return () => {
+      cancelled = true;
+      if (timer) window.clearTimeout(timer);
+    };
   }, []);
 
   const handleDownloadRustOcrModel = async () => {

--- a/src/components/settings/useAdvancedSectionController.test.jsx
+++ b/src/components/settings/useAdvancedSectionController.test.jsx
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
 
 import { getClipBackfillOffer } from '../../lib/task_api';
@@ -24,6 +24,7 @@ describe('useAdvancedSectionController', () => {
   let clipRunActive;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     clipRunActive = true;
     getClipBackfillOffer.mockResolvedValue({
       migration_settled: true,
@@ -34,7 +35,7 @@ describe('useAdvancedSectionController', () => {
     });
     invoke.mockImplementation(async (command) => {
       if (command === 'get_advanced_config') return {};
-      if (command === 'storage_get_startup_vacuum_status') return { in_progress: false };
+      if (command === 'storage_is_startup_vacuum_in_progress') return false;
       if (command === 'get_rust_ocr_model_status') return {};
       if (command === 'get_ml_ocr_status') return {};
       if (command === 'get_ml_semantic_status') {
@@ -46,6 +47,11 @@ describe('useAdvancedSectionController', () => {
       if (command === 'clip_index_stop_now') return true;
       return undefined;
     });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('restores and can stop a CLIP run owned by an earlier settings mount', async () => {
@@ -77,5 +83,58 @@ describe('useAdvancedSectionController', () => {
 
     expect(reopened.result.current.clipIndexRunning).toBe(false);
     expect(reopened.result.current.clipIndexStopping).toBe(false);
+    expect(invoke).toHaveBeenCalledWith('storage_is_startup_vacuum_in_progress');
+    expect(invoke).not.toHaveBeenCalledWith('storage_get_startup_vacuum_status');
+    expect(invoke).toHaveBeenCalledWith('get_ml_semantic_status', {
+      refreshDiagnostics: true,
+    });
+    expect(getClipBackfillOffer).toHaveBeenCalledWith(true);
+  });
+
+  it('waits for each OCR status request before scheduling the next poll', async () => {
+    vi.useFakeTimers();
+    clipRunActive = false;
+    const ocrResolvers = [];
+    invoke.mockImplementation((command) => {
+      if (command === 'get_advanced_config') return Promise.resolve({});
+      if (command === 'storage_is_startup_vacuum_in_progress') return Promise.resolve(false);
+      if (command === 'get_rust_ocr_model_status') return Promise.resolve({});
+      if (command === 'get_ml_ocr_status') {
+        return new Promise((resolve) => ocrResolvers.push(resolve));
+      }
+      if (command === 'get_ml_semantic_status') {
+        return Promise.resolve({
+          backend: { index_run_active: false },
+          clip_backend: { index_run_active: false },
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const hook = renderHook(() => useAdvancedSectionController({
+      monitorStatus: 'stopped',
+      t,
+    }));
+
+    await act(async () => Promise.resolve());
+    expect(invoke.mock.calls.filter(([command]) => command === 'get_ml_ocr_status')).toHaveLength(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(15000);
+      await Promise.resolve();
+    });
+    expect(invoke.mock.calls.filter(([command]) => command === 'get_ml_ocr_status')).toHaveLength(1);
+
+    await act(async () => {
+      ocrResolvers[0]({ state: 'stopped' });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await Promise.resolve();
+    });
+    expect(invoke.mock.calls.filter(([command]) => command === 'get_ml_ocr_status')).toHaveLength(2);
+
+    hook.unmount();
   });
 });

--- a/src/lib/task_api.js
+++ b/src/lib/task_api.js
@@ -175,10 +175,11 @@ export async function listClipRebuildErrors(offset = 0, limit = 100) {
  * the step-7 copy to settle. The counts it returns are deliberately separate:
  * `skipped_deleted` is the ordinary consequence of having deleted screenshots
  * and needs no action, while `never_indexed` is what a backfill would encode
- * and what `estimated_seconds` is an estimate for.
+ * and what `estimated_seconds` is an estimate for. The full-history census is
+ * deferred until system idle unless `allowExpensive` is an explicit refresh.
  */
-export async function getClipBackfillOffer() {
-  return invoke('get_clip_backfill_offer');
+export async function getClipBackfillOffer(allowExpensive = false) {
+  return invoke('get_clip_backfill_offer', { allowExpensive });
 }
 
 /**


### PR DESCRIPTION
## 问题

冷启动打开高级设置时，启动 VACUUM 检查、同步状态查询和重复轮询会竞争数据库全局锁。CLIP 全量诊断进一步放大等待时间。

## 修复

- 将启动 VACUUM 检查改为只读，并为高级页提供原子状态查询。
- 将 OCR 状态查询移出 IPC 调度线程，轮询改为串行 single-flight。
- 缓存并合并索引诊断请求，将昂贵的 CLIP 统计延后到空闲或显式刷新。
- 分别记录数据库 mutex 等待时间和实际持锁时间。

## 验证

- `npm run test:frontend`（99 项）
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`（352 项）