### PR TITLE
m2: cut over BGE classification inference to Rust

### DIFF
--- a/docs/python-removal-roadmap.md
+++ b/docs/python-removal-roadmap.md
@@ -6,10 +6,15 @@ learning interfere with whatever the user has in the foreground.
 
 **Current milestone.** Milestone 2, targeted at v0.8.4 Beta. Steps 1-5 of the
 M2.5 cutover sequence are merged. Step 6 is implemented on
-`m2/reranker-shadow-cutover`, and steps 7-9 — the whole CLIP sequence — on
-`m2/clip-vector-migration`. Both are waiting on an on-machine soak; step 9
-additionally skipped its shadow phase, which section 6 records as an outstanding
-gate item rather than a closed one.
+`m2/reranker-shadow-cutover`, steps 7-9 — the whole CLIP sequence — on
+`m2/clip-vector-migration`, and step 10 in the current working tree. Steps 6-10
+are waiting on their on-machine gates. Steps 9 and 10 deliberately skipped
+shadow mode: both are direct Rust-default cutovers with explicit Python rollback,
+so the missing live comparisons remain open gate items rather than implied
+evidence.
+
+**Source snapshot.** Updated on 2026-08-07 against commit `f96c56a` plus the
+uncommitted M2.5 step-10 working tree described below.
 
 ---
 
@@ -50,7 +55,7 @@ again.
 | Milestone | Target | Status | What it is waiting on |
 | --- | --- | --- | --- |
 | M1 — Vector semantics and migration baseline | folded into M2 | **DONE** | — |
-| M2 — Rust ONNX inference and per-kind index ownership | v0.8.4 Beta | **IN PROGRESS** — 5 of 10 cutover steps merged; steps 6 and 7-9 implemented and soaking | step 6's reranked-ordering numbers; steps 7-9's end-to-end retrieval comparison and a migration run against a real collection; then BGE shadow (step 10) |
+| M2 — Rust ONNX inference and per-kind index ownership | v0.8.4 Beta | **IN PROGRESS** — 5 of 10 cutover steps merged; steps 6-10 implemented and soaking | step 6's reranked-ordering numbers; steps 7-9's end-to-end retrieval comparison and a migration run against a real collection; step 10's BGE parity and monitor soak |
 | M3 — Smart Cluster worker in Rust | post-v0.8.4 Beta | **PLANNED** (scope reduced) | M2 step 6 |
 | M4 — Task clustering decision | post-M3 | **PLANNED** | M2 (embedding similarity) |
 | M5 — Classification and PII resolution | post-M4 | **PLANNED** | M2-M4 |
@@ -77,8 +82,10 @@ of DLL working set. Model registration, install status, sizing, and OCR
 `onnxruntime-directml` inference, ChromaDB, and post-process orchestration.
 
 **Hop 2 — move ONNX inference from Python into Rust. OCR and MiniLM retrieval
-done.** Everything else still runs its ONNX session inside the Python
-`onnxruntime`.
+are merged; reranking, CLIP, and BGE classification inference are implemented
+in the current branch sequence.** BGE is intentionally narrower than a full
+classification port: Python still runs the classifier and calls the Rust
+semantic worker for embeddings through reverse IPC.
 
 This is why Milestone 2 is organized around a shared runtime rather than one
 feature per release: embedding, reranking, and classification already sit on one
@@ -129,8 +136,13 @@ Specifics worth knowing before touching this area:
   Cluster calibration and the Smart Cluster scoring worker. On `main`. The step-6
   branch moves both to Rust and keeps this path as the `rerank_runtime = python`
   rollback.
-- **BGE classification** (`monitor/classifier.py`), invoked from OCR
-  post-process (`monitor/monitor/worker_process.py`).
+- **BGE classification orchestration** (`monitor/classifier.py`), invoked from
+  OCR post-process (`monitor/monitor/worker_process.py`). In the current working
+  tree its default embedder calls the shared Rust semantic worker; Python still
+  owns anchor loading, scoring, thresholds, learned anchors, and persistence of
+  the selected category. The local Python ONNX path remains the explicit
+  rollback and the per-request fallback after an ordinary Rust failure. A
+  foreground-priority refusal does not start a competing Python model.
 - **HDBSCAN / PaCMAP task clustering** (`monitor/task_clustering.py`), including
   the `task_vectors` hot layer and the `task_centroids` cold layer.
 - **MiniLM inference in three places that are not the capture path**: the
@@ -342,14 +354,15 @@ disabled. Each of MiniLM, the reranker, and CLIP moves through
 counts toward the v0.8.4 Beta completion claim only after its own gate passes.
 
 **Explicitly out of scope for this milestone's production cutover:** BGE
-classification and `task_centroids`, even though the shared Rust runtime may
-exercise BGE in shadow mode.
+classification orchestration and `task_centroids`. Step 10 moves only the BGE
+embedding inference call into the shared Rust runtime through a supported
+Python-to-Rust bridge; the classifier itself remains a Milestone 5 consumer.
 
 **What Milestone 2 cannot do.** Removing Python ONNX and Chroma here would be a
 functional regression. Chroma stays available for the still-live task-clustering
-collections until Milestone 4, and Python BGE stays available until
-classification has a Rust consumer (Milestone 5) or a deliberately supported
-Rust inference bridge.
+collections until Milestone 4. Step 10 supplies the supported Rust inference
+bridge, but local Python BGE stays available through its rollback window and
+Python classification orchestration stays until Milestone 5.
 
 #### Sub-milestone status
 
@@ -359,7 +372,7 @@ Rust inference bridge.
 | M2.2 | Separate Rust semantic runtime | **DONE** |
 | M2.3 | Rust-owned derived embedding storage and ledger | **DONE** 2026-07-21 |
 | M2.4 | Sentinel-triggered MiniLM migration | **DONE** 2026-07-24 |
-| M2.5 | Dual-write, shadow-query, then cut over by capability | **IN PROGRESS** — 5 of 10 steps merged, step 6 soaking |
+| M2.5 | Dual-write, shadow-query, then cut over by capability | **IN PROGRESS** — 5 of 10 steps merged, steps 6-10 soaking |
 | M2.6 | Bounded-memory ANN reads from the `.cpdvec` sidecar | **PLANNED** — the persistence shell exists; no query path consumes ANN data yet |
 
 #### M2.1 — Freeze the Python behavior contract — DONE
@@ -575,14 +588,15 @@ The cutover sequence, with status:
 | 7 | CLIP vector export and migration | **IMPLEMENTED, SOAKING** — `m2/clip-vector-migration` |
 | 8 | Rust CLIP image-encoder dual-write for new captures | **IMPLEMENTED, SOAKING** — same branch |
 | 9 | Rust CLIP text-query shadow mode, then cut over `search_nl` and MCP capability reporting | **IMPLEMENTED, SOAKING** — same branch; **the shadow phase was skipped**, see below |
-| 10 | BGE in the shared Rust runtime, shadow mode only | PLANNED |
+| 10 | Rust-default BGE classification inference through reverse IPC, with Python rollback | **IMPLEMENTED, SOAKING** — current working tree; shadow mode skipped |
 
 Two ordering constraints are load-bearing. **Step 8 precedes step 9:** do not cut
 over visual search while new screenshots still depend solely on Python image
 encoding, or old data will be searchable while new captures silently stop being
-indexed. **Step 10 does not remove Python BGE:** the classification consumer is a
-Milestone 5 item, and Python BGE inference stays until classification has a Rust
-path or a deliberately supported Rust inference bridge.
+indexed. **Step 10 does not remove Python classification:** scoring, thresholds,
+anchors, and post-process orchestration remain a Milestone 5 item. It does make
+the supported Rust inference bridge the default and retains local Python ONNX as
+the manual rollback and automatic fallback.
 
 ##### Step 3 — measured result (2026-07-27)
 
@@ -1440,6 +1454,79 @@ launch resumed its snapshot. The run start is deliberately conservative: the
 actual snapshot begins later, and older snapshot-external rows are the only ones
 the cleanup is meant to remove.
 
+##### Step 10 — Rust-default BGE classification inference — IMPLEMENTED, SOAKING
+
+Step 10 skipped the planned shadow-only phase at the maintainer's direction. It
+uses the same operational shape as the earlier direct cutovers: Rust is the
+default, Python remains an explicit rollback, and the comparison that a live
+shadow would have produced stays an open on-machine gate.
+
+**What changed.** `TextEmbedder` in `monitor/classifier.py` still receives every
+classification request, but its default `rust` path sends the text batch through
+`StorageClient.embed_bge_texts` and authenticated reverse IPC. The
+`bge_embed_texts` handler in `reverse_ipc.rs` validates the request and calls
+`classification_runtime::embed_bge_texts`, which loads `BgeSmallZh` in the
+shared semantic worker. The response names the model and dimension; Python
+rejects a vector matrix whose row count or width does not match the request.
+The Rust boundary accepts at most 512 texts and 262,144 UTF-8 bytes per reverse
+IPC request. It preserves input order while splitting that aggregate into
+semantic-worker requests of at most 32 texts, then verifies every chunk's row
+count and dimensions before merging the vectors in the original order. An
+anchor index above 32 texts is therefore expected to span multiple worker
+requests; it does not trigger Python fallback merely because it exceeds one
+worker request.
+
+This is a supported inference bridge, not the Milestone 5 classifier port.
+`ClassificationService` still loads `anchors.json`, builds and invalidates the
+anchor index, blends process-local and global anchor scores, applies the title,
+OCR, relevance, and minimum-confidence thresholds, learns user anchors, and
+writes the selected category from the OCR post-process worker. No derived index
+or migration is introduced by this step.
+
+**Scheduling and fallback.** Classification waits up to 15 seconds for a queued
+foreground semantic request to take priority, then returns `foreground_busy`
+without loading Python BGE; falling back in that case would put two copies of
+the same model in competition with the foreground request the scheduler was
+trying to protect. Other Rust errors fall back for that request only after the
+legacy Python model loads successfully. Rust failures and completed Python
+fallbacks are counted separately, so a refusal that did not produce a Python
+result is not reported as a fallback. The Rust inference call retains one
+120-second deadline across all chunks; each chunk receives only the time
+remaining on that shared deadline.
+
+**Rollback and diagnostics.** `classification_runtime = rust|python` defaults
+to `rust`. Settings -> Advanced exposes the same switch and restart action as
+the existing inference rollback controls. Rust passes the selected value to the
+monitor as `CARBONPAPER_CLASSIFICATION_RUNTIME`; both the nested post-process
+worker and `MonitorState` latch it for that child process. Changing the registry
+selection therefore does not change the live path until the monitor restarts.
+`get_ml_semantic_status` reports the selected runtime, the active monitor
+runtime, the last serving backend, Rust success count, completed fallback count,
+and the last Rust failure. The migration oracle forces `python`, so it remains
+the independent side of the parity contract instead of calling back into Rust.
+
+**What remains before DONE.** The implementation and automated contracts pass,
+but these machine-dependent gates are still open:
+
+1. Run the M2.1 BGE oracle against the installed pinned model and record token
+   equality, maximum absolute vector error, and minimum cosine for CPU. Repeat
+   for DirectML if that provider is enabled for the release configuration.
+2. On a populated profile, run the same title/OCR/process samples once with
+   `classification_runtime=python` and once with `rust`, restarting the monitor
+   between them. Record category agreement, confidence deltas, and any threshold
+   crossings, including learned and process-scoped anchors.
+3. Record cold and warm BGE latency, semantic-worker memory, OCR post-process
+   completion time, and foreground-search latency while automatic
+   classification is active. Exercise the 15-second priority refusal rather
+   than assuming it from unit tests alone. The benchmark's production-batch
+   gate must also pass: the complete anchor batch must fit the 512-text bridge
+   limit and every internally generated worker chunk must fit the 32-text
+   protocol limit.
+4. Soak normal capture, monitor restart, semantic-worker failure, and explicit
+   Python rollback on a real profile. Confirm that ordinary failures complete
+   through Python, `foreground_busy` does not start Python BGE, and the selected
+   versus active runtime display changes only after restart.
+
 ##### Configuration surface
 Enum backends, not ambiguous booleans, because inference and index ownership cut
 over at different times:
@@ -1451,6 +1538,7 @@ over at different times:
 | `rerank_runtime` | `python` \| `rust` | `rust` (step 6) |
 | `clip_runtime` | `python` \| `rust` | `rust` (step 9) |
 | `clip_index` | `chroma` \| `dual` \| `rust` | `rust` (step 9) |
+| `classification_runtime` | `python` \| `rust` | `rust` (step 10) |
 
 `clip_runtime` ships without the `rust_shadow` value this table used to
 anticipate, for the reason step 4 retired MiniLM's: nothing can enter shadow
@@ -1484,8 +1572,10 @@ it and nothing is draining at all.
 
 Invalid or unavailable Rust configurations fall back observably for one release,
 with a local diagnostic explaining why. `rust_shadow` is retired from
-`semantic_runtime` now that nothing can enter shadow mode for MiniLM; CLIP will
-introduce and then retire its own.
+`semantic_runtime` now that nothing can enter shadow mode for MiniLM; CLIP and
+BGE classification inference ship without a shadow value. Step 10's
+`foreground_busy` refusal is deliberately not a fallback because loading Python
+BGE would compete with the foreground semantic request.
 
 Search response schemas, filters, offsets, limits, thresholds, MCP tool
 availability, and frontend labels are preserved and explicitly tested. OCR
@@ -1542,8 +1632,9 @@ Python-backed are advertised honestly and remain usable through fallback.
 capability advertised as Rust-read and Python-written.
 
 **No regressions elsewhere.** Existing automatic classification and task
-clustering do not regress: Python BGE remains until its consumer migrates, and
-`task_vectors` and `task_centroids` remain available to the Milestone 4 path.
+clustering do not regress: Python still owns classification orchestration and
+keeps local BGE as the step-10 rollback, while `task_vectors` and
+`task_centroids` remain available to the Milestone 4 path.
 
 **Lifecycle.** Embedding migration and rebuild are interruptible and resumable.
 Session lock and unlock, process crash, partial `.cpdvec` generation, model upgrade,
@@ -1772,9 +1863,11 @@ idle-gated (`task_clustering.py:1696`), but there is no Rust replacement.
 **Goal.** Remove the remaining Python-only machine-learning features, or make
 them optional add-ons.
 
-**Where the code is.** Classification (`monitor/classifier.py`, BGE via ONNX with
-a torch fallback) runs inside OCR post-process
-(`monitor/monitor/worker_process.py`). PII is a **two-tier MCP-output filter**:
+**Where the code is.** Classification orchestration (`monitor/classifier.py`)
+runs inside OCR post-process (`monitor/monitor/worker_process.py`). Step 10
+routes BGE embeddings to Rust by default, with local Python ONNX and torch kept
+as rollback; anchor scoring, learning, thresholds, and category assignment have
+not moved. PII is a **two-tier MCP-output filter**:
 tier 1 is Rust aho-corasick dictionary masking (`sensitive_filter.rs`), tier 2 is
 Python Presidio NER, default-on (`presidio_enabled: true` at
 `sensitive_filter.rs:73`, applied at `mcp_server.rs:825-865`). The Rust rule
@@ -1783,10 +1876,10 @@ is untouched. `torch`, `spacy`, and `presidio-*` remain in `requirements.txt`.
 
 **Work.**
 
-- Replace Python BGE classification with Rust embedding-based scoring using the
-  Milestone 2 engine, or with simple process and title rules, or with
-  user-defined Smart Clusters — or remove automatic classification from the
-  default experience.
+- Replace the remaining Python classification orchestration with Rust
+  embedding-based scoring using the Milestone 2 engine, or with simple process
+  and title rules, or with user-defined Smart Clusters — or remove automatic
+  classification from the default experience.
 - PII: keep and extend the Rust deterministic rules. Decide Presidio and spaCy's
   fate — add ONNX NER only for a concrete workflow, otherwise make advanced PII
   optional and not part of the default install. Clarify whether PII also applies
@@ -1980,7 +2073,7 @@ for at least one release.
 | Python MiniLM inference and Chroma semantic retrieval | Only after the relevant Milestone 2 capability is stable for one release. Note the three surviving Python MiniLM call sites listed in section 3 — the reranked query encode, the hot-layer rebuild, and the Smart Cluster worker — of which the first and third move at step 6 and the second at Milestone 4. Keep Chroma and any dual-write needed by `task_vectors` and `task_centroids` until the Milestone 4 decision is complete. |
 | Python bge-reranker inference | Remove from calibration and from the Smart Cluster scoring path together, after the M2.5 step 6 parity and cutover gates. Step 6 leaves it in place as the `rerank_runtime = python` rollback for one release. Remove the remaining worker surface after Milestone 3. |
 | `monitor_smart_cluster_calibrate_preview` | **DELETED.** It was an auth-guarded Tauri command with no caller outside `api_contracts.test.js`: the calibration screen goes through `nlClusterQuery(..., enableRerank = true)`. The command, its Python handler, its security-guard entry, and its test reference were removed together. |
-| Python BGE classification inference | Do not remove in Milestone 2 merely because the Rust runtime can load BGE. Remove only when Milestone 5 classification uses Rust directly, or while a deliberately supported Python-to-Rust inference bridge is active and tested. |
+| Python BGE classification inference | **Not eligible yet.** Step 10 supplies a supported, tested Python-to-Rust inference bridge, but the local Python runtime is still the manual and automatic rollback for its release window. Remove that local inference path only after the step-10 parity and soak gates pass and Rust has been the default for one release. Python classification orchestration remains until Milestone 5 even after that inference path becomes removable. |
 | Python Smart Cluster worker | Only after Milestone 3 is stable. |
 | Python HDBSCAN and PaCMAP | Only after Milestone 4 is stable. |
 | Python classification and PII dependencies | Only after Milestone 5 is stable. |
@@ -1997,7 +2090,8 @@ latest before the capability's first production release.
 | MiniLM shadow toggle, query and document probes, `semantic_shadow_samples`, `semantic_doc_encoder_runs`, the settings card | **DELETED** with the M2.5 step-4 cutover. Tables are dropped in `storage/schema.rs`. |
 | The `rust_shadow` value of `semantic_runtime` | **DELETED** — normalizes to the shipped default. |
 | The reranker ONNX variant selector (`rerankVariant` argument, `available_variants` dropdown) | **DELETED** with M2.5 step 6. Only `model_uint8.onnx` is installed and the Rust engine pins it, so the selector offered choices that could not load and the `q4f16` default named a file that is never on disk. The loaded variant is still reported. |
-| Reranker, CLIP, and BGE shadow harnesses | Not yet built. Same rule applies at their own cutovers: enforce deletion **in the cutover PR**, not as an end-of-milestone sweep. An unowned diagnostic panel never gets deleted later. |
+| Reranker shadow harness | Not yet built. If step 6 adds one for its outstanding ordering comparison, delete it in the cutover PR rather than leaving an unowned diagnostic panel. |
+| CLIP and BGE shadow harnesses | **NOT BUILT BY DECISION.** Steps 9 and 10 cut directly to Rust-default with Python rollback. Their offline and on-machine comparisons are release evidence, not persistent production modes or UI. |
 
 When deleting a shadow harness, check for functions the production path has since
 adopted. `minilm_sources` began life as the document-encoder probe's source
@@ -2018,7 +2112,7 @@ removed production code.
   `m2/minilm-dual-write-migration`, `m2/minilm-shadow-cutover`,
   `m2/minilm-query-cutover`, `m2/minilm-capture-indexing`,
   `m2/reranker-shadow-cutover`, `m2/clip-vector-migration`, `m2/clip-cutover`,
-  `m2/search-ui-capabilities`, `m2/bge-shadow`. Infrastructure may merge to
+  `m2/search-ui-capabilities`, `m2/bge-inference-cutover`. Infrastructure may merge to
   `main` while disabled; each consumer cutover carries its own gate and rollback.
 - **Do not open a release branch** until the intended capabilities have passed
   their gates on `main`. Release branches are stabilization-only; do not
@@ -2026,8 +2120,8 @@ removed production code.
 - **Backend selection is explicit per capability.** Prefer enums
   (`python|rust_shadow|rust`, `chroma|dual|rust`) over one boolean per
   replacement, because inference and index ownership cut over at different times.
-  The cautionary precedent: only `rust_ocr_dml_beta` (a DirectML accelerator
-  toggle) ever existed for OCR, which shipped default with no `rust_ocr` flag.
+  The cautionary precedent: an earlier one-off Rust OCR DirectML accelerator
+  toggle existed without an explicit OCR backend selection flag.
   Milestones 2-5 must not repeat that unobservable big-bang cutover.
 - **Every flag and replacement gets a telemetry-free local diagnostic** command
   reporting status and last error. The OCR runtime and `mcp_get_status` are the
@@ -2087,12 +2181,18 @@ matters:
    and an app restart, and that the Chroma mirror keeps the `clip_runtime =
    python` rollback usable.
 
-**Then BGE shadow mode** (step 10), which does not remove Python BGE.
+**Step 10 is implemented in the current working tree.** BGE inference is Rust by
+default through authenticated reverse IPC, while Python keeps the classifier,
+the explicit rollback, and ordinary per-request fallback. Its next work is the
+four on-machine gates listed in the step-10 section: numeric parity, category and
+confidence agreement across a monitor restart, latency and foreground-isolation
+measurement, and a real-profile failure/rollback soak.
 
 **Standing constraints.** No Rust backend becomes authoritative until its Python
-behavior contract, dual-write and migration, shadow-query, lifecycle,
-performance, and rollback gates pass. Chroma remains for Milestone 4 task
-clustering, and Python BGE remains for Milestone 5 classification.
+behavior contract, applicable data-migration gate, comparison evidence,
+lifecycle, performance, and rollback gates pass. Chroma remains for Milestone 4
+task clustering. Python classification remains for Milestone 5, and local
+Python BGE remains through the step-10 rollback window.
 
 ---
 
@@ -2139,3 +2239,4 @@ milestone bodies; this is an index so a reversal is not silently re-reversed.
 | 2026-08-04 | The `search_nl` **time filter now works, and that is a bug fix with a release note**. Python filters on `metadata["created_at"]`, which `worker_process.py` never wrote, so start/end bounds have silently passed everything for as long as the feature has existed. Rust reads the timestamp from SQLite. Recorded as a deliberate behaviour change rather than left to look like a parity gap. |
 | 2026-08-04 | MCP `search_nl` availability stops meaning **"is Python running"**. Two backends can answer it now, so the capability flag reports which one would. `tools/list` remains a static contract and always advertises the tool; temporary backend unavailability is reported by status and at call time instead of changing the schema. |
 | 2026-08-06 | The existing `.cpdvec` file is recorded as a **generation-safe flat snapshot, not an ANN reader already in production**. M2.6 adds the ANN payload and query integration for the no-retention CLIP corpus, while SQLite stays authoritative and the bounded paged exact scan remains the complete fallback. |
+| 2026-08-07 | Step 10 changed from BGE shadow-only to a **direct Rust-default inference bridge** at the maintainer's direction. Python still owns classification orchestration and stays available through `classification_runtime=python`; ordinary Rust failures fall back per request, while `foreground_busy` does not load Python and compete with foreground semantic work. The selected value is latched at monitor spawn, so the Settings change takes effect only after monitor restart. |

--- a/monitor/classifier.py
+++ b/monitor/classifier.py
@@ -27,6 +27,16 @@ from typing import Tuple, List, Dict, Optional, Any
 
 logger = logging.getLogger(__name__)
 
+_RUST_SCHEDULING_YIELDS = (
+    "foreground_busy:",
+    "background_busy:",
+)
+
+
+def _is_rust_scheduling_yield(error: Exception) -> bool:
+    message = str(error)
+    return any(marker in message for marker in _RUST_SCHEDULING_YIELDS)
+
 # ---------------------------------------------------------------------------
 # Weight scheme constants
 # ---------------------------------------------------------------------------
@@ -479,6 +489,9 @@ class TextEmbedder:
     _model = None
     _tokenizer = None
     _is_onnx = False
+    _initialized = False
+    _selected_runtime = None
+    _last_backend = None
     _lock = threading.Lock()
 
     def __new__(cls):
@@ -488,61 +501,143 @@ class TextEmbedder:
 
     def initialize(self):
         """Load model & tokenizer (lazy, called once)."""
-        if self._model is not None:
+        if self._initialized:
             return
 
         with self._lock:
-            if self._model is not None:
+            if self._initialized:
                 return
 
-            model_path = os.environ.get("BGE_MODEL_PATH")
-            if not model_path:
-                model_path = os.path.join(
-                    os.environ.get("LOCALAPPDATA", os.path.expanduser("~")),
-                    "carbonPaper",
-                    "models",
-                    "bge-small-zh-v1.5",
+            runtime = os.environ.get(
+                "CARBONPAPER_CLASSIFICATION_RUNTIME", "rust"
+            ).strip().lower()
+            self._selected_runtime = runtime if runtime in ("rust", "python") else "rust"
+            if self._selected_runtime == "rust":
+                logger.info(
+                    "BGE-small-zh-v1.5 classification inference routed to Rust"
                 )
+                self._initialized = True
+                return
 
-            from onnx_utils import is_onnx_testing_enabled, get_onnx_model_path, create_onnx_session
+            self._initialize_python_model()
+            self._initialized = True
 
-            if is_onnx_testing_enabled():
-                primary_onnx_path = os.path.join(
-                    os.environ.get("LOCALAPPDATA", os.path.expanduser("~")),
-                    "CarbonPaper",
-                    "models-onnx",
-                    "bge-small-zh-v1.5",
-                )
-                if not os.environ.get("BGE_MODEL_PATH") and (
-                    get_onnx_model_path(primary_onnx_path, "model_int8.onnx")
-                    or get_onnx_model_path(primary_onnx_path, os.path.join("onnx", "model_quantized.onnx"))
-                ):
-                    model_path = primary_onnx_path
-                onnx_file = get_onnx_model_path(model_path, "model_int8.onnx") or get_onnx_model_path(model_path, os.path.join("onnx", "model_quantized.onnx"))
-                if onnx_file:
-                    from logging_config import log_model_loading
-                    log_model_loading("BGE-small-zh-v1.5 (ONNX)")
-                    logger.info("Loading BGE-small-zh-v1.5 from ONNX: %s ...", onnx_file)
-                    from numpy_tokenizer import NumpyTokenizer
-                    self._tokenizer = NumpyTokenizer(model_path)
-                    self._model = create_onnx_session(onnx_file)
-                    self._is_onnx = True
-                    logger.info("BGE-small-zh-v1.5 loaded successfully via ONNX")
-                    return
+    def _initialize_python_model(self):
+        """Load the legacy local runtime for explicit rollback or fallback."""
+        if self._model is not None:
+            return
 
-            from transformers import AutoTokenizer, AutoModel
-            from logging_config import log_model_loading
-            log_model_loading("BGE-small-zh-v1.5")
-            logger.info("Loading BGE-small-zh-v1.5 from %s ...", model_path)
-            self._tokenizer = AutoTokenizer.from_pretrained(model_path)
-            self._model = AutoModel.from_pretrained(model_path)
-            self._model.eval()
-            self._is_onnx = False
-            logger.info("BGE-small-zh-v1.5 loaded successfully (device=%s)", self._model.device)
+        model_path = os.environ.get("BGE_MODEL_PATH")
+        if not model_path:
+            model_path = os.path.join(
+                os.environ.get("LOCALAPPDATA", os.path.expanduser("~")),
+                "carbonPaper",
+                "models",
+                "bge-small-zh-v1.5",
+            )
+
+        from onnx_utils import is_onnx_testing_enabled, get_onnx_model_path, create_onnx_session
+
+        if is_onnx_testing_enabled():
+            primary_onnx_path = os.path.join(
+                os.environ.get("LOCALAPPDATA", os.path.expanduser("~")),
+                "CarbonPaper",
+                "models-onnx",
+                "bge-small-zh-v1.5",
+            )
+            if not os.environ.get("BGE_MODEL_PATH") and (
+                get_onnx_model_path(primary_onnx_path, "model_int8.onnx")
+                or get_onnx_model_path(primary_onnx_path, os.path.join("onnx", "model_quantized.onnx"))
+            ):
+                model_path = primary_onnx_path
+            onnx_file = get_onnx_model_path(model_path, "model_int8.onnx") or get_onnx_model_path(model_path, os.path.join("onnx", "model_quantized.onnx"))
+            if onnx_file:
+                from logging_config import log_model_loading
+                log_model_loading("BGE-small-zh-v1.5 (ONNX)")
+                logger.info("Loading BGE-small-zh-v1.5 from ONNX: %s ...", onnx_file)
+                from numpy_tokenizer import NumpyTokenizer
+                self._tokenizer = NumpyTokenizer(model_path)
+                self._model = create_onnx_session(onnx_file)
+                self._is_onnx = True
+                logger.info("BGE-small-zh-v1.5 loaded successfully via ONNX")
+                return
+
+        from transformers import AutoTokenizer, AutoModel
+        from logging_config import log_model_loading
+        log_model_loading("BGE-small-zh-v1.5")
+        logger.info("Loading BGE-small-zh-v1.5 from %s ...", model_path)
+        self._tokenizer = AutoTokenizer.from_pretrained(model_path)
+        self._model = AutoModel.from_pretrained(model_path)
+        self._model.eval()
+        self._is_onnx = False
+        logger.info("BGE-small-zh-v1.5 loaded successfully (device=%s)", self._model.device)
 
     def encode(self, texts: List[str]) -> np.ndarray:
         """Batch-encode texts; returns (N, dim) L2-normalised numpy array."""
         self.initialize()
+
+        if self._selected_runtime == "rust":
+            try:
+                result = self._encode_rust(texts)
+                self._last_backend = "rust"
+                return result
+            except Exception as exc:
+                # A foreground query deliberately outranks background
+                # classification. Do not answer that scheduling decision by
+                # loading the same model in Python and competing anyway.
+                if _is_rust_scheduling_yield(exc):
+                    raise
+                logger.warning(
+                    "Rust BGE inference failed; falling back to Python for this request: %s",
+                    exc,
+                )
+                with self._lock:
+                    self._initialize_python_model()
+                result = self._encode_python(texts)
+                self._last_backend = "python"
+                try:
+                    from storage_client import get_storage_client
+                    storage = get_storage_client()
+                    if storage:
+                        storage.record_classification_python_fallback(str(exc))
+                except Exception as diagnostic_exc:
+                    logger.debug(
+                        "Failed to record BGE Python fallback: %s", diagnostic_exc
+                    )
+                return result
+
+        result = self._encode_python(texts)
+        self._last_backend = "python"
+        try:
+            from storage_client import get_storage_client
+            storage = get_storage_client()
+            if storage:
+                storage.record_classification_python_inference()
+        except Exception as diagnostic_exc:
+            logger.debug(
+                "Failed to record Python BGE inference: %s", diagnostic_exc
+            )
+        return result
+
+    @staticmethod
+    def _encode_rust(texts: List[str]) -> np.ndarray:
+        from storage_client import get_storage_client
+
+        storage = get_storage_client()
+        if not storage:
+            raise RuntimeError("Rust storage client is unavailable")
+        response = storage.embed_bge_texts(texts)
+        vectors = np.asarray(response.get("vectors"), dtype=np.float32)
+        dimensions = int(response.get("dimensions") or 0)
+        if vectors.ndim != 2 or vectors.shape != (len(texts), dimensions):
+            raise RuntimeError(
+                f"Rust BGE returned shape {vectors.shape}, expected ({len(texts)}, {dimensions})"
+            )
+        return vectors
+
+    def _encode_python(self, texts: List[str]) -> np.ndarray:
+        if self._model is None or self._tokenizer is None:
+            raise RuntimeError("Python BGE runtime is not initialised")
 
         if self._is_onnx:
             encoded = self._tokenizer(

--- a/monitor/monitor/__init__.py
+++ b/monitor/monitor/__init__.py
@@ -790,6 +790,9 @@ def start(_debug, pipe_name: str = None, auth_token: str = None, storage_pipe: s
     worker_env = {
         'CARBONPAPER_CLUSTERING_ENABLED': str(config.CLUSTERING_ENABLED),
         'CARBONPAPER_CLASSIFICATION_ENABLED': str(config.CLASSIFICATION_ENABLED),
+        'CARBONPAPER_CLASSIFICATION_RUNTIME': os.environ.get(
+            'CARBONPAPER_CLASSIFICATION_RUNTIME', 'rust'
+        ),
         'CARBONPAPER_CLUSTERING_ALLOW_FULL_LOW_MEMORY': str(config.CLUSTERING_ALLOW_FULL_LOW_MEMORY),
         'CARBONPAPER_USE_ONNX': os.environ.get('CARBONPAPER_USE_ONNX', 'true'),
         'CARBONPAPER_OCR_TIMEOUT_SECS': str(getattr(config, '_ocr_timeout_secs', 120)),

--- a/monitor/monitor/worker_process.py
+++ b/monitor/monitor/worker_process.py
@@ -24,6 +24,20 @@ from .worker_supervisor import WorkerSupervisor, attach_response_metadata
 logger = logging.getLogger(__name__)
 WORKER_PROTOCOL_VERSION = 2
 
+_CLASSIFICATION_SCHEDULING_YIELDS = (
+    "foreground_busy:",
+    "background_busy:",
+)
+
+
+class _PostprocessDeferred(RuntimeError):
+    """The job yielded its model slot and must remain durably pending."""
+
+
+def _is_classification_scheduling_yield(error: Exception) -> bool:
+    message = str(error)
+    return any(marker in message for marker in _CLASSIFICATION_SCHEDULING_YIELDS)
+
 
 def _python_owns_clip_encoding() -> bool:
     """Return the CLIP capture owner latched into this worker at spawn."""
@@ -48,6 +62,7 @@ class OcrPostprocessQueue:
         self.dropped = 0
         self.processed = 0
         self.failed = 0
+        self.deferred = 0
         self.vector_failed = 0
         self.vector_retry_enqueued = 0
         self.last_indexing_error: Optional[str] = None
@@ -116,6 +131,47 @@ class OcrPostprocessQueue:
                         pass
                 self._handle_job(job)
                 self.processed += 1
+            except _PostprocessDeferred as exc:
+                self.deferred += 1
+                persisted = False
+                if job.get("_persistent_postprocess"):
+                    try:
+                        from storage_client import get_storage_client
+                        sc = get_storage_client()
+                        if sc:
+                            persisted = bool(
+                                sc.set_ocr_postprocess_status(
+                                    int(job.get("screenshot_id")), "pending", str(exc)
+                                )
+                            )
+                    except Exception:
+                        logger.warning(
+                            "[DIAG:ocr_postprocess] failed to persist deferred state screenshot_id=%s",
+                            job.get("screenshot_id"),
+                            exc_info=True,
+                        )
+                if not persisted and job.get("_persistent_postprocess"):
+                    # Storage trouble should not strand the row in `processing`.
+                    # This fallback may charge one ordinary retry, but preserves
+                    # the work when the preferred no-penalty transition failed.
+                    try:
+                        from storage_client import get_storage_client
+                        sc = get_storage_client()
+                        if sc:
+                            sc.record_ocr_postprocess_retry(
+                                int(job.get("screenshot_id")), str(exc)
+                            )
+                    except Exception:
+                        logger.warning(
+                            "[DIAG:ocr_postprocess] failed to persist deferred retry screenshot_id=%s",
+                            job.get("screenshot_id"),
+                            exc_info=True,
+                        )
+                logger.info(
+                    "[DIAG:ocr_postprocess] deferred screenshot_id=%s reason=%s",
+                    job.get("screenshot_id"),
+                    exc,
+                )
             except Exception as exc:
                 self.failed += 1
                 if job.get("_persistent_postprocess"):
@@ -275,6 +331,8 @@ class OcrPostprocessQueue:
                     category_confidence,
                 )
             except Exception as exc:
+                if _is_classification_scheduling_yield(exc):
+                    raise _PostprocessDeferred(str(exc)) from exc
                 logger.warning("Classification failed: %s", exc)
 
         logger.info(
@@ -329,6 +387,7 @@ class OcrPostprocessQueue:
             "dropped": self.dropped,
             "processed": self.processed,
             "failed": self.failed,
+            "deferred": self.deferred,
             "vector_failed": self.vector_failed,
             "vector_retry_enqueued": self.vector_retry_enqueued,
             "vector_retry_backlog_count": backlog_count,

--- a/monitor/storage_client.py
+++ b/monitor/storage_client.py
@@ -81,6 +81,7 @@ READ_RETRY_COMMANDS = {
     'get_auth_status',
     'get_temp_image',
     'screenshot_exists',
+    'bge_embed_texts',
 }
 
 IDEMPOTENT_RETRY_COMMANDS = {
@@ -742,6 +743,34 @@ class StorageClient:
             request['category_confidence'] = float(category_confidence)
         response = self._send_request(request)
         return response.get('status') == 'success'
+
+    def embed_bge_texts(self, texts: List[str]) -> Dict[str, Any]:
+        """Run BGE text embedding in the shared Rust semantic worker."""
+        response = self._send_request(
+            {
+                'command': 'bge_embed_texts',
+                'texts': [str(text) for text in texts],
+            },
+            timeout=150,
+        )
+        if response.get('status') == 'success':
+            data = response.get('data')
+            if isinstance(data, dict):
+                return data
+        raise RuntimeError(response.get('error', 'Rust BGE inference failed'))
+
+    def record_classification_python_fallback(self, error: str) -> None:
+        """Best-effort diagnostic after Python serves a failed Rust request."""
+        self._send_request({
+            'command': 'classification_record_python_fallback',
+            'error': str(error),
+        })
+
+    def record_classification_python_inference(self) -> None:
+        """Record that the explicit Python rollback served an inference."""
+        self._send_request({
+            'command': 'classification_record_python_inference',
+        })
 
     # ---- Smart Cluster reverse IPC --------------------------------------
 

--- a/monitor/tests/test_bge_benchmark.py
+++ b/monitor/tests/test_bge_benchmark.py
@@ -1,0 +1,167 @@
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT_DIR / "tools" / "benchmark_bge.py"
+SPEC = importlib.util.spec_from_file_location("benchmark_bge", SCRIPT_PATH)
+benchmark_bge = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(benchmark_bge)
+
+
+def test_embedding_text_corpus_is_stable_deduplicated_and_bounds_ocr():
+    long_ocr = "x" * 300
+    samples = [
+        {"window_title": " title ", "ocr_text": long_ocr},
+        {"window_title": "title", "ocr_text": "short OCR"},
+        {"window_title": "", "ocr_text": ""},
+    ]
+
+    texts = benchmark_bge._build_embedding_texts(samples)
+
+    assert texts == ["title", "x" * 200, "short OCR"]
+
+
+def test_embedding_comparison_enforces_cpu_gate():
+    python_vectors = np.asarray([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    rust_vectors = python_vectors.copy()
+
+    result = benchmark_bge.compare_embeddings(python_vectors, rust_vectors, "cpu")
+
+    assert result["gate"]["passed"] is True
+    assert result["min_cosine"] == 1.0
+    assert result["max_abs_error"] == 0.0
+
+
+def _classification_result(rows):
+    return {
+        "anchor_index_ms": 1.0,
+        "anchor_count": 12,
+        "latency_ms": benchmark_bge.summarize_values([2.0]),
+        "rows": rows,
+    }
+
+
+def test_classification_comparison_reports_branch_and_threshold_crossings():
+    python = _classification_result(
+        [
+            {
+                "screenshot_id": 7,
+                "category": "编程开发",
+                "confidence": 0.3799,
+                "confidence_rounded": 0.3799,
+                "used_ocr": False,
+                "local_veto_active": False,
+                "top_order": ["编程开发", "网页浏览"],
+            }
+        ]
+    )
+    rust = _classification_result(
+        [
+            {
+                "screenshot_id": 7,
+                "category": "编程开发",
+                "confidence": 0.3801,
+                "confidence_rounded": 0.3801,
+                "used_ocr": True,
+                "local_veto_active": False,
+                "top_order": ["编程开发", "网页浏览"],
+            }
+        ]
+    )
+
+    result = benchmark_bge.compare_classifications(python, rust)
+
+    assert result["summary"]["category_agreement"] == 1.0
+    assert result["summary"]["branch_agreement"] == 0.0
+    assert result["summary"]["threshold_crossings"]["0.38"] == 1
+    assert result["summary"]["passed"] is False
+    assert "window_title" not in result["rows"][0]
+    assert "ocr_text" not in result["rows"][0]
+
+
+def test_classification_comparison_passes_identical_results():
+    rows = [
+        {
+            "screenshot_id": 11,
+            "category": "网页浏览",
+            "confidence": 0.62,
+            "confidence_rounded": 0.62,
+            "used_ocr": False,
+            "local_veto_active": True,
+            "top_order": ["网页浏览", "阅读资讯"],
+        }
+    ]
+
+    result = benchmark_bge.compare_classifications(
+        _classification_result(rows), _classification_result([dict(rows[0])])
+    )
+
+    assert result["summary"]["passed"] is True
+    assert result["summary"]["confidence_abs_delta"]["max"] == 0.0
+
+
+def test_classification_batch_contract_accepts_multi_chunk_anchor_index():
+    contract = benchmark_bge._classification_operational_contract(203)
+
+    assert contract["classification_bridge_max_batch"] == 512
+    assert contract["classification_bridge_chunk_size"] == 32
+    assert contract["semantic_worker_max_batch"] == 32
+    assert contract["required_worker_request_count"] == 7
+    assert contract["max_worker_request_batch"] == 32
+    assert contract["production_bridge_request_compatible"] is True
+    assert contract["production_worker_chunk_compatible"] is True
+    assert contract["production_batch_contract_compatible"] is True
+    assert "production_single_request_compatible" not in contract
+
+
+def test_rust_classifier_adapter_uses_production_worker_chunks(monkeypatch):
+    request_sizes = []
+
+    def fake_embed(_worker, texts):
+        request_sizes.append(len(texts))
+        return np.ones((len(texts), 2), dtype=np.float32), {}
+
+    monkeypatch.setattr(benchmark_bge, "_rust_embed_timed", fake_embed)
+
+    vectors = benchmark_bge.RustEmbedderAdapter(object()).encode(
+        [f"anchor-{index}" for index in range(65)]
+    )
+
+    assert request_sizes == [32, 32, 1]
+    assert vectors.shape == (65, 2)
+
+
+def test_classification_batch_contract_rejects_bridge_overflow_and_chunk_drift(
+    monkeypatch,
+):
+    overflow = benchmark_bge._classification_operational_contract(513)
+
+    assert overflow["production_bridge_request_compatible"] is False
+    assert overflow["production_worker_chunk_compatible"] is True
+    assert overflow["production_batch_contract_compatible"] is False
+
+    monkeypatch.setattr(benchmark_bge, "CLASSIFICATION_BRIDGE_CHUNK_SIZE", 33)
+    drifted = benchmark_bge._classification_operational_contract(203)
+
+    assert drifted["production_bridge_request_compatible"] is True
+    assert drifted["production_worker_chunk_compatible"] is False
+    assert drifted["production_batch_contract_compatible"] is False
+
+
+def test_report_privacy_guard_rejects_plaintext_and_vector_fields():
+    benchmark_bge.assert_report_has_no_plaintext_payloads(
+        {"dataset": {"sample_ids": [1]}, "numeric": {"shape": [1, 512]}}
+    )
+
+    for field in ("window_title", "ocr_text", "process_name", "vectors", "embeddings"):
+        try:
+            benchmark_bge.assert_report_has_no_plaintext_payloads(
+                {"nested": [{field: "sensitive"}]}
+            )
+        except ValueError as error:
+            assert field in str(error)
+        else:
+            raise AssertionError(f"privacy guard accepted {field}")

--- a/monitor/tests/test_classifier_runtime.py
+++ b/monitor/tests/test_classifier_runtime.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pytest
+
+import classifier
+import storage_client
+
+
+class _RustStorage:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+        self.requests = []
+        self.fallbacks = []
+        self.python_inferences = 0
+
+    def embed_bge_texts(self, texts):
+        self.requests.append(list(texts))
+        if self.error:
+            raise RuntimeError(self.error)
+        return self.response
+
+    def record_classification_python_fallback(self, error):
+        self.fallbacks.append(error)
+
+    def record_classification_python_inference(self):
+        self.python_inferences += 1
+
+
+@pytest.fixture
+def fresh_embedder(monkeypatch):
+    monkeypatch.setenv("CARBONPAPER_CLASSIFICATION_RUNTIME", "rust")
+    classifier.TextEmbedder._instance = None
+    classifier.TextEmbedder._model = None
+    classifier.TextEmbedder._tokenizer = None
+    classifier.TextEmbedder._is_onnx = False
+    classifier.TextEmbedder._initialized = False
+    classifier.TextEmbedder._selected_runtime = None
+    classifier.TextEmbedder._last_backend = None
+    yield classifier.TextEmbedder()
+    classifier.TextEmbedder._instance = None
+
+
+def test_rust_is_the_default_classification_embedder(fresh_embedder, monkeypatch):
+    storage = _RustStorage({
+        "dimensions": 2,
+        "vectors": [[0.0, 1.0], [1.0, 0.0]],
+    })
+    monkeypatch.setattr(storage_client, "get_storage_client", lambda: storage)
+
+    result = fresh_embedder.encode(["alpha", "beta"])
+
+    np.testing.assert_array_equal(
+        result,
+        np.asarray([[0.0, 1.0], [1.0, 0.0]], dtype=np.float32),
+    )
+    assert storage.requests == [["alpha", "beta"]]
+    assert fresh_embedder._last_backend == "rust"
+    assert fresh_embedder._model is None
+
+
+def test_rust_failure_falls_back_to_python_and_records_it(fresh_embedder, monkeypatch):
+    storage = _RustStorage(error="worker_stopped: test")
+    monkeypatch.setattr(storage_client, "get_storage_client", lambda: storage)
+    expected = np.asarray([[0.25, 0.75]], dtype=np.float32)
+    monkeypatch.setattr(
+        fresh_embedder,
+        "_initialize_python_model",
+        lambda: setattr(fresh_embedder, "_model", object()),
+    )
+    monkeypatch.setattr(fresh_embedder, "_encode_python", lambda texts: expected)
+
+    result = fresh_embedder.encode(["fallback"])
+
+    assert result is expected
+    assert fresh_embedder._last_backend == "python"
+    assert storage.fallbacks == ["worker_stopped: test"]
+
+
+def test_foreground_priority_does_not_trigger_python_competition(fresh_embedder, monkeypatch):
+    storage = _RustStorage(error="foreground_busy: query active")
+    monkeypatch.setattr(storage_client, "get_storage_client", lambda: storage)
+    called = []
+    monkeypatch.setattr(fresh_embedder, "_encode_python", lambda texts: called.append(texts))
+
+    with pytest.raises(RuntimeError, match="foreground_busy"):
+        fresh_embedder.encode(["wait"])
+
+    assert called == []
+
+
+def test_background_batch_contention_does_not_trigger_python_competition(
+    fresh_embedder, monkeypatch
+):
+    storage = _RustStorage(error="background_busy: CLIP batch active")
+    monkeypatch.setattr(storage_client, "get_storage_client", lambda: storage)
+    called = []
+    monkeypatch.setattr(fresh_embedder, "_encode_python", lambda texts: called.append(texts))
+
+    with pytest.raises(RuntimeError, match="background_busy"):
+        fresh_embedder.encode(["wait"])
+
+    assert called == []
+
+
+def test_explicit_python_runtime_reports_the_serving_backend(fresh_embedder, monkeypatch):
+    storage = _RustStorage()
+    monkeypatch.setattr(storage_client, "get_storage_client", lambda: storage)
+    fresh_embedder._selected_runtime = "python"
+    fresh_embedder._initialized = True
+    expected = np.asarray([[0.5, 0.5]], dtype=np.float32)
+    monkeypatch.setattr(fresh_embedder, "_encode_python", lambda texts: expected)
+
+    result = fresh_embedder.encode(["python"])
+
+    assert result is expected
+    assert fresh_embedder._last_backend == "python"
+    assert storage.python_inferences == 1

--- a/monitor/tests/test_ocr_postprocess_queue.py
+++ b/monitor/tests/test_ocr_postprocess_queue.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 
 import monitor.config as config
@@ -40,6 +42,14 @@ class DummyClassifier:
         return "Development", 0.87654
 
 
+class YieldingClassifier:
+    def __init__(self, error):
+        self.error = error
+
+    def classify(self, **_kwargs):
+        raise RuntimeError(self.error)
+
+
 class DummyStorageClient:
     def __init__(self):
         self.updates = []
@@ -60,6 +70,24 @@ class DummyStorageClient:
 
     def update_screenshot_category(self, screenshot_id, category, category_confidence=None):
         self.updates.append((screenshot_id, category, category_confidence))
+        return True
+
+
+class LifecycleStorageClient(DummyStorageClient):
+    def __init__(self):
+        super().__init__()
+        self.postprocess_statuses = []
+        self.postprocess_retries = []
+        self.pending = threading.Event()
+
+    def set_ocr_postprocess_status(self, screenshot_id, status, error=None):
+        self.postprocess_statuses.append((screenshot_id, status, error))
+        if status == "pending":
+            self.pending.set()
+        return True
+
+    def record_ocr_postprocess_retry(self, screenshot_id, error):
+        self.postprocess_retries.append((screenshot_id, error))
         return True
 
 
@@ -104,6 +132,49 @@ def test_ocr_postprocess_updates_category_async_path(monkeypatch):
 
     assert classifier.calls == [("Editor", "async classification text", "code.exe")]
     assert storage.updates == [(42, "Development", 0.8765)]
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "foreground_busy: reranked query active",
+        "background_busy: CLIP batch active",
+    ],
+)
+def test_classification_scheduling_yield_returns_persistent_job_to_pending(
+    monkeypatch, reason
+):
+    storage = LifecycleStorageClient()
+    queue = OcrPostprocessQueue(
+        DummyOcrWorker(), YieldingClassifier(reason), maxsize=1
+    )
+    monkeypatch.setattr(config, "CLASSIFICATION_ENABLED", True)
+    monkeypatch.setattr("storage_client.get_storage_client", lambda: storage)
+
+    queue.start()
+    try:
+        assert queue.enqueue(
+            {
+                "screenshot_id": 43,
+                "window_title": "Editor",
+                "process_name": "code.exe",
+                "ocr_text": "deferred classification text",
+                "image_bytes": b"",
+                "_persistent_postprocess": True,
+            }
+        )
+        assert storage.pending.wait(timeout=2.0)
+    finally:
+        queue.stop()
+
+    assert storage.postprocess_statuses == [
+        (43, "processing", None),
+        (43, "pending", reason),
+    ]
+    assert storage.postprocess_retries == []
+    assert queue.processed == 0
+    assert queue.failed == 0
+    assert queue.deferred == 1
 
 
 def test_ocr_service_loads_python_engine_only_on_first_inference(monkeypatch):

--- a/monitor/tests/test_storage_client_contracts.py
+++ b/monitor/tests/test_storage_client_contracts.py
@@ -121,6 +121,47 @@ def test_storage_client_smart_cluster_reverse_ipc_payload_contract():
     ]
 
 
+def test_storage_client_bge_bridge_payload_and_retry_contract():
+    client = sc.StorageClient("test-pipe")
+    calls = []
+    responses = [
+        {"status": "success", "data": {"dimensions": 2, "vectors": [[0.0, 1.0]]}},
+        {"status": "success", "data": {"recorded": True}},
+        {"status": "success", "data": {"recorded": True}},
+    ]
+
+    def fake_send(request, timeout=sc.DEFAULT_REVERSE_IPC_TIMEOUT_SECS):
+        calls.append((request, timeout))
+        return responses.pop(0)
+
+    client._send_request = fake_send
+
+    assert client.embed_bge_texts(["alpha"]) == {
+        "dimensions": 2,
+        "vectors": [[0.0, 1.0]],
+    }
+    client.record_classification_python_fallback("worker_stopped: test")
+    client.record_classification_python_inference()
+
+    assert calls == [
+        ({"command": "bge_embed_texts", "texts": ["alpha"]}, 150),
+        (
+            {
+                "command": "classification_record_python_fallback",
+                "error": "worker_stopped: test",
+            },
+            sc.DEFAULT_REVERSE_IPC_TIMEOUT_SECS,
+        ),
+        (
+            {"command": "classification_record_python_inference"},
+            sc.DEFAULT_REVERSE_IPC_TIMEOUT_SECS,
+        ),
+    ]
+    assert "bge_embed_texts" in sc.READ_RETRY_COMMANDS
+    assert "classification_record_python_fallback" not in sc.SAFE_RETRY_AFTER_SEND_COMMANDS
+    assert "classification_record_python_inference" not in sc.SAFE_RETRY_AFTER_SEND_COMMANDS
+
+
 def test_the_retired_minilm_mirror_commands_are_not_retried_as_idempotent():
     """M2.5 step 5 removed the Python→Rust MiniLM mirror in both directions.
 

--- a/src-tauri/examples/bge_benchmark_export.rs
+++ b/src-tauri/examples/bge_benchmark_export.rs
@@ -1,0 +1,479 @@
+//! Read-only, local fixture exporter for the BGE migration benchmark.
+//!
+//! Plaintext is emitted only as one JSON document on stdout. Diagnostics use
+//! stderr so callers can keep stdout in an anonymous pipe and avoid writing
+//! decrypted screenshot data to disk.
+
+#[allow(dead_code)]
+#[path = "../src/credential_manager.rs"]
+mod credential_manager;
+#[allow(dead_code)]
+#[path = "../src/registry_config.rs"]
+mod registry_config;
+
+use credential_manager::{
+    decrypt_row_key_with_cng, decrypt_with_master_key, derive_db_key_from_public_key, CngKeySession,
+};
+use rusqlite::{params, Connection, OpenFlags};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+const DEFAULT_SAMPLE_SIZE: usize = 100;
+const DEFAULT_SEED: &str = "carbonpaper-bge-v1";
+const DEFAULT_MAX_OCR_CHARS: usize = 4096;
+
+#[derive(Debug)]
+struct Args {
+    data_dir: PathBuf,
+    sample_size: usize,
+    seed: String,
+    sample_ids: Option<Vec<i64>>,
+    max_ocr_chars: usize,
+}
+
+#[derive(Serialize)]
+struct ExportPayload {
+    schema_version: u32,
+    database: DatabaseSnapshot,
+    selection: SelectionMetadata,
+    corpus_sha256: String,
+    samples: Vec<BenchmarkSample>,
+}
+
+#[derive(Serialize)]
+struct DatabaseSnapshot {
+    size_bytes: u64,
+    modified_unix_ns: Option<u128>,
+}
+
+#[derive(Serialize)]
+struct SelectionMetadata {
+    seed: String,
+    requested_sample_size: usize,
+    eligible_rows: usize,
+    selected_ids: Vec<i64>,
+    skipped_rows: usize,
+    max_ocr_chars: usize,
+}
+
+#[derive(Serialize)]
+struct BenchmarkSample {
+    screenshot_id: i64,
+    window_title: String,
+    process_name: String,
+    ocr_text: String,
+}
+
+struct RawScreenshot {
+    window_title_plain: Option<String>,
+    process_name_plain: Option<String>,
+    window_title_enc: Option<Vec<u8>>,
+    process_name_enc: Option<Vec<u8>>,
+    content_key_enc: Option<Vec<u8>>,
+}
+
+fn usage() -> &'static str {
+    "Usage: cargo run --example bge_benchmark_export -- \
+        --data-dir PATH [--sample-size N] [--seed TEXT] \
+        [--sample-ids ID,ID,...] [--max-ocr-chars N]"
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut data_dir = None;
+    let mut sample_size = DEFAULT_SAMPLE_SIZE;
+    let mut seed = DEFAULT_SEED.to_string();
+    let mut sample_ids = None;
+    let mut max_ocr_chars = DEFAULT_MAX_OCR_CHARS;
+    let mut args = env::args().skip(1);
+
+    while let Some(arg) = args.next() {
+        let value = match arg.as_str() {
+            "--help" | "-h" => return Err(usage().to_string()),
+            "--data-dir" | "--sample-size" | "--seed" | "--sample-ids" | "--max-ocr-chars" => args
+                .next()
+                .ok_or_else(|| format!("missing value for {arg}"))?,
+            _ => return Err(format!("unknown argument: {arg}\n{}", usage())),
+        };
+        match arg.as_str() {
+            "--data-dir" => data_dir = Some(PathBuf::from(value)),
+            "--sample-size" => {
+                sample_size = value
+                    .parse::<usize>()
+                    .map_err(|_| "--sample-size must be a positive integer".to_string())?;
+            }
+            "--seed" => seed = value,
+            "--sample-ids" => sample_ids = Some(parse_sample_ids(&value)?),
+            "--max-ocr-chars" => {
+                max_ocr_chars = value
+                    .parse::<usize>()
+                    .map_err(|_| "--max-ocr-chars must be a positive integer".to_string())?;
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    if sample_size == 0 {
+        return Err("--sample-size must be greater than zero".to_string());
+    }
+    if max_ocr_chars < 200 {
+        return Err("--max-ocr-chars must be at least 200".to_string());
+    }
+    let data_dir = data_dir.ok_or_else(|| format!("--data-dir is required\n{}", usage()))?;
+    Ok(Args {
+        data_dir,
+        sample_size,
+        seed,
+        sample_ids,
+        max_ocr_chars,
+    })
+}
+
+fn parse_sample_ids(raw: &str) -> Result<Vec<i64>, String> {
+    let mut seen = HashSet::new();
+    let mut ids = Vec::new();
+    for value in raw
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let id = value
+            .parse::<i64>()
+            .map_err(|_| format!("invalid screenshot id: {value}"))?;
+        if id <= 0 {
+            return Err(format!("screenshot ids must be positive: {id}"));
+        }
+        if seen.insert(id) {
+            ids.push(id);
+        }
+    }
+    if ids.is_empty() {
+        return Err("--sample-ids did not contain any ids".to_string());
+    }
+    Ok(ids)
+}
+
+fn open_database(data_dir: &Path) -> Result<(Connection, DatabaseSnapshot), Box<dyn Error>> {
+    let db_path = data_dir.join("screenshots.db");
+    let public_key_path = data_dir.join("credential_public_key.bin");
+    if !db_path.is_file() {
+        return Err(format!("database does not exist: {}", db_path.display()).into());
+    }
+    if !public_key_path.is_file() {
+        return Err(format!("public key does not exist: {}", public_key_path.display()).into());
+    }
+
+    let public_key = fs::read(&public_key_path)?;
+    let db_key = derive_db_key_from_public_key(&public_key);
+    let conn = Connection::open_with_flags(
+        &db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    conn.execute_batch(&format!("PRAGMA key = \"x'{}'\";", hex::encode(db_key)))?;
+    conn.execute_batch("SELECT count(*) FROM sqlite_master; PRAGMA query_only = ON; BEGIN;")?;
+
+    let metadata = fs::metadata(db_path)?;
+    let modified_unix_ns = metadata
+        .modified()
+        .ok()
+        .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+        .map(|value| value.as_nanos());
+    Ok((
+        conn,
+        DatabaseSnapshot {
+            size_bytes: metadata.len(),
+            modified_unix_ns,
+        },
+    ))
+}
+
+fn stable_score(seed: &str, screenshot_id: i64) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"CarbonPaper-BGE-benchmark-sample-v1\0");
+    hasher.update(seed.as_bytes());
+    hasher.update([0]);
+    hasher.update(screenshot_id.to_le_bytes());
+    hasher.finalize().into()
+}
+
+fn select_candidate_ids(
+    conn: &Connection,
+    seed: &str,
+    sample_size: usize,
+    explicit_ids: Option<&[i64]>,
+) -> Result<(Vec<i64>, usize), Box<dyn Error>> {
+    if let Some(ids) = explicit_ids {
+        return Ok((ids.to_vec(), ids.len()));
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT s.id FROM screenshots s \
+         WHERE s.is_deleted = 0 AND (\
+             s.window_title_enc IS NOT NULL OR length(COALESCE(s.window_title, '')) > 0 OR \
+             EXISTS (SELECT 1 FROM ocr_results r \
+                     WHERE r.screenshot_id = s.id AND r.is_deleted = 0)\
+         ) ORDER BY s.id ASC",
+    )?;
+    let mut ranked = stmt
+        .query_map([], |row| row.get::<_, i64>(0))?
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .map(|id| (stable_score(seed, id), id))
+        .collect::<Vec<_>>();
+    let eligible_rows = ranked.len();
+    ranked.sort_unstable_by(|left, right| left.0.cmp(&right.0).then(left.1.cmp(&right.1)));
+
+    // Decryption failures and empty legacy rows should not shrink a normal run.
+    // Keep a deterministic reserve while avoiding unnecessary sensitive reads.
+    let reserve = sample_size.saturating_mul(8).max(sample_size);
+    ranked.truncate(reserve.min(ranked.len()));
+    Ok((
+        ranked.into_iter().map(|(_, id)| id).collect(),
+        eligible_rows,
+    ))
+}
+
+fn load_raw_screenshot(
+    conn: &Connection,
+    screenshot_id: i64,
+) -> Result<Option<RawScreenshot>, Box<dyn Error>> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT window_title, process_name, window_title_enc, process_name_enc, \
+                content_key_encrypted \
+         FROM screenshots WHERE id = ?1 AND is_deleted = 0",
+    )?;
+    let mut rows = stmt.query(params![screenshot_id])?;
+    let Some(row) = rows.next()? else {
+        return Ok(None);
+    };
+    Ok(Some(RawScreenshot {
+        window_title_plain: row.get(0)?,
+        process_name_plain: row.get(1)?,
+        window_title_enc: row.get(2)?,
+        process_name_enc: row.get(3)?,
+        content_key_enc: row.get(4)?,
+    }))
+}
+
+fn first_encrypted_key(
+    conn: &Connection,
+    candidate_ids: &[i64],
+) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
+    for screenshot_id in candidate_ids {
+        if let Some(raw) = load_raw_screenshot(conn, *screenshot_id)? {
+            if let Some(key) = raw.content_key_enc {
+                return Ok(Some(key));
+            }
+        }
+        let key = conn
+            .query_row(
+                "SELECT text_key_encrypted FROM ocr_results \
+                 WHERE screenshot_id = ?1 AND is_deleted = 0 \
+                   AND text_key_encrypted IS NOT NULL ORDER BY id ASC LIMIT 1",
+                params![screenshot_id],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .ok();
+        if key.is_some() {
+            return Ok(key);
+        }
+    }
+    Ok(None)
+}
+
+fn decrypt_optional_text(
+    encrypted: Option<&[u8]>,
+    plaintext: Option<String>,
+    row_key: Option<&[u8]>,
+) -> Option<String> {
+    match (encrypted, row_key) {
+        (Some(data), Some(key)) => decrypt_with_master_key(key, data)
+            .ok()
+            .and_then(|value| String::from_utf8(value).ok()),
+        _ => plaintext,
+    }
+}
+
+fn load_ocr_text(
+    conn: &Connection,
+    cng: &CngKeySession,
+    screenshot_id: i64,
+    max_chars: usize,
+) -> Result<String, Box<dyn Error>> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT text, text_enc, text_key_encrypted FROM ocr_results \
+         WHERE screenshot_id = ?1 AND is_deleted = 0 ORDER BY id ASC",
+    )?;
+    let mut rows = stmt.query(params![screenshot_id])?;
+    let mut parts = Vec::new();
+    let mut char_count = 0usize;
+    while let Some(row) = rows.next()? {
+        let plain: Option<String> = row.get(0)?;
+        let encrypted: Option<Vec<u8>> = row.get(1)?;
+        let encrypted_key: Option<Vec<u8>> = row.get(2)?;
+        let text = match (encrypted.as_deref(), encrypted_key.as_deref()) {
+            (Some(data), Some(key_data)) => {
+                cng.unwrap_row_key(key_data).ok().and_then(|mut row_key| {
+                    let value = decrypt_with_master_key(&row_key, data)
+                        .ok()
+                        .and_then(|bytes| String::from_utf8(bytes).ok());
+                    row_key.fill(0);
+                    value
+                })
+            }
+            _ => plain,
+        };
+        let Some(text) = text.filter(|value| !value.trim().is_empty()) else {
+            continue;
+        };
+        char_count =
+            char_count.saturating_add(text.chars().count() + usize::from(!parts.is_empty()));
+        parts.push(text);
+        if char_count >= max_chars {
+            break;
+        }
+    }
+    Ok(parts.join(" ").chars().take(max_chars).collect())
+}
+
+fn load_sample(
+    conn: &Connection,
+    cng: &CngKeySession,
+    screenshot_id: i64,
+    max_ocr_chars: usize,
+) -> Result<Option<BenchmarkSample>, Box<dyn Error>> {
+    let Some(raw) = load_raw_screenshot(conn, screenshot_id)? else {
+        return Ok(None);
+    };
+    let mut screenshot_key = raw
+        .content_key_enc
+        .as_deref()
+        .and_then(|encrypted| cng.unwrap_row_key(encrypted).ok());
+    let window_title = decrypt_optional_text(
+        raw.window_title_enc.as_deref(),
+        raw.window_title_plain,
+        screenshot_key.as_deref(),
+    )
+    .unwrap_or_default();
+    let process_name = decrypt_optional_text(
+        raw.process_name_enc.as_deref(),
+        raw.process_name_plain,
+        screenshot_key.as_deref(),
+    )
+    .unwrap_or_default();
+    if let Some(key) = screenshot_key.as_mut() {
+        key.fill(0);
+    }
+    let ocr_text = load_ocr_text(conn, cng, screenshot_id, max_ocr_chars)?;
+
+    if window_title.trim().is_empty() && ocr_text.trim().is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(BenchmarkSample {
+        screenshot_id,
+        window_title,
+        process_name,
+        ocr_text,
+    }))
+}
+
+fn corpus_sha256(samples: &[BenchmarkSample]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"CarbonPaper-BGE-benchmark-corpus-v1\0");
+    for sample in samples {
+        hasher.update(sample.screenshot_id.to_le_bytes());
+        for value in [&sample.window_title, &sample.process_name, &sample.ocr_text] {
+            hasher.update((value.len() as u64).to_le_bytes());
+            hasher.update(value.as_bytes());
+        }
+    }
+    hex::encode(hasher.finalize())
+}
+
+fn run(args: Args) -> Result<(), Box<dyn Error>> {
+    let (conn, database) = open_database(&args.data_dir)?;
+    let (candidate_ids, eligible_rows) = select_candidate_ids(
+        &conn,
+        &args.seed,
+        args.sample_size,
+        args.sample_ids.as_deref(),
+    )?;
+    if candidate_ids.is_empty() {
+        return Err("no eligible screenshots were found".into());
+    }
+
+    if let Some(encrypted_key) = first_encrypted_key(&conn, &candidate_ids)? {
+        eprintln!("Authenticating with Windows CNG for local benchmark decryption...");
+        let mut row_key = decrypt_row_key_with_cng(&encrypted_key)?;
+        row_key.fill(0);
+    }
+    let cng = CngKeySession::open_silent()?;
+
+    let wanted = args
+        .sample_ids
+        .as_ref()
+        .map(Vec::len)
+        .unwrap_or(args.sample_size);
+    let mut samples = Vec::with_capacity(wanted);
+    let mut skipped_rows = 0usize;
+    for screenshot_id in candidate_ids {
+        match load_sample(&conn, &cng, screenshot_id, args.max_ocr_chars) {
+            Ok(Some(sample)) => samples.push(sample),
+            Ok(None) => skipped_rows += 1,
+            Err(error) => {
+                skipped_rows += 1;
+                eprintln!("Skipping screenshot id {screenshot_id}: {error}");
+            }
+        }
+        if samples.len() >= wanted {
+            break;
+        }
+    }
+    if samples.is_empty() {
+        return Err("selected rows could not be decrypted into benchmark inputs".into());
+    }
+    if samples.len() < wanted {
+        eprintln!(
+            "Warning: requested {wanted} samples but only {} were usable",
+            samples.len()
+        );
+    }
+
+    let selected_ids = samples.iter().map(|sample| sample.screenshot_id).collect();
+    let payload = ExportPayload {
+        schema_version: 1,
+        database,
+        selection: SelectionMetadata {
+            seed: args.seed,
+            requested_sample_size: wanted,
+            eligible_rows,
+            selected_ids,
+            skipped_rows,
+            max_ocr_chars: args.max_ocr_chars,
+        },
+        corpus_sha256: corpus_sha256(&samples),
+        samples,
+    };
+    let stdout = io::stdout();
+    let mut writer = stdout.lock();
+    serde_json::to_writer(&mut writer, &payload)?;
+    writer.write_all(b"\n")?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn main() {
+    match parse_args().and_then(|args| run(args).map_err(|error| error.to_string())) {
+        Ok(()) => {}
+        Err(error) => {
+            eprintln!("BGE benchmark export failed: {error}");
+            std::process::exit(2);
+        }
+    }
+}

--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -1660,10 +1660,10 @@ async fn process_ocr_async(
     let in_flight_after_inc = capture_state.in_flight_ocr_count.load(Ordering::SeqCst);
 
     let task_started = std::time::Instant::now();
-    let route = OcrRouteConfig::from_registry();
+    let route = OcrRouteConfig::from_app(app);
     let initial_engine = "rust";
-    let initial_provider = if route.use_directml_beta {
-        "directml_beta"
+    let initial_provider = if route.use_directml {
+        "directml"
     } else {
         "cpu"
     };
@@ -1770,14 +1770,14 @@ async fn process_ocr_async(
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct OcrRouteConfig {
-    pub(crate) use_directml_beta: bool,
+    pub(crate) use_directml: bool,
 }
 
 impl OcrRouteConfig {
-    pub(crate) fn from_registry() -> Self {
+    pub(crate) fn from_app(app: &tauri::AppHandle) -> Self {
+        let configured = crate::registry_config::get_bool("use_dml").unwrap_or(false);
         Self {
-            use_directml_beta: crate::registry_config::get_bool("rust_ocr_dml_beta")
-                .unwrap_or(false),
+            use_directml: app.state::<MonitorState>().allows_directml(configured),
         }
     }
 }
@@ -1794,11 +1794,15 @@ pub(crate) async fn process_ocr_inner(
     timeout_secs: u32,
     route: OcrRouteConfig,
 ) -> Result<(), String> {
-    let use_directml_beta = route.use_directml_beta;
+    // Re-check suppression at the request boundary in case game mode changed
+    // after the capture task read its initial route.
+    let use_directml = app
+        .state::<MonitorState>()
+        .allows_directml(route.use_directml);
     tracing::info!(
-        "[ML:ROUTER] Raw RGB Rust OCR selected screenshot_id={} dml_beta={} dimensions={}x{} bytes={} timeout_secs={}",
+        "[ML:ROUTER] Raw RGB Rust OCR selected screenshot_id={} directml={} dimensions={}x{} bytes={} timeout_secs={}",
         screenshot_id,
-        use_directml_beta,
+        use_directml,
         rgb_image.width(),
         rgb_image.height(),
         rgb_image.as_raw().len(),
@@ -1813,7 +1817,7 @@ pub(crate) async fn process_ocr_inner(
             app.clone(),
             rgb_image,
             std::time::Duration::from_secs(timeout_secs as u64),
-            use_directml_beta,
+            use_directml,
         )
         .await?;
     let ocr_results = convert_ml_ocr_blocks(output.blocks)?;
@@ -1831,11 +1835,7 @@ pub(crate) async fn process_ocr_inner(
         "completed",
         Some("rust"),
         Some("ppocrv5-ch-mobile"),
-        Some(if use_directml_beta {
-            "directml_beta"
-        } else {
-            "cpu"
-        }),
+        Some(if use_directml { "directml" } else { "cpu" }),
         None,
         Some(output.timings.request_total_ms),
     ) {

--- a/src-tauri/src/classification_runtime.rs
+++ b/src-tauri/src/classification_runtime.rs
@@ -1,0 +1,443 @@
+//! BGE classification inference routing and its observable fallback diagnostic.
+//!
+//! Classification orchestration and learned anchors remain in the Python
+//! post-process worker for now. The expensive text embedding call is served by
+//! the shared Rust semantic worker by default, over authenticated reverse IPC.
+
+use crate::ml_protocol::{
+    MlSemanticModel, MAX_SEMANTIC_BATCH, MAX_SEMANTIC_TEXT_BYTES, MAX_SEMANTIC_TEXT_ITEM_BYTES,
+};
+use crate::semantic_runtime::SemanticRuntimeState;
+use serde::Serialize;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Manager};
+
+const DEFAULT_RUNTIME: &str = "rust";
+const EMBED_TIMEOUT: Duration = Duration::from_secs(120);
+const FOREGROUND_WAIT_BUDGET: Duration = Duration::from_secs(15);
+const BACKGROUND_BATCH_WAIT_BUDGET: Duration = Duration::from_secs(15);
+const MAX_TEXTS_PER_REQUEST: usize = 512;
+
+#[derive(Debug, Clone, Default)]
+struct ClassificationDiagnosticInner {
+    last_backend: Option<String>,
+    last_error: Option<String>,
+    fallback_count: u64,
+    success_count: u64,
+    last_elapsed_ms: Option<f64>,
+}
+
+impl ClassificationDiagnosticInner {
+    fn record_rust_success(&mut self, elapsed_ms: f64) {
+        self.last_backend = Some("rust".to_string());
+        self.last_error = None;
+        self.success_count = self.success_count.saturating_add(1);
+        self.last_elapsed_ms = Some(elapsed_ms);
+    }
+
+    fn record_rust_failure(&mut self, error: &str, elapsed_ms: f64) {
+        self.last_error = Some(truncate_error(error));
+        self.last_elapsed_ms = Some(elapsed_ms);
+    }
+
+    fn record_python_fallback(&mut self, error: &str) {
+        self.last_backend = Some("python".to_string());
+        self.last_error = Some(truncate_error(error));
+        self.fallback_count = self.fallback_count.saturating_add(1);
+    }
+
+    fn record_python_inference(&mut self) {
+        self.last_backend = Some("python".to_string());
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ClassificationBackendStatus {
+    pub selected_runtime: String,
+    pub active_runtime: Option<String>,
+    pub last_backend: Option<String>,
+    pub last_error: Option<String>,
+    pub fallback_count: u64,
+    pub success_count: u64,
+    pub last_elapsed_ms: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BgeEmbeddingResponse {
+    pub backend: &'static str,
+    pub model_id: &'static str,
+    pub dimensions: usize,
+    pub vectors: Vec<Vec<f32>>,
+    pub elapsed_ms: f64,
+}
+
+static DIAGNOSTIC: OnceLock<Mutex<ClassificationDiagnosticInner>> = OnceLock::new();
+
+fn diagnostic() -> &'static Mutex<ClassificationDiagnosticInner> {
+    DIAGNOSTIC.get_or_init(|| Mutex::new(ClassificationDiagnosticInner::default()))
+}
+
+pub fn classification_runtime() -> String {
+    let configured = crate::registry_config::get_string("classification_runtime")
+        .unwrap_or_else(|| DEFAULT_RUNTIME.to_string());
+    if is_selectable_classification_runtime(&configured) {
+        configured
+    } else {
+        DEFAULT_RUNTIME.to_string()
+    }
+}
+
+pub fn is_selectable_classification_runtime(value: &str) -> bool {
+    matches!(value, "rust" | "python")
+}
+
+pub fn backend_status(active_runtime: Option<String>) -> ClassificationBackendStatus {
+    let selected_runtime = classification_runtime();
+    let inner = diagnostic()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    ClassificationBackendStatus {
+        last_backend: inner.last_backend.clone(),
+        selected_runtime,
+        active_runtime,
+        last_error: inner.last_error.clone(),
+        fallback_count: inner.fallback_count,
+        success_count: inner.success_count,
+        last_elapsed_ms: inner.last_elapsed_ms,
+    }
+}
+
+fn record_rust_success(elapsed_ms: f64) {
+    let mut inner = diagnostic()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    inner.record_rust_success(elapsed_ms);
+}
+
+fn record_rust_failure(error: &str, elapsed_ms: f64) {
+    let mut inner = diagnostic()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    inner.record_rust_failure(error, elapsed_ms);
+}
+
+pub fn record_python_fallback(error: &str) {
+    let mut inner = diagnostic()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    inner.record_python_fallback(error);
+}
+
+pub fn record_python_inference() {
+    let mut inner = diagnostic()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    inner.record_python_inference();
+}
+
+fn truncate_error(error: &str) -> String {
+    const MAX_CHARS: usize = 512;
+    error.chars().take(MAX_CHARS).collect()
+}
+
+fn directml_preference(configured: bool, game_mode_suppressed: bool) -> bool {
+    configured && !game_mode_suppressed
+}
+
+/// Read the effective provider preference at each classification chunk.
+///
+/// Game mode can change while a large BGE request is being drained. Reading
+/// only the registry value once would let later chunks keep using a DirectML
+/// semantic worker after the monitor has suppressed GPU inference.
+fn current_directml_preference(app: &AppHandle) -> bool {
+    let monitor = app.state::<crate::monitor::MonitorState>();
+    directml_preference(
+        crate::registry_config::get_bool("use_dml").unwrap_or(false),
+        monitor.is_dml_suppressed(),
+    )
+}
+
+fn validate_texts(texts: &[String]) -> Result<(), String> {
+    if texts.is_empty() {
+        return Err("invalid_request: BGE text list is empty".to_string());
+    }
+    if texts.len() > MAX_TEXTS_PER_REQUEST {
+        return Err(format!(
+            "invalid_request: BGE text list exceeds {MAX_TEXTS_PER_REQUEST} items"
+        ));
+    }
+    let total_bytes = texts.iter().try_fold(0usize, |total, text| {
+        let item_bytes = text.len();
+        if item_bytes > MAX_SEMANTIC_TEXT_ITEM_BYTES {
+            return Err(format!(
+                "limit_exceeded: BGE text item exceeds limit: {item_bytes} > {MAX_SEMANTIC_TEXT_ITEM_BYTES} bytes"
+            ));
+        }
+        total
+            .checked_add(item_bytes)
+            .ok_or_else(|| "invalid_request: BGE text length overflow".to_string())
+    })?;
+    if total_bytes > MAX_SEMANTIC_TEXT_BYTES {
+        return Err(format!(
+            "limit_exceeded: BGE text payload exceeds {MAX_SEMANTIC_TEXT_BYTES} bytes"
+        ));
+    }
+    Ok(())
+}
+
+async fn wait_for_foreground(
+    state: &Arc<SemanticRuntimeState>,
+    deadline: Instant,
+) -> Result<(), String> {
+    let started = Instant::now();
+    while state.foreground_waiting() {
+        if started.elapsed() >= FOREGROUND_WAIT_BUDGET {
+            return Err(
+                "foreground_busy: BGE classification stood aside for a foreground query"
+                    .to_string(),
+            );
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(
+                "foreground_busy: BGE classification deadline expired while standing aside for a foreground query"
+                    .to_string(),
+            );
+        }
+        tokio::time::sleep(std::cmp::min(
+            crate::semantic_runtime::FOREGROUND_POLL_INTERVAL,
+            remaining,
+        ))
+        .await;
+    }
+    Ok(())
+}
+
+fn semantic_text_chunks(texts: &[String]) -> std::slice::Chunks<'_, String> {
+    texts.chunks(MAX_SEMANTIC_BATCH)
+}
+
+async fn acquire_background_batch_slot<'a>(
+    gate: &'a tokio::sync::Mutex<()>,
+    deadline: Instant,
+) -> Result<tokio::sync::MutexGuard<'a, ()>, String> {
+    tokio::time::timeout_at(tokio::time::Instant::from_std(deadline), gate.lock())
+        .await
+        .map_err(|_| {
+            "background_busy: BGE classification stood aside for another background model batch"
+                .to_string()
+        })
+}
+
+// Keep one deadline across all protocol-sized requests. A fresh timeout per
+// chunk would multiply the bridge's 120-second budget by the number of chunks.
+async fn embed_bge_chunks(
+    app: &AppHandle,
+    state: &Arc<SemanticRuntimeState>,
+    texts: &[String],
+    deadline: Instant,
+) -> Result<(usize, Vec<Vec<f32>>), String> {
+    let mut dimensions = None;
+    let mut vectors = Vec::with_capacity(texts.len());
+
+    for (chunk_index, chunk) in semantic_text_chunks(texts).enumerate() {
+        wait_for_foreground(state, deadline).await?;
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err("timeout: BGE classification deadline expired".to_string());
+        }
+
+        let prefer_directml = current_directml_preference(app);
+        let result = state
+            .embed_text(
+                app.clone(),
+                MlSemanticModel::BgeSmallZh,
+                chunk.to_vec(),
+                remaining,
+                prefer_directml,
+            )
+            .await
+            .map_err(|error| {
+                if state.foreground_waiting() {
+                    format!(
+                        "foreground_busy: BGE classification yielded after a foreground query arrived: {error}"
+                    )
+                } else {
+                    error
+                }
+            })?;
+
+        if result.vectors.len() != chunk.len() {
+            return Err(format!(
+                "protocol: BGE response contains {} vectors for {} texts in chunk {}",
+                result.vectors.len(),
+                chunk.len(),
+                chunk_index + 1
+            ));
+        }
+        if result
+            .vectors
+            .iter()
+            .any(|vector| vector.len() != result.dimensions)
+        {
+            return Err(format!(
+                "protocol: BGE response contains a mismatched vector dimension in chunk {}",
+                chunk_index + 1
+            ));
+        }
+        if let Some(expected_dimensions) = dimensions {
+            if expected_dimensions != result.dimensions {
+                return Err(format!(
+                    "protocol: BGE response dimension changed between chunks: expected {}, got {}",
+                    expected_dimensions, result.dimensions
+                ));
+            }
+        } else {
+            dimensions = Some(result.dimensions);
+        }
+        vectors.extend(result.vectors);
+    }
+
+    let dimensions = dimensions.ok_or_else(|| {
+        "protocol: BGE response did not contain any vector dimensions".to_string()
+    })?;
+    if vectors.len() != texts.len() {
+        return Err(format!(
+            "protocol: BGE response contains {} vectors for {} texts",
+            vectors.len(),
+            texts.len()
+        ));
+    }
+    Ok((dimensions, vectors))
+}
+
+pub async fn embed_bge_texts(
+    app: AppHandle,
+    texts: Vec<String>,
+) -> Result<BgeEmbeddingResponse, String> {
+    validate_texts(&texts)?;
+    let active_runtime = app
+        .state::<crate::monitor::MonitorState>()
+        .active_classification_runtime();
+    if active_runtime.as_deref() != Some("rust") {
+        return Err(format!(
+            "runtime_disabled: active classification runtime is {}",
+            active_runtime.as_deref().unwrap_or("stopped")
+        ));
+    }
+
+    let started = Instant::now();
+    let deadline = started + EMBED_TIMEOUT;
+    let state = app.state::<Arc<SemanticRuntimeState>>().inner().clone();
+    let result = async {
+        // Do not claim the background scheduler while a foreground query is
+        // already active. Re-checking inside `embed_bge_chunks` closes the race
+        // between this observation, lock acquisition, and every later chunk.
+        wait_for_foreground(&state, deadline).await?;
+        let slot_deadline = std::cmp::min(deadline, Instant::now() + BACKGROUND_BATCH_WAIT_BUDGET);
+        let _background_batch = acquire_background_batch_slot(
+            &crate::semantic_runtime::BACKGROUND_PASS_GUARD,
+            slot_deadline,
+        )
+        .await?;
+        embed_bge_chunks(&app, &state, &texts, deadline).await
+    }
+    .await;
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+    match result {
+        Ok((dimensions, vectors)) => {
+            record_rust_success(elapsed_ms);
+            Ok(BgeEmbeddingResponse {
+                backend: "rust",
+                model_id: "bge-small-zh-v1.5",
+                dimensions,
+                vectors,
+                elapsed_ms,
+            })
+        }
+        Err(error) => {
+            record_rust_failure(&error, elapsed_ms);
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_live_classification_runtimes_are_selectable() {
+        assert!(is_selectable_classification_runtime("rust"));
+        assert!(is_selectable_classification_runtime("python"));
+        assert!(!is_selectable_classification_runtime("rust_shadow"));
+        assert!(!is_selectable_classification_runtime("chroma"));
+    }
+
+    #[test]
+    fn directml_preference_yields_to_game_mode_suppression() {
+        assert!(!directml_preference(false, false));
+        assert!(directml_preference(true, false));
+        assert!(!directml_preference(true, true));
+    }
+
+    #[test]
+    fn embedding_request_limits_bound_reverse_ipc_work() {
+        assert!(validate_texts(&["text".to_string()]).is_ok());
+        assert!(validate_texts(&[]).is_err());
+        assert!(validate_texts(&vec![String::new(); MAX_TEXTS_PER_REQUEST]).is_ok());
+        assert!(validate_texts(&vec![String::new(); MAX_TEXTS_PER_REQUEST + 1]).is_err());
+        assert!(validate_texts(&["x".repeat(MAX_SEMANTIC_TEXT_ITEM_BYTES + 1)]).is_err());
+        let multibyte_payload = vec!["中".repeat(1_000); 100];
+        let error = validate_texts(&multibyte_payload).unwrap_err();
+        assert!(error.contains("payload"), "{error}");
+    }
+
+    #[test]
+    fn production_batches_stay_within_the_semantic_worker_limit() {
+        let texts = vec!["anchor".to_string(); MAX_SEMANTIC_BATCH * 6 + 11];
+        let sizes: Vec<usize> = semantic_text_chunks(&texts)
+            .map(|chunk| chunk.len())
+            .collect();
+
+        let mut expected = vec![MAX_SEMANTIC_BATCH; 6];
+        expected.push(11);
+        assert_eq!(sizes, expected);
+        assert!(sizes.iter().all(|size| *size <= MAX_SEMANTIC_BATCH));
+    }
+
+    #[test]
+    fn rust_failures_only_count_after_python_serves_the_fallback() {
+        let mut diagnostic = ClassificationDiagnosticInner::default();
+        diagnostic.record_rust_failure("worker_stopped: test", 12.0);
+
+        assert_eq!(diagnostic.fallback_count, 0);
+
+        diagnostic.record_python_fallback("worker_stopped: test");
+
+        assert_eq!(diagnostic.fallback_count, 1);
+        assert_eq!(diagnostic.last_backend.as_deref(), Some("python"));
+    }
+
+    #[tokio::test]
+    async fn classification_batch_does_not_bypass_a_busy_background_slot() {
+        let gate = tokio::sync::Mutex::new(());
+        let held = gate.lock().await;
+        let result =
+            acquire_background_batch_slot(&gate, Instant::now() + Duration::from_millis(25)).await;
+
+        let error = match result {
+            Ok(_) => panic!("classification unexpectedly acquired the occupied batch slot"),
+            Err(error) => error,
+        };
+        assert!(error.starts_with("background_busy:"));
+        drop(held);
+        assert!(
+            acquire_background_batch_slot(&gate, Instant::now() + Duration::from_millis(25),)
+                .await
+                .is_ok()
+        );
+    }
+}

--- a/src-tauri/src/commands/utility.rs
+++ b/src-tauri/src/commands/utility.rs
@@ -169,6 +169,11 @@ const BACKEND_SELECTIONS: &[BackendSelection] = &[
         read: crate::clip_query::clip_index_backend,
         accepts: crate::clip_query::is_selectable_clip_index,
     },
+    BackendSelection {
+        key: "classification_runtime",
+        read: crate::classification_runtime::classification_runtime,
+        accepts: crate::classification_runtime::is_selectable_classification_runtime,
+    },
 ];
 
 /// Returns advanced runtime configuration as a JSON object.
@@ -180,7 +185,6 @@ pub fn get_advanced_config() -> Result<serde_json::Value, String> {
     let cpu_limit_enabled = registry_config::get_bool("cpu_limit_enabled").unwrap_or(true);
     let cpu_limit_percent = registry_config::get_u32("cpu_limit_percent").unwrap_or(10);
     let ocr_timeout_secs = registry_config::get_u32("ocr_timeout_secs").unwrap_or(120);
-    let rust_ocr_dml_beta = registry_config::get_bool("rust_ocr_dml_beta").unwrap_or(false);
     let use_dml = registry_config::get_bool("use_dml").unwrap_or(false);
     let dml_device_id = registry_config::get_u32("dml_device_id").unwrap_or(0);
     let game_mode_enabled = registry_config::get_bool("game_mode_enabled").unwrap_or(true);
@@ -199,7 +203,6 @@ pub fn get_advanced_config() -> Result<serde_json::Value, String> {
         "cpu_limit_enabled": cpu_limit_enabled,
         "cpu_limit_percent": cpu_limit_percent,
         "ocr_timeout_secs": ocr_timeout_secs,
-        "rust_ocr_dml_beta": rust_ocr_dml_beta,
         "use_dml": use_dml,
         "dml_device_id": dml_device_id,
         "game_mode_enabled": game_mode_enabled,
@@ -246,12 +249,6 @@ pub fn set_advanced_config(
     if let Some(v) = config.get("ocr_timeout_secs").and_then(|v| v.as_u64()) {
         let clamped = (v as u32).clamp(30, 600);
         registry_config::set_u32("ocr_timeout_secs", clamped)?;
-    }
-    if let Some(v) = config.get("rust_ocr_dml_beta").and_then(|v| v.as_bool()) {
-        // Temporary migration setting. It intentionally does not mirror the
-        // existing Python DML preference and will be removed when the Rust
-        // runtime adopts the unified application DML configuration.
-        registry_config::set_bool("rust_ocr_dml_beta", v)?;
     }
     if let Some(v) = config.get("use_dml").and_then(|v| v.as_bool()) {
         registry_config::set_bool("use_dml", v)?;
@@ -437,6 +434,48 @@ pub fn set_extension_enhancement(
 ) -> Result<(), String> {
     crate::commands::check_auth_required(&credential_state)?;
     registry_config::set_bool("extension_enhanced_global", enabled)
+}
+
+/// One-time migration for the retired Rust OCR DirectML toggle.
+///
+/// The beta toggle was a separate preference while the Rust OCR worker was
+/// being brought online. Its value is carried into `use_dml` only when the
+/// unified preference has never been written; an explicit existing value wins.
+/// The old registry value is removed after a successful migration so it cannot
+/// reappear as a second source of truth.
+pub fn migrate_dml_config() {
+    const LEGACY_KEY: &str = "rust_ocr_dml_beta";
+    let Some(legacy) = registry_config::get_bool(LEGACY_KEY) else {
+        return;
+    };
+
+    let current = registry_config::get_bool("use_dml");
+    if current.is_none() {
+        if let Err(error) =
+            registry_config::set_bool("use_dml", migrated_dml_value(current, legacy))
+        {
+            tracing::warn!(
+                "Failed to migrate legacy Rust OCR DirectML preference: {}",
+                error
+            );
+            return;
+        }
+    }
+
+    match registry_config::delete_value(LEGACY_KEY) {
+        Ok(()) => tracing::info!(
+            "Migrated legacy Rust OCR DirectML preference into use_dml (legacy={})",
+            legacy
+        ),
+        Err(error) => tracing::warn!(
+            "Migrated use_dml but could not remove legacy Rust OCR DirectML preference: {}",
+            error
+        ),
+    }
+}
+
+fn migrated_dml_value(current: Option<bool>, legacy: bool) -> bool {
+    current.unwrap_or(legacy)
 }
 
 /// One-time migration: the per-browser enhancement toggles
@@ -687,7 +726,15 @@ pub fn open_path(
 
 #[cfg(test)]
 mod tests {
-    use super::{migrated_enhancement_value, BACKEND_SELECTIONS};
+    use super::{migrated_dml_value, migrated_enhancement_value, BACKEND_SELECTIONS};
+
+    #[test]
+    fn dml_migration_preserves_an_explicit_unified_preference() {
+        assert!(migrated_dml_value(None, true));
+        assert!(!migrated_dml_value(None, false));
+        assert!(migrated_dml_value(Some(true), false));
+        assert!(!migrated_dml_value(Some(false), true));
+    }
 
     #[test]
     fn test_migrated_enhancement_value() {
@@ -709,6 +756,7 @@ mod tests {
             "semantic_index",
             "clip_runtime",
             "clip_index",
+            "classification_runtime",
         ] {
             assert!(
                 BACKEND_SELECTIONS

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@
 mod analysis;
 mod autostart;
 mod capture;
+mod classification_runtime;
 mod clip_index;
 mod clip_migration;
 mod clip_query;
@@ -1025,6 +1026,10 @@ pub fn run() {
                 } else {
                     tracing::error!("Storage initialization deferred: public key unavailable");
                 }
+
+                // Apply preference migrations before any monitor can spawn a
+                // worker that reads the unified DirectML setting.
+                commands::utility::migrate_dml_config();
 
                 if registry_config::get_bool("game_mode_enabled").unwrap_or(false) {
                     tracing::info!("Restoring game mode monitor on startup");

--- a/src-tauri/src/ml_runtime.rs
+++ b/src-tauri/src/ml_runtime.rs
@@ -218,25 +218,32 @@ impl MlRuntimeState {
         app: AppHandle,
         image: Arc<RgbImage>,
         timeout: Duration,
-        use_directml_beta: bool,
+        use_directml: bool,
     ) -> Result<MlOcrResult, String> {
         // The worker protocol is single-request. Holding this gate across
         // provider selection, startup and the response prevents a concurrent
         // provider switch from killing an in-flight request.
         let _request_guard = self.request_gate.lock().await;
+        // A capture task may outlive the game-mode transition that created it.
+        // Clamp the route again here so a stale task cannot start or retain a
+        // DirectML worker after suppression becomes active.
+        let use_directml = use_directml
+            && app
+                .state::<crate::monitor::MonitorState>()
+                .allows_directml(true);
         let directml_disabled = self
             .inner
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .directml_disabled_for_session;
-        let provider = if use_directml_beta && !directml_disabled {
+        let provider = if use_directml && !directml_disabled {
             MlProvider::DirectMl
         } else {
             MlProvider::Cpu
         };
-        if use_directml_beta && directml_disabled {
+        if use_directml && directml_disabled {
             tracing::warn!(
-                "[ML:DML] DirectML Beta is disabled for this session after an earlier failure; using CPU"
+                "[ML:DML] DirectML is disabled for this session after an earlier failure; using CPU"
             );
         }
         let state_for_start = self.clone();
@@ -369,7 +376,7 @@ impl MlRuntimeState {
             .as_ref()
             .map(|process| match process.provider {
                 MlProvider::Cpu => "cpu",
-                MlProvider::DirectMl => "directml_beta",
+                MlProvider::DirectMl => "directml",
             })
             .unwrap_or("none");
         MlRuntimeStatus {
@@ -560,7 +567,7 @@ impl MlRuntimeState {
 
     fn disable_directml_for_session(&self, error: &str) {
         tracing::warn!(
-            "[ML:DML] disabling temporary DirectML Beta provider for this session: {}",
+            "[ML:DML] disabling DirectML provider for this session: {}",
             error
         );
         let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -108,6 +108,10 @@ pub struct MonitorState {
     /// Read this through [`MonitorState::python_owns_clip_encoding`] rather
     /// than directly, for the reason that method records.
     python_clip_encoder: AtomicBool,
+    /// Classification runtime handed to the live Python monitor at spawn.
+    /// Unlike the registry selection, this value changes only with the child
+    /// process lifecycle.
+    active_classification_runtime: Mutex<Option<String>>,
     /// Prevents the monitor from restarting during migration tasks
     pub migration_lock: AtomicBool,
     recovery: Mutex<MonitorRecoveryState>,
@@ -136,6 +140,7 @@ impl MonitorState {
             stopping: AtomicBool::new(false),
             python_smart_cluster_worker: AtomicBool::new(false),
             python_clip_encoder: AtomicBool::new(false),
+            active_classification_runtime: Mutex::new(None),
             migration_lock: AtomicBool::new(false),
             recovery: Mutex::new(MonitorRecoveryState::default()),
             python_ipc_client: AsyncMutex::new(None),
@@ -211,6 +216,47 @@ impl MonitorState {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .is_some()
+    }
+
+    pub fn set_active_classification_runtime(&self, runtime: Option<String>) {
+        let mut active = self
+            .active_classification_runtime
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        *active = runtime;
+    }
+
+    /// Runtime selected by the environment of the currently live monitor.
+    pub fn active_classification_runtime(&self) -> Option<String> {
+        let running = self
+            .process
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .is_some();
+        if !running {
+            return None;
+        }
+        self.active_classification_runtime
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone()
+    }
+
+    /// Whether game mode currently prevents GPU inference.
+    ///
+    /// The two flags have different lifetimes: the ordinary suppression is
+    /// cleared when GPU pressure falls, while the permanent flag lasts until
+    /// game mode (or the application) is restarted. Callers that choose a
+    /// provider must observe both flags so a Rust worker cannot bypass the
+    /// Python monitor's game-mode policy.
+    pub fn is_dml_suppressed(&self) -> bool {
+        self.game_mode_dml_suppressed.load(Ordering::SeqCst)
+            || self.game_mode_permanently_suppressed.load(Ordering::SeqCst)
+    }
+
+    /// Combines the persisted preference with the live game-mode policy.
+    pub fn allows_directml(&self, configured: bool) -> bool {
+        configured && !self.is_dml_suppressed()
     }
 }
 
@@ -333,6 +379,7 @@ fn cleanup_monitor_runtime_after_unexpected_exit(state: &MonitorState) {
     // The Python Smart Cluster worker died with its process, so the Rust one
     // may take the queue back as soon as the switch allows it.
     state.set_python_smart_cluster_worker(false);
+    state.set_active_classification_runtime(None);
     {
         let mut guard = state.reverse_ipc.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(ref mut server) = *guard {
@@ -1646,6 +1693,11 @@ pub async fn start_monitor_impl(
         // not the registry key it came from — decides who encodes captures.
         let python_clip_runtime = crate::clip_query::clip_runtime();
         let python_encodes_clip = python_clip_runtime == "python";
+        // BGE classification remains orchestrated by the post-process worker,
+        // but its embedder calls the shared Rust semantic worker by default.
+        // The child reads this once, so changing the rollback lever takes effect
+        // with the same monitor restart as the other inference runtime flags.
+        let python_classification_runtime = crate::classification_runtime::classification_runtime();
         cmd_proc
             .env(
                 "CARBONPAPER_CLUSTERING_ENABLED",
@@ -1674,6 +1726,10 @@ pub async fn start_monitor_impl(
             // the collection they both target.
             .env("CARBONPAPER_CLIP_RUNTIME", &python_clip_runtime)
             .env(
+                "CARBONPAPER_CLASSIFICATION_RUNTIME",
+                &python_classification_runtime,
+            )
+            .env(
                 "CARBONPAPER_OCR_TIMEOUT_SECS",
                 crate::registry_config::get_u32("ocr_timeout_secs")
                     .unwrap_or(120)
@@ -1695,44 +1751,38 @@ pub async fn start_monitor_impl(
                 );
         }
 
-        // Pass DirectML configuration
-        if crate::registry_config::get_bool("use_dml").unwrap_or(false) {
-            // 检查游戏模式是否抑制了 DML（临时或永久）
-            let suppressed = state.game_mode_dml_suppressed.load(Ordering::SeqCst)
-                || state
-                    .game_mode_permanently_suppressed
-                    .load(Ordering::SeqCst);
-            if !suppressed {
-                // 先枚举可用 GPU，如果完全没有可用显卡则跳过 DML
-                let gpus = enumerate_gpus_internal().unwrap_or_default();
-                if gpus.is_empty() {
-                    tracing::warn!(
-                        "No compatible GPU detected, skipping DirectML (falling back to CPU)"
-                    );
-                } else {
-                    cmd_proc.env("CARBONPAPER_USE_DML", "1");
-                    let mut device_id =
-                        crate::registry_config::get_u32("dml_device_id").unwrap_or(0);
-                    // 校验 device_id 是否仍然有效，无效则回退到第一张可用卡
-                    if !gpus
-                        .iter()
-                        .any(|g| g.get("id").and_then(|v| v.as_u64()) == Some(device_id as u64))
-                    {
-                        let fallback_id =
-                            gpus[0].get("id").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-                        tracing::warn!(
-                            "DML device_id {} no longer exists, falling back to {}",
-                            device_id,
-                            fallback_id
-                        );
-                        device_id = fallback_id;
-                        let _ = crate::registry_config::set_u32("dml_device_id", device_id);
-                    }
-                    cmd_proc.env("CARBONPAPER_DML_DEVICE_ID", device_id.to_string());
-                }
+        // Pass DirectML configuration. The persisted preference is not enough:
+        // game mode can temporarily or permanently suppress GPU inference.
+        let configured_dml = crate::registry_config::get_bool("use_dml").unwrap_or(false);
+        if state.allows_directml(configured_dml) {
+            // 先枚举可用 GPU，如果完全没有可用显卡则跳过 DML
+            let gpus = enumerate_gpus_internal().unwrap_or_default();
+            if gpus.is_empty() {
+                tracing::warn!(
+                    "No compatible GPU detected, skipping DirectML (falling back to CPU)"
+                );
             } else {
-                tracing::info!("Game mode: DML suppressed, starting Python without DML");
+                cmd_proc.env("CARBONPAPER_USE_DML", "1");
+                let mut device_id = crate::registry_config::get_u32("dml_device_id").unwrap_or(0);
+                // 校验 device_id 是否仍然有效，无效则回退到第一张可用卡
+                if !gpus
+                    .iter()
+                    .any(|g| g.get("id").and_then(|v| v.as_u64()) == Some(device_id as u64))
+                {
+                    let fallback_id =
+                        gpus[0].get("id").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+                    tracing::warn!(
+                        "DML device_id {} no longer exists, falling back to {}",
+                        device_id,
+                        fallback_id
+                    );
+                    device_id = fallback_id;
+                    let _ = crate::registry_config::set_u32("dml_device_id", device_id);
+                }
+                cmd_proc.env("CARBONPAPER_DML_DEVICE_ID", device_id.to_string());
             }
+        } else if configured_dml {
+            tracing::info!("Game mode: DML suppressed, starting Python without DML");
         }
 
         cmd_proc
@@ -1848,6 +1898,7 @@ pub async fn start_monitor_impl(
         // drains `smart_cluster_pending`, whatever the registry key says later.
         state.set_python_smart_cluster_worker(python_drains_smart_clusters);
         state.set_python_clip_encoder(python_encodes_clip);
+        state.set_active_classification_runtime(Some(python_classification_runtime));
 
         (python_executable, python_exists)
     };
@@ -2208,6 +2259,7 @@ pub async fn stop_monitor_impl(
     // The Python Smart Cluster worker stopped with its process; the queue is
     // the Rust worker's again as soon as the switch allows it.
     state.set_python_smart_cluster_worker(false);
+    state.set_active_classification_runtime(None);
     {
         let mut guard = state.pipe_name.lock().unwrap_or_else(|e| e.into_inner());
         *guard = None;
@@ -2476,6 +2528,13 @@ fn query_gpu_memory_usage(device_id: u32) -> Result<f64, String> {
     }
 }
 
+fn stop_rust_directml_worker_for_game_mode(app: &AppHandle) {
+    let semantic = app.state::<Arc<crate::semantic_runtime::SemanticRuntimeState>>();
+    if semantic.inner().stop_if_directml() {
+        tracing::info!("Game mode: stopped resident Rust DirectML semantic worker");
+    }
+}
+
 /// 启动游戏模式监控循环（GPU 负载 + 全屏非浏览器检测）
 pub fn start_game_mode_monitor(app: AppHandle) {
     let monitor_state = app.state::<MonitorState>();
@@ -2611,6 +2670,7 @@ pub fn start_game_mode_monitor(app: AppHandle) {
                     state
                         .game_mode_permanently_suppressed
                         .store(true, Ordering::SeqCst);
+                    stop_rust_directml_worker_for_game_mode(&app_clone);
                     let _ = app_clone.emit(
                         "game-mode-status",
                         serde_json::json!({
@@ -2638,6 +2698,7 @@ pub fn start_game_mode_monitor(app: AppHandle) {
                     usage * 100.0
                 );
                 state.game_mode_dml_suppressed.store(true, Ordering::SeqCst);
+                stop_rust_directml_worker_for_game_mode(&app_clone);
                 let _ = app_clone.emit(
                     "game-mode-status",
                     serde_json::json!({"active": true, "usage": usage}),
@@ -2829,5 +2890,25 @@ mod tests {
         assert_eq!(recovery["last_error"], "pipe failed");
         assert_eq!(recovery["crash_count"], 1);
         assert!(recovery["last_crashed_at_ms"].as_u64().unwrap_or(0) > 0);
+    }
+
+    #[test]
+    fn directml_policy_requires_both_preference_and_clear_game_mode() {
+        let state = MonitorState::new();
+        assert!(!state.allows_directml(false));
+        assert!(state.allows_directml(true));
+
+        state.game_mode_dml_suppressed.store(true, Ordering::SeqCst);
+        assert!(state.is_dml_suppressed());
+        assert!(!state.allows_directml(true));
+
+        state
+            .game_mode_dml_suppressed
+            .store(false, Ordering::SeqCst);
+        state
+            .game_mode_permanently_suppressed
+            .store(true, Ordering::SeqCst);
+        assert!(state.is_dml_suppressed());
+        assert!(!state.allows_directml(true));
     }
 }

--- a/src-tauri/src/reverse_ipc.rs
+++ b/src-tauri/src/reverse_ipc.rs
@@ -574,7 +574,7 @@ async fn handle_client(
                 }
             }
         } else {
-            let response = process_request(&req, &storage, &app_handle);
+            let response = process_request(&req, &storage, &app_handle).await;
 
             // 发送响应
             let response_bytes = serde_json::to_vec(&response).unwrap_or_default();
@@ -594,7 +594,7 @@ async fn handle_client(
 }
 
 /// 处理存储请求
-fn process_request(
+async fn process_request(
     req: &serde_json::Value,
     storage: &StorageState,
     app_handle: &tauri::AppHandle,
@@ -608,6 +608,44 @@ fn process_request(
     }
 
     let response = match command {
+        "bge_embed_texts" => {
+            let texts = match req.get("texts").and_then(|value| value.as_array()) {
+                Some(values) => {
+                    let mut texts = Vec::with_capacity(values.len());
+                    for (index, value) in values.iter().enumerate() {
+                        let Some(text) = value.as_str() else {
+                            return StorageResponse::error(&format!(
+                                "texts[{index}] must be a string"
+                            ));
+                        };
+                        texts.push(text.to_string());
+                    }
+                    texts
+                }
+                None => return StorageResponse::error("texts must be an array"),
+            };
+            match crate::classification_runtime::embed_bge_texts(app_handle.clone(), texts).await {
+                Ok(result) => StorageResponse::success(
+                    serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})),
+                ),
+                Err(error) => StorageResponse::error(&error),
+            }
+        }
+
+        "classification_record_python_fallback" => {
+            let error = req
+                .get("error")
+                .and_then(|value| value.as_str())
+                .unwrap_or("Rust BGE inference was unavailable");
+            crate::classification_runtime::record_python_fallback(error);
+            StorageResponse::success(serde_json::json!({ "recorded": true }))
+        }
+
+        "classification_record_python_inference" => {
+            crate::classification_runtime::record_python_inference();
+            StorageResponse::success(serde_json::json!({ "recorded": true }))
+        }
+
         "save_screenshot" => {
             // 解析保存截图请求
             let request = match serde_json::from_value::<SaveScreenshotRequest>(req.clone()) {
@@ -1730,7 +1768,7 @@ async fn process_nmh_request(
                         let ocr_guard = ocr_slot.into_task_guard(screenshot_id);
                         tokio::spawn(async move {
                             let _ocr_guard = ocr_guard;
-                            let route = crate::capture::OcrRouteConfig::from_registry();
+                            let route = crate::capture::OcrRouteConfig::from_app(&app_clone);
                             let result = process_extension_ocr(
                                 &app_clone,
                                 &storage_arc,
@@ -2042,8 +2080,8 @@ async fn process_extension_ocr(
     timestamp_ms: i64,
     route: crate::capture::OcrRouteConfig,
 ) -> Result<(), String> {
-    let provider = if route.use_directml_beta {
-        "directml_beta"
+    let provider = if route.use_directml {
+        "directml"
     } else {
         "cpu"
     };

--- a/src-tauri/src/semantic_runtime.rs
+++ b/src-tauri/src/semantic_runtime.rs
@@ -19,7 +19,7 @@ use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use windows::Win32::Foundation::{CloseHandle, HANDLE};
 use windows::Win32::System::JobObjects::{
     AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
@@ -64,6 +64,10 @@ pub struct SemanticRuntimeStatus {
     /// their own schedules and each has its own rollback lever: a user reading
     /// one field could not tell which of the two it described.
     pub clip_backend: crate::clip_query::ClipBackendStatus,
+    /// BGE automatic-classification inference selection and fallback history.
+    /// Classification has no derived index, so its diagnostic is only runtime
+    /// ownership, the last backend that served it, and the last Rust failure.
+    pub classification_backend: crate::classification_runtime::ClassificationBackendStatus,
 }
 
 const BACKEND_DIAGNOSTIC_CACHE_TTL: Duration = Duration::from_secs(5);
@@ -453,25 +457,46 @@ impl SemanticRuntimeState {
         let deadline = Instant::now() + timeout;
         let _request_guard =
             acquire_request_slot(&self.request_gate, deadline, request.request_id()).await?;
+        // Re-read game mode after waiting for the single request slot. A BGE
+        // chunk can queue while another model is running, and suppression may
+        // begin during that wait. Using the earlier value here could start a
+        // fresh DirectML worker after game mode had already taken the GPU back.
+        let prefer_directml = directml_allowed_for_request(&app, prefer_directml);
         let model = request_model(&request);
-        let provider = match self.select_provider(&app, prefer_directml, model).await {
+        let mut provider = match self.select_provider(&app, prefer_directml, model).await {
             Ok(provider) => provider,
             Err(error) => {
-                self.disable_directml_for_session(&error);
-                self.restart_process("directml_startup_fallback");
+                if directml_allowed_for_request(&app, true) {
+                    self.disable_directml_for_session(&error);
+                    self.restart_process("directml_startup_fallback");
+                } else {
+                    self.stop_if_directml();
+                }
                 return self
                     .send_once(&app, MlProvider::Cpu, request, body, deadline)
                     .await;
             }
         };
+        // Suppression can also arrive while a cold DirectML worker is starting.
+        // Tear that worker down before submitting the request and continue on
+        // CPU without treating an intentional game-mode transition as a broken
+        // DirectML session.
+        if provider == MlProvider::DirectMl && !directml_allowed_for_request(&app, true) {
+            self.stop_if_directml();
+            provider = MlProvider::Cpu;
+        }
         let first = self
             .send_once(&app, provider, request.clone(), body.clone(), deadline)
             .await;
         if provider == MlProvider::DirectMl {
             if let Err(error) = &first {
                 if should_fallback_from_directml(error) {
-                    self.disable_directml_for_session(error);
-                    self.restart_process("directml_fallback");
+                    if directml_allowed_for_request(&app, true) {
+                        self.disable_directml_for_session(error);
+                        self.restart_process("directml_fallback");
+                    } else {
+                        self.stop_if_directml();
+                    }
                     return self
                         .send_once(&app, MlProvider::Cpu, request, body, deadline)
                         .await;
@@ -664,6 +689,7 @@ impl SemanticRuntimeState {
             directml_disabled_for_session: inner.directml_disabled_for_session,
             backend: crate::semantic_query::backend_status(None),
             clip_backend: crate::clip_query::backend_status(None),
+            classification_backend: crate::classification_runtime::backend_status(None),
         }
     }
 
@@ -673,6 +699,28 @@ impl SemanticRuntimeState {
             .lock()
             .unwrap_or_else(|error| error.into_inner());
         self.stop_locked();
+    }
+
+    /// Stop a resident DirectML worker when game mode takes the GPU back.
+    /// CPU workers are left alone because suppression targets GPU contention,
+    /// and killing a CPU worker would only add an avoidable cold start later.
+    pub fn stop_if_directml(&self) -> bool {
+        let _lifecycle_guard = self
+            .lifecycle_lock
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let is_directml = self
+            .inner
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .process
+            .as_ref()
+            .map(|process| process.provider == MlProvider::DirectMl)
+            .unwrap_or(false);
+        if is_directml {
+            self.stop_locked();
+        }
+        is_directml
     }
 
     fn stop_locked(&self) {
@@ -694,12 +742,22 @@ impl SemanticRuntimeState {
     fn ensure_process(
         &self,
         app: &AppHandle,
-        provider: MlProvider,
+        requested_provider: MlProvider,
     ) -> Result<Arc<SemanticMlChild>, String> {
         let _guard = self
             .lifecycle_lock
             .lock()
             .unwrap_or_else(|error| error.into_inner());
+        // This is the last provider decision before a process can be reused or
+        // spawned. Keeping it inside the lifecycle lock closes the remaining
+        // gap between the async request-level check and worker startup.
+        let provider = if requested_provider == MlProvider::DirectMl
+            && !directml_allowed_for_request(app, true)
+        {
+            MlProvider::Cpu
+        } else {
+            requested_provider
+        };
         {
             let inner = self.inner.lock().unwrap_or_else(|error| error.into_inner());
             if let Some(process) = &inner.process {
@@ -972,12 +1030,12 @@ pub const FOREGROUND_POLL_INTERVAL: Duration = Duration::from_millis(250);
 /// they point here rather than restating it — so an engine that one day caches
 /// two models invalidates one paragraph instead of seven.
 ///
-/// Both background loops therefore claim this before doing anything that
-/// touches the worker: capture indexing (`minilm_index.rs`, MiniLM) and Smart
-/// Cluster scoring (`smart_cluster_scoring.rs`, MiniLM anchors then the
-/// cross-encoder). It lives here rather than in either module because neither
-/// owns the other, and a guard private to one of them is exactly the shape this
-/// started as.
+/// Every background model batch therefore claims this before touching the
+/// worker: MiniLM capture indexing, CLIP image indexing, BGE automatic
+/// classification, and Smart Cluster scoring (MiniLM anchors followed by the
+/// cross-encoder). It lives here rather than in one of those modules because
+/// none owns the others, and a guard private to any one path would recreate the
+/// same model-thrashing bug at the next boundary.
 pub static BACKGROUND_PASS_GUARD: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// Wait for exclusive use of the single semantic worker, inside the caller's own
@@ -1105,6 +1163,13 @@ fn route_provider(
             MlProvider::Cpu
         }
     })
+}
+
+fn directml_allowed_for_request(app: &AppHandle, requested: bool) -> bool {
+    requested
+        && app
+            .state::<crate::monitor::MonitorState>()
+            .allows_directml(true)
 }
 
 fn response_request_id(response: &MlResponse) -> Option<u64> {
@@ -1282,12 +1347,15 @@ fn assign_kill_on_close_job(child: &Child) -> Result<SemanticJobHandle, String> 
 #[tauri::command]
 pub async fn get_ml_semantic_status(
     state: tauri::State<'_, Arc<SemanticRuntimeState>>,
+    monitor: tauri::State<'_, crate::monitor::MonitorState>,
     storage: tauri::State<'_, Arc<crate::storage::StorageState>>,
     index_run: tauri::State<'_, Arc<crate::minilm_index::SemanticIndexRunState>>,
     clip_run: tauri::State<'_, Arc<crate::clip_index::ClipIndexRunState>>,
     refresh_diagnostics: Option<bool>,
 ) -> Result<SemanticRuntimeStatus, String> {
     let mut status = state.status();
+    status.classification_backend =
+        crate::classification_runtime::backend_status(monitor.active_classification_runtime());
     // Read before the blocking call below, so a run that finishes while the
     // ledger read is queued behind the database mutex is not reported as still
     // going. Erring towards "finished" is the safe direction: the settings
@@ -1404,10 +1472,14 @@ pub fn get_background_index_progress(
 pub fn restart_ml_semantic_worker(
     window: tauri::Window,
     state: tauri::State<'_, Arc<SemanticRuntimeState>>,
+    monitor: tauri::State<'_, crate::monitor::MonitorState>,
 ) -> Result<SemanticRuntimeStatus, String> {
     crate::commands::check_main_window(&window)?;
     state.stop();
-    Ok(state.status())
+    let mut status = state.status();
+    status.classification_backend =
+        crate::classification_runtime::backend_status(monitor.active_classification_runtime());
+    Ok(status)
 }
 
 #[cfg(test)]

--- a/src/components/settings/AdvancedSection.jsx
+++ b/src/components/settings/AdvancedSection.jsx
@@ -4,7 +4,7 @@ import AdvancedWarning from './advanced/AdvancedWarning';
 import ClusteringTechnicalCard from './advanced/ClusteringTechnicalCard';
 import CpuLimitCard from './advanced/CpuLimitCard';
 import DatabaseMaintenanceCard from './advanced/DatabaseMaintenanceCard';
-import { ClipBackendCard, DmlAccelerationCard, OcrEngineCard, OnnxRuntimeCard, SemanticBackendCard } from './advanced/InferenceCards';
+import { ClassificationBackendCard, ClipBackendCard, DmlAccelerationCard, OcrEngineCard, OnnxRuntimeCard, SemanticBackendCard } from './advanced/InferenceCards';
 import NetworkAccessCard from './advanced/NetworkAccessCard';
 import OcrQueueCard from './advanced/OcrQueueCard';
 import { useAdvancedSectionController } from './useAdvancedSectionController';
@@ -20,6 +20,7 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
     cpuChanged,
     dmlChanged,
     onnxChanged,
+    classificationRuntimeChanged,
     gpus,
     gpuLoading,
     vacuumRunning,
@@ -35,6 +36,7 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
     clearCpuChanged,
     clearDmlChanged,
     clearOnnxChanged,
+    clearClassificationRuntimeChanged,
     handleToggle,
     handleCpuPercentChange,
     handleOcrTimeoutDraftChange,
@@ -56,6 +58,7 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
     clipBackfillBusy,
     handleClipBackfillDecision,
     handleToggleRustClipIndex,
+    handleToggleRustClassification,
     handleRunClipIndexNow,
     handleStopClipIndex,
     semanticIndexProgress,
@@ -129,6 +132,16 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
         onToggle={handleToggle}
         onRestartMonitor={onRestartMonitor}
         onClearChanged={clearOnnxChanged}
+      />
+
+      <ClassificationBackendCard
+        config={config}
+        status={semanticStatus}
+        monitorStatus={monitorStatus}
+        runtimeChanged={classificationRuntimeChanged}
+        onToggleRust={handleToggleRustClassification}
+        onRestartMonitor={onRestartMonitor}
+        onClearChanged={clearClassificationRuntimeChanged}
       />
 
       <SemanticBackendCard

--- a/src/components/settings/advanced/InferenceCards.jsx
+++ b/src/components/settings/advanced/InferenceCards.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle, ChevronDown, Cpu, Database, Image as ImageIcon, Monitor, RefreshCw, Zap } from 'lucide-react';
+import { AlertTriangle, ChevronDown, Cpu, Database, Image as ImageIcon, Monitor, RefreshCw, Tags, Zap } from 'lucide-react';
 import SettingsHelpTooltip from '../SettingsHelpTooltip';
 import { SettingsSwitch } from '../SettingsControls';
 import { formatEstimate } from '../../ClipBackfillDialog';
@@ -58,21 +58,6 @@ export function OcrEngineCard({
               '隔离的 Rust ML 进程直接读取 RGB 捕获帧。',
             )}
           </p>
-        </div>
-
-        <div className="flex items-center justify-between gap-4">
-            <div className="flex-1 min-w-0">
-              <p className="text-sm text-ide-text font-medium">
-                {t('settings.advanced.rust_ocr.dml_beta', 'DirectML Beta')}
-              </p>
-              <p className="text-xs text-ide-muted mt-1">
-                {t('settings.advanced.rust_ocr.dml_beta_desc', '临时实验开关，默认关闭；未来会废弃并合并到统一的 DirectML 设置。')}
-              </p>
-            </div>
-            <SettingsSwitch
-              checked={Boolean(config.rust_ocr_dml_beta)}
-              onChange={() => onToggle('rust_ocr_dml_beta')}
-            />
         </div>
 
         <div className="flex items-center justify-between gap-4 rounded-lg border border-ide-border/60 bg-ide-panel/40 p-3">
@@ -633,6 +618,98 @@ export function ClipBackendCard({
             )}
           </div>
         </div>
+      </div>
+    </div>
+  );
+}
+
+export function ClassificationBackendCard({
+  config,
+  status,
+  monitorStatus,
+  runtimeChanged,
+  onToggleRust,
+  onRestartMonitor,
+  onClearChanged,
+}) {
+  const { t } = useTranslation();
+  const usesRust = (config.classification_runtime || 'rust') === 'rust';
+  const backend = status?.classification_backend;
+  const servedLabel = {
+    rust: t('settings.advanced.classification_backend.served_rust'),
+    python: t('settings.advanced.classification_backend.served_python'),
+  }[backend?.last_backend] || t('settings.advanced.classification_backend.served_unknown');
+  const activeLabel = {
+    rust: t('settings.advanced.classification_backend.runtime_rust'),
+    python: t('settings.advanced.classification_backend.runtime_python'),
+  }[backend?.active_runtime] || t('settings.advanced.classification_backend.runtime_stopped');
+
+  return (
+    <div className="space-y-3">
+      <label className="text-sm font-semibold text-ide-accent px-1 flex items-center gap-2">
+        <Tags className="w-4 h-4" />
+        {t('settings.advanced.classification_backend.title')}
+      </label>
+
+      <div className="p-4 bg-ide-bg border border-ide-border rounded-xl space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-ide-text font-medium">
+              {t('settings.advanced.classification_backend.label')}
+            </p>
+            <p className="text-xs text-ide-muted mt-1">
+              {t('settings.advanced.classification_backend.description')}
+            </p>
+            <p className="text-xs text-ide-muted mt-1">
+              {t('settings.advanced.classification_backend.rollback_note')}
+            </p>
+          </div>
+          <SettingsSwitch checked={usesRust} onChange={() => onToggleRust(!usesRust)} />
+        </div>
+
+        <div className="rounded-lg border border-ide-border/60 bg-ide-panel/40 p-3 space-y-2">
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+            <span className="text-ide-muted">
+              {t('settings.advanced.classification_backend.selected')}
+            </span>
+            <span className="text-ide-text text-right">
+              {usesRust
+                ? t('settings.advanced.classification_backend.runtime_rust')
+                : t('settings.advanced.classification_backend.runtime_python')}
+            </span>
+            <span className="text-ide-muted">
+              {t('settings.advanced.classification_backend.last_inference')}
+            </span>
+            <span className="text-ide-text text-right">{servedLabel}</span>
+            <span className="text-ide-muted">
+              {t('settings.advanced.classification_backend.active')}
+            </span>
+            <span className="text-ide-text text-right">{activeLabel}</span>
+            <span className="text-ide-muted">
+              {t('settings.advanced.classification_backend.successes')}
+            </span>
+            <span className="text-ide-text text-right">{backend?.success_count ?? 0}</span>
+            <span className="text-ide-muted">
+              {t('settings.advanced.classification_backend.fallbacks')}
+            </span>
+            <span className="text-ide-text text-right">{backend?.fallback_count ?? 0}</span>
+          </div>
+          {backend?.last_error && (
+            <p className="text-[11px] text-ide-warning-muted leading-snug break-words">
+              {t('settings.advanced.classification_backend.last_reason')}: {backend.last_error}
+            </p>
+          )}
+        </div>
+
+        {runtimeChanged && (
+          <ChangedNotice
+            monitorStatus={monitorStatus}
+            onRestartMonitor={onRestartMonitor}
+            onClearChanged={onClearChanged}
+          >
+            {t('settings.advanced.classification_backend.changed_notice')}
+          </ChangedNotice>
+        )}
       </div>
     </div>
   );

--- a/src/components/settings/useAdvancedSectionController.js
+++ b/src/components/settings/useAdvancedSectionController.js
@@ -13,6 +13,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
   const [cpuChanged, setCpuChanged] = useState(false);
   const [dmlChanged, setDmlChanged] = useState(false);
   const [onnxChanged, setOnnxChanged] = useState(false);
+  const [classificationRuntimeChanged, setClassificationRuntimeChanged] = useState(false);
   const [gpus, setGpus] = useState([]);
   const [gpuLoading, setGpuLoading] = useState(false);
   const [vacuumRunning, setVacuumRunning] = useState(false);
@@ -251,6 +252,17 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     if (saved) await refreshSemanticStatus();
   };
 
+  const handleToggleRustClassification = async (enabled) => {
+    const newConfig = {
+      ...config,
+      classification_runtime: enabled ? 'rust' : 'python',
+    };
+    const saved = await saveConfig(newConfig);
+    if (!saved) return;
+    setClassificationRuntimeChanged(true);
+    await refreshSemanticStatus();
+  };
+
   /**
    * Progress of a running manual pass, one event per encoded chunk of four.
    *
@@ -446,17 +458,6 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     if (key === 'clustering_allow_full_low_memory') {
       await syncOcrConfigToMonitor(newConfig);
     }
-    if (key === 'rust_ocr_dml_beta') {
-      try {
-        await withAuth(
-          () => invoke('restart_ml_ocr_worker'),
-          { autoPrompt: true },
-        );
-      } catch (err) {
-        console.warn('Failed to restart Rust ML OCR worker:', err);
-      }
-      await refreshMlOcrStatus();
-    }
   };
 
   const handleRestartMlOcr = async () => {
@@ -534,6 +535,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     cpuChanged,
     dmlChanged,
     onnxChanged,
+    classificationRuntimeChanged,
     gpus,
     gpuLoading,
     vacuumRunning,
@@ -562,6 +564,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     clearCpuChanged: () => setCpuChanged(false),
     clearDmlChanged: () => setDmlChanged(false),
     clearOnnxChanged: () => setOnnxChanged(false),
+    clearClassificationRuntimeChanged: () => setClassificationRuntimeChanged(false),
     handleToggle,
     handleCpuPercentChange,
     handleOcrTimeoutDraftChange,
@@ -575,6 +578,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     handleRunSemanticIndexNow,
     handleStopSemanticIndex,
     handleToggleRustClipIndex,
+    handleToggleRustClassification,
     handleRunClipIndexNow,
     handleStopClipIndex,
     refreshSemanticStatus,

--- a/src/components/settings/useAdvancedSectionController.test.jsx
+++ b/src/components/settings/useAdvancedSectionController.test.jsx
@@ -137,4 +137,24 @@ describe('useAdvancedSectionController', () => {
 
     hook.unmount();
   });
+
+  it('persists the Python classification rollback and marks it for restart', async () => {
+    clipRunActive = false;
+    const hook = renderHook(() => useAdvancedSectionController({
+      monitorStatus: 'running',
+      t,
+    }));
+
+    await waitFor(() => expect(hook.result.current.config).toEqual({}));
+
+    await act(async () => {
+      await hook.result.current.handleToggleRustClassification(false);
+    });
+
+    expect(invoke).toHaveBeenCalledWith('set_advanced_config', {
+      config: { classification_runtime: 'python' },
+    });
+    expect(hook.result.current.config.classification_runtime).toBe('python');
+    expect(hook.result.current.classificationRuntimeChanged).toBe(true);
+  });
 });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -246,8 +246,6 @@
         "use_rust": "Use Rust OCR",
         "rust_desc": "Runs OCR directly on RGB capture frames in an isolated Rust ML process.",
         "python_desc": "Python OCR is no longer used as the screenshot OCR fallback.",
-        "dml_beta": "DirectML Beta",
-        "dml_beta_desc": "Temporary experimental switch, off by default. It will be removed in favor of the unified DirectML setting.",
         "model_ready": "PP-OCRv5 Mobile is installed",
         "model_missing": "PP-OCRv5 Mobile must be installed",
         "model_bundled": "PP-OCRv5 Mobile is bundled with CarbonPaper",
@@ -263,9 +261,9 @@
         "retry_failed": "Retry failed screenshots ({{count}})"
       },
       "dml": {
-        "title": "OCR inference acceleration",
+        "title": "DirectML inference acceleration",
         "label": "Use DirectML for inference",
-        "description": "When enabled, uses GPU for OCR inference acceleration; requires DirectX 12 compatible GPU",
+        "description": "When enabled, uses the GPU for DirectML-capable OCR and vector inference; requires a DirectX 12 compatible GPU",
         "changed_notice": "DirectML changes take effect when the monitor service restarts",
         "notice": "Note: Running DirectML on the primary GPU may impact gaming performance.",
         "gpu_select": "Select GPU device",
@@ -346,6 +344,25 @@
         "run_stopping": "Stopping. The run ends once the current image finishes.",
         "run_done": "Indexed {{indexed}} image(s); {{remaining}} still waiting.",
         "run_skipped": "This run did not start: {{reason}}."
+      },
+      "classification_backend": {
+        "title": "Automatic screenshot classification",
+        "label": "Use Rust for BGE classification inference",
+        "description": "BGE-small-zh matches window titles and, when needed, OCR text against classification anchors. The result is stored on the screenshot and used by category filters and task summaries.",
+        "rollback_note": "When off, BGE runs in the local Python runtime again. Classification rules, existing categories, and learned anchors are unchanged.",
+        "selected": "Selected runtime",
+        "active": "Active monitor runtime",
+        "runtime_rust": "Rust (default)",
+        "runtime_python": "Python (rollback)",
+        "runtime_stopped": "Not running",
+        "last_inference": "Last inference served by",
+        "served_rust": "Rust",
+        "served_python": "Python",
+        "served_unknown": "No classification since startup",
+        "successes": "Rust successes",
+        "fallbacks": "Automatic fallbacks",
+        "last_reason": "Last Rust failure",
+        "changed_notice": "The classification runtime takes effect after the monitor service restarts"
       },
       "onnx": {
         "title": "ONNX Inference (Experimental)",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -246,8 +246,6 @@
         "use_rust": "使用 Rust OCR",
         "rust_desc": "使用隔离的 Rust ML 进程直接处理 RGB 捕获帧。",
         "python_desc": "Python OCR 不再作为截图 OCR 回退路径。",
-        "dml_beta": "DirectML Beta",
-        "dml_beta_desc": "临时实验开关，默认关闭；未来会废弃并合并到统一的 DirectML 设置。",
         "model_ready": "PP-OCRv5 Mobile 已安装",
         "model_missing": "需要安装 PP-OCRv5 Mobile 模型",
         "model_bundled": "PP-OCRv5 Mobile 随 CarbonPaper 安装",
@@ -263,9 +261,9 @@
         "retry_failed": "重试失败截图（{{count}}）"
       },
       "dml": {
-        "title": "OCR 推理加速",
+        "title": "DirectML 推理加速",
         "label": "使用 DirectML 进行推理",
-        "description": "启用后将使用 GPU 进行 OCR 推理加速，需要 DirectX 12 兼容的显卡。",
+        "description": "启用后将使用 GPU 加速支持 DirectML 的 OCR 和向量推理，需要 DirectX 12 兼容的显卡。",
         "notice": "注意：在主要 GPU 上运行 DirectML 可能会影响游戏性能。",
         "changed_notice": "DirectML 设置将在下次启动监控服务时生效",
         "gpu_select": "选择 GPU 设备",
@@ -346,6 +344,25 @@
         "run_stopping": "正在停止。当前这张画面处理完就会结束。",
         "run_done": "本次索引了 {{indexed}} 张画面，还有 {{remaining}} 张在等待。",
         "run_skipped": "本次没有开始索引：{{reason}}。"
+      },
+      "classification_backend": {
+        "title": "截图内容自动分类",
+        "label": "使用 Rust 运行 BGE 分类推理",
+        "description": "使用 BGE-small-zh 将窗口标题和必要的 OCR 文本与分类锚点进行匹配。分类结果会写入截图，并用于分类筛选和任务摘要。",
+        "rollback_note": "关闭后恢复由 Python 本地运行时执行 BGE。分类规则、已有类别和学习锚点不会改变。",
+        "selected": "选择的运行时",
+        "active": "当前监控进程",
+        "runtime_rust": "Rust（默认）",
+        "runtime_python": "Python（回滚）",
+        "runtime_stopped": "未运行",
+        "last_inference": "上次推理由谁完成",
+        "served_rust": "Rust",
+        "served_python": "Python",
+        "served_unknown": "本次启动后尚未分类",
+        "successes": "Rust 成功次数",
+        "fallbacks": "自动回退次数",
+        "last_reason": "上次 Rust 失败原因",
+        "changed_notice": "分类运行时将在监控服务重启后生效"
       },
       "onnx": {
         "title": "ONNX 推理 (测试性)",

--- a/tools/benchmark_bge.py
+++ b/tools/benchmark_bge.py
@@ -1,0 +1,1341 @@
+"""Benchmark Python ONNX BGE against the Rust semantic worker on local data.
+
+The tool is offline. It selects rows deterministically, asks a read-only Rust
+helper to decrypt them through the production CNG/AES-GCM implementation, and
+keeps all plaintext in anonymous process pipes and memory. Reports contain only
+row ids, aggregate lengths, category names, scores, and performance metrics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import gc
+import hashlib
+import json
+import os
+import platform
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MONITOR_DIR = REPO_ROOT / "monitor"
+TAURI_DIR = REPO_ROOT / "src-tauri"
+DEFAULT_DATA_DIR = Path(r"D:\tools\carbonpaper\data")
+DEFAULT_APPDATA_ROOT = (
+    Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    / "carbonpaper"
+)
+DEFAULT_SEED = "carbonpaper-bge-v1"
+CPU_MIN_COSINE = 0.99999
+CPU_MAX_ABS_ERROR = 1e-4
+DIRECTML_MIN_COSINE = 0.999
+DIRECTML_MAX_ABS_ERROR = 1e-3
+MAX_WORKER_RESPONSE_BYTES = 64 * 1024 * 1024
+SEMANTIC_WORKER_MAX_BATCH = 32
+CLASSIFICATION_BRIDGE_MAX_BATCH = 512
+CLASSIFICATION_BRIDGE_CHUNK_SIZE = 32
+
+
+def _memory_snapshot(process: Any) -> dict[str, int]:
+    try:
+        info = process.memory_info()
+    except Exception:
+        return {}
+    return {
+        "private_bytes": int(getattr(info, "private", getattr(info, "vms", 0))),
+        "working_set_bytes": int(getattr(info, "wset", getattr(info, "rss", 0))),
+        "peak_working_set_bytes": int(
+            getattr(info, "peak_wset", getattr(info, "rss", 0))
+        ),
+    }
+
+
+class MemorySampler:
+    def __init__(self, process: Any, interval: float = 0.02) -> None:
+        self.process = process
+        self.interval = interval
+        self._stop = threading.Event()
+        self._peak: dict[str, int] = {}
+        self._thread = threading.Thread(
+            target=self._sample,
+            name="bge-memory-sampler",
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        self._record()
+        self._thread.start()
+
+    def _record(self) -> None:
+        for name, value in _memory_snapshot(self.process).items():
+            self._peak[name] = max(self._peak.get(name, 0), value)
+
+    def _sample(self) -> None:
+        while not self._stop.wait(self.interval):
+            self._record()
+
+    def stop(self) -> dict[str, int]:
+        self._stop.set()
+        self._thread.join(timeout=2)
+        self._record()
+        return dict(self._peak)
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(float(value) for value in values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * percentile / 100.0
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def summarize_values(values: Sequence[float]) -> dict[str, float | int]:
+    finite = [float(value) for value in values]
+    if not finite:
+        return {"count": 0, "mean": 0.0, "p50": 0.0, "p95": 0.0, "p99": 0.0, "max": 0.0}
+    return {
+        "count": len(finite),
+        "mean": statistics.fmean(finite),
+        "p50": _percentile(finite, 50),
+        "p95": _percentile(finite, 95),
+        "p99": _percentile(finite, 99),
+        "max": max(finite),
+    }
+
+
+def _memory_with_deltas(
+    baseline: Mapping[str, int],
+    after_load: Mapping[str, int],
+    peak: Mapping[str, int],
+) -> dict[str, Any]:
+    keys = sorted(set(baseline) | set(after_load) | set(peak))
+    return {
+        "baseline": dict(baseline),
+        "after_model_load": dict(after_load),
+        "peak": dict(peak),
+        "model_load_delta": {
+            key: int(after_load.get(key, 0)) - int(baseline.get(key, 0)) for key in keys
+        },
+        "peak_delta": {
+            key: int(peak.get(key, 0)) - int(baseline.get(key, 0)) for key in keys
+        },
+    }
+
+
+def _configure_python_environment(
+    model_root: Path,
+    provider: str,
+    dml_device_id: int,
+) -> None:
+    os.environ.update(
+        {
+            "CARBONPAPER_CLASSIFICATION_RUNTIME": "python",
+            "CARBONPAPER_USE_ONNX": "1",
+            "CARBONPAPER_USE_DML": "1" if provider == "directml" else "0",
+            "CARBONPAPER_DML_DEVICE_ID": str(dml_device_id),
+            "CARBONPAPER_ONNX_LOAD_MODE": "buffer",
+            "BGE_MODEL_PATH": str(model_root / "bge-small-zh-v1.5"),
+            "DO_NOT_TRACK": "1",
+            "HF_HUB_DISABLE_TELEMETRY": "1",
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+        }
+    )
+
+
+def _reset_text_embedder(classifier: Any) -> None:
+    classifier.TextEmbedder._instance = None
+    classifier.TextEmbedder._model = None
+    classifier.TextEmbedder._tokenizer = None
+    classifier.TextEmbedder._is_onnx = False
+    classifier.TextEmbedder._initialized = False
+    classifier.TextEmbedder._selected_runtime = None
+    classifier.TextEmbedder._last_backend = None
+
+
+def _repeat_to_size(texts: Sequence[str], size: int) -> list[str]:
+    if not texts:
+        raise ValueError("benchmark text corpus is empty")
+    return [texts[index % len(texts)] for index in range(size)]
+
+
+def _python_encode_timed(
+    embedder: Any, texts: Sequence[str]
+) -> tuple[Any, dict[str, float]]:
+    import numpy as np
+
+    from onnx_utils import build_transformer_inputs
+
+    started = time.perf_counter()
+    encoded = embedder._tokenizer(
+        list(texts),
+        padding=True,
+        truncation=True,
+        max_length=512,
+        return_tensors="np",
+    )
+    preprocess_ms = (time.perf_counter() - started) * 1000.0
+    inference_started = time.perf_counter()
+    inputs = build_transformer_inputs(embedder._model, encoded)
+    last_hidden_state = embedder._model.run(None, inputs)[0]
+    vectors = np.asarray(last_hidden_state[:, 0, :], dtype=np.float32)
+    norm = np.linalg.norm(vectors, axis=1, keepdims=True)
+    vectors = vectors / np.clip(norm, a_min=1e-9, a_max=None)
+    inference_ms = (time.perf_counter() - inference_started) * 1000.0
+    return vectors, {
+        "preprocess_ms": preprocess_ms,
+        "inference_ms": inference_ms,
+        "wall_ms": (time.perf_counter() - started) * 1000.0,
+    }
+
+
+def _benchmark_python_runner(payload: Mapping[str, Any]) -> dict[str, Any]:
+    import psutil
+
+    process = psutil.Process()
+    process_start_baseline = _memory_snapshot(process)
+    import_sampler = MemorySampler(process)
+    import_sampler.start()
+    import_started = time.perf_counter()
+    if str(MONITOR_DIR) not in sys.path:
+        sys.path.insert(0, str(MONITOR_DIR))
+    _configure_python_environment(
+        Path(str(payload["model_root"])),
+        str(payload["provider"]),
+        int(payload["dml_device_id"]),
+    )
+    import classifier
+    import numpy as np
+    import onnxruntime as ort
+
+    module_import_ms = (time.perf_counter() - import_started) * 1000.0
+    runtime_ready_baseline = _memory_snapshot(process)
+    runtime_import_peak = import_sampler.stop()
+    sampler = MemorySampler(process)
+    sampler.start()
+    _reset_text_embedder(classifier)
+    embedder = classifier.TextEmbedder()
+    load_started = time.perf_counter()
+    embedder.initialize()
+    model_load_ms = (time.perf_counter() - load_started) * 1000.0
+    if not embedder._is_onnx:
+        raise RuntimeError("Python benchmark unexpectedly loaded the PyTorch BGE model")
+    after_load = _memory_snapshot(process)
+
+    texts = [str(text) for text in payload["texts"]]
+    first_texts = _repeat_to_size(texts, int(payload["first_batch_size"]))
+    _, first = _python_encode_timed(embedder, first_texts)
+    result: dict[str, Any] = {
+        "module_import_ms": module_import_ms,
+        "model_load_ms": model_load_ms,
+        "cold_inference": first,
+        "providers": list(embedder._model.get_providers()),
+        "onnxruntime_version": ort.__version__,
+        "numpy_version": np.__version__,
+    }
+
+    if payload.get("mode") == "full":
+        chunks = []
+        chunk_size = int(payload["correctness_chunk_size"])
+        for offset in range(0, len(texts), chunk_size):
+            vectors, _ = _python_encode_timed(
+                embedder, texts[offset : offset + chunk_size]
+            )
+            chunks.append(vectors)
+        all_vectors = np.concatenate(chunks, axis=0)
+        warm_results = []
+        for batch_size in payload["batch_sizes"]:
+            batch = _repeat_to_size(texts, int(batch_size))
+            for _ in range(int(payload["warmup"])):
+                _python_encode_timed(embedder, batch)
+            iterations = [
+                _python_encode_timed(embedder, batch)[1]
+                for _ in range(int(payload["iterations"]))
+            ]
+            warm_results.append(
+                {
+                    "batch_size": int(batch_size),
+                    "wall_ms": summarize_values(
+                        [item["wall_ms"] for item in iterations]
+                    ),
+                    "preprocess_ms": summarize_values(
+                        [item["preprocess_ms"] for item in iterations]
+                    ),
+                    "inference_ms": summarize_values(
+                        [item["inference_ms"] for item in iterations]
+                    ),
+                }
+            )
+        result["warm_batches"] = warm_results
+        result["vectors"] = all_vectors.tolist()
+
+    peak = sampler.stop()
+    result["memory"] = _memory_with_deltas(runtime_ready_baseline, after_load, peak)
+    result["memory"]["process_start_baseline"] = process_start_baseline
+    result["memory"]["runtime_import_delta"] = {
+        key: int(runtime_ready_baseline.get(key, 0))
+        - int(process_start_baseline.get(key, 0))
+        for key in sorted(set(process_start_baseline) | set(runtime_ready_baseline))
+    }
+    result["memory"]["runtime_import_peak"] = runtime_import_peak
+    return result
+
+
+def _run_internal_python_runner() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        result = _benchmark_python_runner(payload)
+        json.dump(result, sys.stdout, ensure_ascii=True, separators=(",", ":"))
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+        return 0
+    except Exception as error:  # noqa: BLE001 - isolated runner reports to parent
+        print(f"Python BGE runner failed: {error}", file=sys.stderr)
+        return 2
+
+
+def _run_python_process(payload: Mapping[str, Any], timeout: float) -> dict[str, Any]:
+    completed = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), "--_python-runner"],
+        input=json.dumps(payload, ensure_ascii=False),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=REPO_ROOT,
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        diagnostics = "\n".join(completed.stderr.splitlines()[-30:])
+        raise RuntimeError(
+            f"Python BGE runner exited with {completed.returncode}:\n{diagnostics}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("Python BGE runner returned invalid JSON") from error
+
+
+def _resolve_exporter(explicit: Path | None, build: bool) -> Path:
+    if explicit:
+        path = explicit.resolve()
+    else:
+        path = TAURI_DIR / "target" / "debug" / "examples" / "bge_benchmark_export.exe"
+    if build:
+        subprocess.run(
+            [
+                "cargo",
+                "build",
+                "--quiet",
+                "--manifest-path",
+                str(TAURI_DIR / "Cargo.toml"),
+                "--example",
+                "bge_benchmark_export",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+        )
+    if not path.is_file():
+        raise FileNotFoundError(f"BGE benchmark exporter was not found: {path}")
+    return path
+
+
+def _extract_samples(args: argparse.Namespace) -> dict[str, Any]:
+    exporter = _resolve_exporter(args.exporter, not args.no_build_exporter)
+    command = [
+        str(exporter),
+        "--data-dir",
+        str(args.data_dir.resolve()),
+        "--sample-size",
+        str(args.sample_size),
+        "--seed",
+        args.seed,
+        "--max-ocr-chars",
+        str(args.max_ocr_chars),
+    ]
+    sample_ids = args.sample_ids
+    if args.reuse_report:
+        report = json.loads(args.reuse_report.read_text(encoding="utf-8"))
+        sample_ids = ",".join(str(value) for value in report["dataset"]["sample_ids"])
+    if sample_ids:
+        command.extend(("--sample-ids", sample_ids))
+    completed = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=REPO_ROOT,
+        timeout=args.timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        diagnostics = completed.stderr.decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"BGE data exporter exited with {completed.returncode}:\n"
+            + "\n".join(diagnostics.splitlines()[-30:])
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        # Never include stdout here: it may contain a partially emitted plaintext payload.
+        raise RuntimeError("BGE data exporter returned invalid JSON") from error
+
+
+class BenchmarkSemanticWorker:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        from validate_rust_semantic import SemanticWorker
+
+        self._worker = SemanticWorker(*args, **kwargs)
+        self.process = self._worker.process
+
+    def read_response(self) -> Mapping[str, Any]:
+        from validate_rust_semantic import _read_exact
+
+        stream = self.process.stdout
+        assert stream is not None
+        try:
+            length = int.from_bytes(_read_exact(stream, 4), "little")
+            if length <= 0 or length > MAX_WORKER_RESPONSE_BYTES:
+                raise ValueError(f"invalid semantic response frame length: {length}")
+            response = json.loads(_read_exact(stream, length))
+        except Exception as error:
+            diagnostics = self._worker._diagnostics()
+            raise RuntimeError(
+                f"failed to read semantic response: {error}{diagnostics}"
+            ) from error
+        if not isinstance(response, Mapping):
+            raise RuntimeError("semantic response is not an object")
+        return response
+
+    def request(
+        self, command: str, *, body: bytes = b"", **fields: Any
+    ) -> Mapping[str, Any]:
+        if self.process.poll() is not None:
+            raise RuntimeError("semantic worker exited before the request")
+        self._worker._request_id += 1
+        request_id = self._worker._request_id
+        request = {"command": command, "request_id": request_id, **fields}
+        payload = json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        stream = self.process.stdin
+        assert stream is not None
+        stream.write(len(payload).to_bytes(4, "little"))
+        stream.write(payload)
+        if body:
+            stream.write(body)
+        stream.flush()
+        response = self.read_response()
+        if response.get("status") == "error":
+            raise RuntimeError(
+                f"semantic request {command} failed: {response.get('kind')}: "
+                f"{response.get('message')}"
+            )
+        if response.get("request_id") != request_id:
+            raise RuntimeError("semantic response request id mismatch")
+        return response
+
+    def close(self) -> None:
+        if self.process.poll() is None:
+            try:
+                response = self.request("shutdown")
+                if response.get("status") != "shutting_down":
+                    raise RuntimeError("unexpected semantic shutdown response")
+                self.process.wait(timeout=10)
+            except Exception:
+                self.process.kill()
+                self.process.wait(timeout=10)
+                raise
+
+    def kill(self) -> None:
+        self._worker.kill()
+
+
+@contextlib.contextmanager
+def _temporary_environment(values: Mapping[str, str | None]) -> Iterable[None]:
+    previous = {name: os.environ.get(name) for name in values}
+    try:
+        for name, value in values.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _resolve_worker_paths(args: argparse.Namespace) -> tuple[Path, Path, Path, Path]:
+    from validate_rust_semantic import _default_ort_dylib, _default_worker
+
+    worker = args.worker.resolve() if args.worker else _default_worker()
+    ort_dylib = args.ort_dylib.resolve() if args.ort_dylib else _default_ort_dylib()
+    models_root = args.models_root.resolve()
+    onnx_models_root = args.onnx_models_root.resolve()
+    if not onnx_models_root.is_dir():
+        onnx_models_root = models_root
+    return worker, ort_dylib, models_root, onnx_models_root
+
+
+def _start_worker(
+    args: argparse.Namespace,
+) -> tuple[BenchmarkSemanticWorker, Mapping[str, Any], float]:
+    worker_path, ort_dylib, models_root, onnx_models_root = _resolve_worker_paths(args)
+    started = time.perf_counter()
+    worker = BenchmarkSemanticWorker(
+        worker_path,
+        ort_dylib,
+        models_root,
+        onnx_models_root,
+        args.provider,
+        args.dml_device_id,
+    )
+    ready = worker.read_response()
+    startup_ms = (time.perf_counter() - started) * 1000.0
+    expected_provider = "direct_ml" if args.provider == "directml" else "cpu"
+    if (
+        ready.get("status") != "semantic_ready"
+        or ready.get("provider") != expected_provider
+    ):
+        worker.kill()
+        raise RuntimeError(f"unexpected semantic worker handshake: {ready!r}")
+    return worker, ready, startup_ms
+
+
+def _rust_embed_timed(
+    worker: BenchmarkSemanticWorker,
+    texts: Sequence[str],
+) -> tuple[Any, dict[str, float]]:
+    import numpy as np
+
+    if not 1 <= len(texts) <= SEMANTIC_WORKER_MAX_BATCH:
+        raise ValueError(
+            f"Rust semantic worker batches must contain 1..={SEMANTIC_WORKER_MAX_BATCH} texts"
+        )
+    started = time.perf_counter()
+    response = worker.request(
+        "embed_text",
+        model="bge_small_zh",
+        texts=list(texts),
+        timeout_ms=10 * 60 * 1000,
+    )
+    wall_ms = (time.perf_counter() - started) * 1000.0
+    vectors = np.asarray(response["vectors"], dtype=np.float32)
+    timings = dict(response.get("timings") or {})
+    timings["wall_ms"] = wall_ms
+    return vectors, {name: float(value) for name, value in timings.items()}
+
+
+def _benchmark_rust_once(
+    args: argparse.Namespace,
+    texts: Sequence[str],
+    mode: str,
+) -> tuple[dict[str, Any], Any | None]:
+    import numpy as np
+    import psutil
+
+    env_value = None if args.rust_intra_threads == 0 else str(args.rust_intra_threads)
+    with _temporary_environment({"CARBONPAPER_ONNX_INTRA_THREADS": env_value}):
+        worker, ready, startup_ms = _start_worker(args)
+        process = psutil.Process(worker.process.pid)
+        baseline = _memory_snapshot(process)
+        sampler = MemorySampler(process)
+        sampler.start()
+        completed = False
+        try:
+            first_texts = _repeat_to_size(texts, args.batch_sizes[0])
+            _, first = _rust_embed_timed(worker, first_texts)
+            after_load = _memory_snapshot(process)
+            result: dict[str, Any] = {
+                "worker_startup_ms": startup_ms,
+                "cold_inference": first,
+                "worker_version": ready.get("worker_version"),
+                "onnxruntime_version": ready.get("ort_version"),
+                "provider": ready.get("provider"),
+            }
+            vectors = None
+            if mode == "full":
+                chunks = []
+                for offset in range(0, len(texts), args.correctness_chunk_size):
+                    chunk, _ = _rust_embed_timed(
+                        worker, texts[offset : offset + args.correctness_chunk_size]
+                    )
+                    chunks.append(chunk)
+                vectors = np.concatenate(chunks, axis=0)
+                warm_results = []
+                for batch_size in args.batch_sizes:
+                    batch = _repeat_to_size(texts, batch_size)
+                    for _ in range(args.warmup):
+                        _rust_embed_timed(worker, batch)
+                    iterations = [
+                        _rust_embed_timed(worker, batch)[1]
+                        for _ in range(args.iterations)
+                    ]
+                    names = sorted({name for item in iterations for name in item})
+                    warm_results.append(
+                        {
+                            "batch_size": batch_size,
+                            **{
+                                name: summarize_values(
+                                    [item.get(name, 0.0) for item in iterations]
+                                )
+                                for name in names
+                            },
+                        }
+                    )
+                result["warm_batches"] = warm_results
+            peak = sampler.stop()
+            result["memory"] = _memory_with_deltas(baseline, after_load, peak)
+            completed = True
+            return result, vectors
+        finally:
+            if not completed:
+                with contextlib.suppress(Exception):
+                    sampler.stop()
+            if worker.process.poll() is None:
+                if completed:
+                    worker.close()
+                else:
+                    worker.kill()
+
+
+def _cold_summary(runs: Sequence[Mapping[str, Any]], backend: str) -> dict[str, Any]:
+    if backend == "python":
+        load_values = [float(run["model_load_ms"]) for run in runs]
+        startup_values = [float(run["module_import_ms"]) for run in runs]
+    else:
+        load_values = [
+            float(run["cold_inference"].get("model_load_ms", 0.0)) for run in runs
+        ]
+        startup_values = [float(run["worker_startup_ms"]) for run in runs]
+    inference_values = [float(run["cold_inference"]["wall_ms"]) for run in runs]
+    return {
+        "runs": len(runs),
+        "startup_or_import_ms": summarize_values(startup_values),
+        "model_load_ms": summarize_values(load_values),
+        "first_inference_wall_ms": summarize_values(inference_values),
+        "load_plus_first_inference_ms": summarize_values(
+            [load + inference for load, inference in zip(load_values, inference_values)]
+        ),
+    }
+
+
+def _run_backend_benchmarks(
+    args: argparse.Namespace,
+    texts: Sequence[str],
+) -> tuple[dict[str, Any], Any, Any]:
+    python_payload = {
+        "mode": "full",
+        "model_root": str(args.models_root.resolve()),
+        "provider": args.provider,
+        "dml_device_id": args.dml_device_id,
+        "texts": list(texts),
+        "first_batch_size": args.batch_sizes[0],
+        "batch_sizes": args.batch_sizes,
+        "warmup": args.warmup,
+        "iterations": args.iterations,
+        "correctness_chunk_size": args.correctness_chunk_size,
+    }
+    python_runs = [_run_python_process(python_payload, args.timeout)]
+    python_vectors = python_runs[0].pop("vectors")
+    for _ in range(args.cold_runs - 1):
+        cold_payload = dict(python_payload)
+        cold_payload["mode"] = "cold"
+        python_runs.append(_run_python_process(cold_payload, args.timeout))
+
+    rust_full, rust_vectors = _benchmark_rust_once(args, texts, "full")
+    rust_runs = [rust_full]
+    for _ in range(args.cold_runs - 1):
+        cold, _ = _benchmark_rust_once(args, texts, "cold")
+        rust_runs.append(cold)
+
+    python_report = dict(python_runs[0])
+    rust_report = dict(rust_runs[0])
+    python_report["cold"] = _cold_summary(python_runs, "python")
+    rust_report["cold"] = _cold_summary(rust_runs, "rust")
+    return {"python": python_report, "rust": rust_report}, python_vectors, rust_vectors
+
+
+def compare_embeddings(
+    python_vectors: Any,
+    rust_vectors: Any,
+    provider: str,
+) -> dict[str, Any]:
+    import numpy as np
+
+    left = np.asarray(python_vectors, dtype=np.float32)
+    right = np.asarray(rust_vectors, dtype=np.float32)
+    if left.shape != right.shape or left.ndim != 2:
+        raise ValueError(
+            f"embedding shape mismatch: Python {left.shape}, Rust {right.shape}"
+        )
+    numerator = np.sum(left * right, axis=1)
+    denominator = np.linalg.norm(left, axis=1) * np.linalg.norm(right, axis=1)
+    cosines = numerator / np.clip(denominator, a_min=1e-12, a_max=None)
+    absolute = np.abs(left - right)
+    pairwise_delta = np.abs((left @ left.T) - (right @ right.T))
+    min_cosine = float(np.min(cosines))
+    max_abs = float(np.max(absolute))
+    min_gate = DIRECTML_MIN_COSINE if provider == "directml" else CPU_MIN_COSINE
+    max_gate = DIRECTML_MAX_ABS_ERROR if provider == "directml" else CPU_MAX_ABS_ERROR
+    return {
+        "shape": list(left.shape),
+        "min_cosine": min_cosine,
+        "mean_cosine": float(np.mean(cosines)),
+        "max_abs_error": max_abs,
+        "mean_abs_error": float(np.mean(absolute)),
+        "max_pairwise_cosine_delta": float(np.max(pairwise_delta)),
+        "max_l2_norm_error_python": float(
+            np.max(np.abs(np.linalg.norm(left, axis=1) - 1.0))
+        ),
+        "max_l2_norm_error_rust": float(
+            np.max(np.abs(np.linalg.norm(right, axis=1) - 1.0))
+        ),
+        "gate": {
+            "min_cosine": min_gate,
+            "max_abs_error": max_gate,
+            "passed": min_cosine >= min_gate and max_abs <= max_gate,
+        },
+    }
+
+
+def _build_embedding_texts(samples: Sequence[Mapping[str, Any]]) -> list[str]:
+    texts = []
+    seen = set()
+    for sample in samples:
+        title = str(sample.get("window_title") or "").strip()
+        ocr = str(sample.get("ocr_text") or "").strip()
+        for value in (title, ocr[:200]):
+            if value and value not in seen:
+                seen.add(value)
+                texts.append(value)
+    return texts
+
+
+class RustEmbedderAdapter:
+    def __init__(self, worker: BenchmarkSemanticWorker) -> None:
+        self.worker = worker
+
+    def encode(self, texts: Sequence[str]) -> Any:
+        import numpy as np
+
+        chunks = [
+            _rust_embed_timed(
+                self.worker,
+                texts[offset : offset + CLASSIFICATION_BRIDGE_CHUNK_SIZE],
+            )[0]
+            for offset in range(
+                0, len(texts), CLASSIFICATION_BRIDGE_CHUNK_SIZE
+            )
+        ]
+        if not chunks:
+            return np.zeros((0, 512), dtype=np.float32)
+        return np.concatenate(chunks, axis=0)
+
+    def encode_single(self, text: str) -> Any:
+        return self.encode([text])[0]
+
+
+def _run_classifier_service(
+    classifier: Any,
+    anchors_path: Path,
+    embedder: Any,
+    samples: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    service = classifier.ClassificationService(str(anchors_path))
+    service.embedder = embedder
+    started = time.perf_counter()
+    service._ensure_index()
+    anchor_index_ms = (time.perf_counter() - started) * 1000.0
+    results = []
+    latencies = []
+    for sample in samples:
+        title = str(sample.get("window_title") or "")
+        ocr_text = str(sample.get("ocr_text") or "")
+        process_name = str(sample.get("process_name") or "")
+        classify_started = time.perf_counter()
+        category, confidence = service.classify(title, ocr_text, process_name)
+        latencies.append((time.perf_counter() - classify_started) * 1000.0)
+        debug = service.classify_debug(title, ocr_text, process_name)
+        results.append(
+            {
+                "screenshot_id": int(sample["screenshot_id"]),
+                "category": category,
+                "confidence": float(confidence),
+                "confidence_rounded": round(float(confidence), 4),
+                "debug_category": debug.get("category"),
+                "used_ocr": bool(debug.get("used_ocr", False)),
+                "local_veto_active": bool(debug.get("local_veto_active", False)),
+                "top_order": [
+                    item.get("category") for item in debug.get("top_scores", [])
+                ],
+            }
+        )
+    return {
+        "anchor_index_ms": anchor_index_ms,
+        "anchor_count": int(len(service.anchor_matrix)),
+        "latency_ms": summarize_values(latencies),
+        "rows": results,
+    }
+
+
+def compare_classifications(
+    python_result: Mapping[str, Any],
+    rust_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    python_rows = {int(row["screenshot_id"]): row for row in python_result["rows"]}
+    rust_rows = {int(row["screenshot_id"]): row for row in rust_result["rows"]}
+    if python_rows.keys() != rust_rows.keys():
+        raise ValueError("Python and Rust classification sample ids differ")
+    rows = []
+    confidence_deltas = []
+    category_matches = 0
+    branch_matches = 0
+    top_order_matches = 0
+    threshold_crossings = {"0.38": 0, "0.50": 0, "0.55": 0}
+    for screenshot_id in python_rows:
+        left = python_rows[screenshot_id]
+        right = rust_rows[screenshot_id]
+        delta = abs(float(left["confidence"]) - float(right["confidence"]))
+        confidence_deltas.append(delta)
+        category_match = left["category"] == right["category"]
+        branch_match = (
+            left["used_ocr"] == right["used_ocr"]
+            and left["local_veto_active"] == right["local_veto_active"]
+        )
+        top_order_match = left["top_order"] == right["top_order"]
+        category_matches += int(category_match)
+        branch_matches += int(branch_match)
+        top_order_matches += int(top_order_match)
+        crossed = []
+        for threshold in (0.38, 0.50, 0.55):
+            if (float(left["confidence"]) >= threshold) != (
+                float(right["confidence"]) >= threshold
+            ):
+                key = f"{threshold:.2f}"
+                threshold_crossings[key] += 1
+                crossed.append(key)
+        rows.append(
+            {
+                "screenshot_id": screenshot_id,
+                "python_category": left["category"],
+                "rust_category": right["category"],
+                "python_confidence": left["confidence_rounded"],
+                "rust_confidence": right["confidence_rounded"],
+                "confidence_abs_delta": delta,
+                "category_match": category_match,
+                "branch_match": branch_match,
+                "top_order_match": top_order_match,
+                "threshold_crossings": crossed,
+            }
+        )
+    count = len(rows)
+    summary = {
+        "sample_count": count,
+        "category_agreement": category_matches / count if count else 0.0,
+        "branch_agreement": branch_matches / count if count else 0.0,
+        "top_order_agreement": top_order_matches / count if count else 0.0,
+        "confidence_abs_delta": summarize_values(confidence_deltas),
+        "threshold_crossings": threshold_crossings,
+        "passed": bool(count)
+        and category_matches == count
+        and branch_matches == count
+        and not any(threshold_crossings.values()),
+    }
+    return {
+        "summary": summary,
+        "python_timing": {
+            "anchor_index_ms": python_result["anchor_index_ms"],
+            "anchor_count": python_result["anchor_count"],
+            "latency_ms": python_result["latency_ms"],
+        },
+        "rust_timing": {
+            "anchor_index_ms": rust_result["anchor_index_ms"],
+            "anchor_count": rust_result["anchor_count"],
+            "latency_ms": rust_result["latency_ms"],
+        },
+        "rows": rows,
+    }
+
+
+def _classification_operational_contract(anchor_count: int) -> dict[str, Any]:
+    if anchor_count < 0:
+        raise ValueError("anchor count cannot be negative")
+
+    bridge_request_compatible = 1 <= anchor_count <= CLASSIFICATION_BRIDGE_MAX_BATCH
+    worker_chunk_compatible = (
+        1 <= CLASSIFICATION_BRIDGE_CHUNK_SIZE <= SEMANTIC_WORKER_MAX_BATCH
+    )
+    if CLASSIFICATION_BRIDGE_CHUNK_SIZE > 0:
+        required_worker_request_count = (
+            anchor_count + CLASSIFICATION_BRIDGE_CHUNK_SIZE - 1
+        ) // CLASSIFICATION_BRIDGE_CHUNK_SIZE
+        max_worker_request_batch = min(
+            anchor_count, CLASSIFICATION_BRIDGE_CHUNK_SIZE
+        )
+    else:
+        required_worker_request_count = 0
+        max_worker_request_batch = 0
+    return {
+        "classification_bridge_max_batch": CLASSIFICATION_BRIDGE_MAX_BATCH,
+        "classification_bridge_chunk_size": CLASSIFICATION_BRIDGE_CHUNK_SIZE,
+        "semantic_worker_max_batch": SEMANTIC_WORKER_MAX_BATCH,
+        "anchor_count": anchor_count,
+        "required_worker_request_count": required_worker_request_count,
+        "max_worker_request_batch": max_worker_request_batch,
+        "production_bridge_request_compatible": bridge_request_compatible,
+        "production_worker_chunk_compatible": worker_chunk_compatible,
+        "production_batch_contract_compatible": (
+            bridge_request_compatible and worker_chunk_compatible
+        ),
+    }
+
+
+def _run_classification_comparison(
+    args: argparse.Namespace,
+    samples: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    if str(MONITOR_DIR) not in sys.path:
+        sys.path.insert(0, str(MONITOR_DIR))
+    _configure_python_environment(
+        args.models_root.resolve(), args.provider, args.dml_device_id
+    )
+    import classifier
+
+    _reset_text_embedder(classifier)
+    python_embedder = classifier.TextEmbedder()
+    python_embedder.initialize()
+    env_value = None if args.rust_intra_threads == 0 else str(args.rust_intra_threads)
+    with tempfile.TemporaryDirectory(prefix="carbonpaper-bge-benchmark-") as temp_dir:
+        temp_root = Path(temp_dir)
+        python_anchors = temp_root / "python" / "anchors.json"
+        rust_anchors = temp_root / "rust" / "anchors.json"
+        python_anchors.parent.mkdir()
+        rust_anchors.parent.mkdir()
+        shutil.copy2(args.data_dir / "anchors.json", python_anchors)
+        shutil.copy2(args.data_dir / "anchors.json", rust_anchors)
+        python_result = _run_classifier_service(
+            classifier, python_anchors, python_embedder, samples
+        )
+        with _temporary_environment({"CARBONPAPER_ONNX_INTRA_THREADS": env_value}):
+            worker, _, _ = _start_worker(args)
+            completed = False
+            try:
+                rust_result = _run_classifier_service(
+                    classifier,
+                    rust_anchors,
+                    RustEmbedderAdapter(worker),
+                    samples,
+                )
+                completed = True
+            finally:
+                if worker.process.poll() is None:
+                    if completed:
+                        worker.close()
+                    else:
+                        worker.kill()
+    result = compare_classifications(python_result, rust_result)
+    anchor_count = int(rust_result["anchor_count"])
+    result["operational_contract"] = _classification_operational_contract(
+        anchor_count
+    )
+    del python_result, rust_result, python_embedder
+    _reset_text_embedder(classifier)
+    gc.collect()
+    return result
+
+
+def _length_summary(values: Sequence[str]) -> dict[str, float | int]:
+    return summarize_values([float(len(value)) for value in values])
+
+
+def _model_fingerprint(model_root: Path) -> dict[str, Any]:
+    candidates = (
+        model_root / "bge-small-zh-v1.5" / "model_int8.onnx",
+        model_root / "bge-small-zh-v1.5" / "onnx" / "model_quantized.onnx",
+    )
+    model_path = next((path for path in candidates if path.is_file()), None)
+    if model_path is None:
+        raise FileNotFoundError("BGE ONNX model was not found under the model root")
+    digest = hashlib.sha256()
+    with model_path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return {
+        "relative_path": model_path.relative_to(model_root).as_posix(),
+        "size_bytes": model_path.stat().st_size,
+        "sha256": digest.hexdigest(),
+    }
+
+
+def _performance_comparison(performance: Mapping[str, Any]) -> list[dict[str, Any]]:
+    python_batches = {
+        int(item["batch_size"]): item for item in performance["python"]["warm_batches"]
+    }
+    rust_batches = {
+        int(item["batch_size"]): item for item in performance["rust"]["warm_batches"]
+    }
+    rows = []
+    for batch_size in sorted(python_batches.keys() & rust_batches.keys()):
+        python_p50 = float(python_batches[batch_size]["wall_ms"]["p50"])
+        rust_p50 = float(rust_batches[batch_size]["wall_ms"]["p50"])
+        rows.append(
+            {
+                "batch_size": batch_size,
+                "python_wall_p50_ms": python_p50,
+                "rust_wall_p50_ms": rust_p50,
+                "rust_speedup": python_p50 / rust_p50 if rust_p50 else None,
+            }
+        )
+    return rows
+
+
+def _format_bytes(value: float | int) -> str:
+    size = float(value)
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if abs(size) < 1024.0 or unit == "GiB":
+            return f"{size:.2f} {unit}"
+        size /= 1024.0
+    return f"{size:.2f} GiB"
+
+
+def _markdown_report(report: Mapping[str, Any]) -> str:
+    numeric = report["numeric_parity"]
+    classification = report.get("classification")
+    lines = [
+        "# BGE Python/Rust benchmark",
+        "",
+        f"- Corpus SHA-256: `{report['dataset']['corpus_sha256']}`",
+        f"- Samples: {report['dataset']['sample_count']}",
+        f"- Embedding inputs: {report['dataset']['embedding_input_count']}",
+        f"- Provider: `{report['environment']['provider']}`",
+        f"- Numeric gate: {'PASS' if numeric['gate']['passed'] else 'FAIL'}",
+        "",
+        "## Numeric parity",
+        "",
+        "| Metric | Value |",
+        "| --- | ---: |",
+        f"| Minimum cosine | {numeric['min_cosine']:.9f} |",
+        f"| Maximum absolute error | {numeric['max_abs_error']:.9g} |",
+        f"| Maximum pairwise cosine delta | {numeric['max_pairwise_cosine_delta']:.9g} |",
+        "",
+        "## Warm inference",
+        "",
+        "| Batch | Python p50 | Rust p50 | Rust speedup |",
+        "| ---: | ---: | ---: | ---: |",
+    ]
+    for row in report["performance_comparison"]:
+        speedup = row["rust_speedup"]
+        lines.append(
+            f"| {row['batch_size']} | {row['python_wall_p50_ms']:.3f} ms | "
+            f"{row['rust_wall_p50_ms']:.3f} ms | "
+            f"{speedup:.3f}x |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Memory",
+            "",
+            "| Backend | Model-load private delta | Peak private delta |",
+            "| --- | ---: | ---: |",
+        ]
+    )
+    for backend in ("python", "rust"):
+        memory = report["performance"][backend]["memory"]
+        lines.append(
+            f"| {backend.title()} | "
+            f"{_format_bytes(memory['model_load_delta']['private_bytes'])} | "
+            f"{_format_bytes(memory['peak_delta']['private_bytes'])} |"
+        )
+    if classification:
+        summary = classification["summary"]
+        operational = classification["operational_contract"]
+        lines.extend(
+            [
+                "",
+                "## Classification",
+                "",
+                "| Metric | Value |",
+                "| --- | ---: |",
+                f"| Category agreement | {summary['category_agreement']:.4%} |",
+                f"| OCR/veto branch agreement | {summary['branch_agreement']:.4%} |",
+                f"| Top-order agreement | {summary['top_order_agreement']:.4%} |",
+                f"| Confidence delta p95 | {summary['confidence_abs_delta']['p95']:.9g} |",
+                f"| Confidence delta max | {summary['confidence_abs_delta']['max']:.9g} |",
+                f"| Threshold crossings | {sum(summary['threshold_crossings'].values())} |",
+                f"| Classification gate | {'PASS' if summary['passed'] else 'FAIL'} |",
+                f"| Production batch contract | {'PASS' if operational['production_batch_contract_compatible'] else 'FAIL'} |",
+                "",
+                f"The production classification bridge accepts up to {operational['classification_bridge_max_batch']} texts "
+                f"and submits chunks of at most {operational['classification_bridge_chunk_size']} to a semantic worker "
+                f"whose request limit is {operational['semantic_worker_max_batch']}. This run's anchor index contains "
+                f"{operational['anchor_count']} texts and requires {operational['required_worker_request_count']} worker "
+                f"requests; the largest contains {operational['max_worker_request_batch']} texts.",
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "Plaintext titles, OCR text, process names, embeddings, and keys are not stored in this report.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def assert_report_has_no_plaintext_payloads(report: Mapping[str, Any]) -> None:
+    forbidden_keys = {
+        "window_title",
+        "ocr_text",
+        "process_name",
+        "vectors",
+        "embeddings",
+    }
+
+    def visit(value: Any, location: str) -> None:
+        if isinstance(value, Mapping):
+            for key, child in value.items():
+                if key in forbidden_keys:
+                    raise ValueError(
+                        f"plaintext or vector field reached report at {location}.{key}"
+                    )
+                visit(child, f"{location}.{key}")
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                visit(child, f"{location}[{index}]")
+
+    visit(report, "report")
+
+
+def _parse_batch_sizes(raw: str) -> list[int]:
+    try:
+        values = [int(value.strip()) for value in raw.split(",") if value.strip()]
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "batch sizes must be comma-separated integers"
+        ) from error
+    if not values or any(
+        value <= 0 or value > SEMANTIC_WORKER_MAX_BATCH for value in values
+    ):
+        raise argparse.ArgumentTypeError(
+            f"batch sizes must be between 1 and {SEMANTIC_WORKER_MAX_BATCH}"
+        )
+    return list(dict.fromkeys(values))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
+    parser.add_argument("--sample-size", type=int, default=100)
+    parser.add_argument("--seed", default=DEFAULT_SEED)
+    parser.add_argument("--sample-ids", help="Comma-separated screenshot ids to replay")
+    parser.add_argument(
+        "--reuse-report", type=Path, help="Replay sample ids from a prior JSON report"
+    )
+    parser.add_argument("--max-ocr-chars", type=int, default=4096)
+    parser.add_argument(
+        "--models-root", type=Path, default=DEFAULT_APPDATA_ROOT / "models"
+    )
+    parser.add_argument(
+        "--onnx-models-root", type=Path, default=DEFAULT_APPDATA_ROOT / "models-onnx"
+    )
+    parser.add_argument("--provider", choices=("cpu", "directml"), default="cpu")
+    parser.add_argument("--dml-device-id", type=int, default=0)
+    parser.add_argument(
+        "--rust-intra-threads",
+        type=int,
+        default=1,
+        help="Use 1 for a fair comparison with Python; 0 uses the Rust production default",
+    )
+    parser.add_argument(
+        "--batch-sizes", type=_parse_batch_sizes, default=[1, 8, 16, 32]
+    )
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=10)
+    parser.add_argument("--cold-runs", type=int, default=3)
+    parser.add_argument("--correctness-chunk-size", type=int, default=32)
+    parser.add_argument("--worker", type=Path)
+    parser.add_argument("--ort-dylib", type=Path)
+    parser.add_argument("--exporter", type=Path)
+    parser.add_argument("--no-build-exporter", action="store_true")
+    parser.add_argument("--skip-classification", action="store_true")
+    parser.add_argument("--extract-only", action="store_true")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--timeout", type=float, default=10 * 60)
+    args = parser.parse_args()
+    if args.sample_size <= 0:
+        parser.error("--sample-size must be positive")
+    if args.max_ocr_chars < 200:
+        parser.error("--max-ocr-chars must be at least 200")
+    if args.dml_device_id < 0 or args.rust_intra_threads < 0:
+        parser.error("device id and thread count cannot be negative")
+    if args.warmup < 0 or args.iterations <= 0 or args.cold_runs <= 0:
+        parser.error(
+            "warmup must be non-negative; iterations and cold-runs must be positive"
+        )
+    if not 1 <= args.correctness_chunk_size <= SEMANTIC_WORKER_MAX_BATCH:
+        parser.error(
+            f"--correctness-chunk-size must be between 1 and {SEMANTIC_WORKER_MAX_BATCH}"
+        )
+    if args.sample_ids and args.reuse_report:
+        parser.error("use only one of --sample-ids and --reuse-report")
+    return args
+
+
+def _clear_plaintext(samples: list[dict[str, Any]], texts: list[str]) -> None:
+    for sample in samples:
+        for key in ("window_title", "process_name", "ocr_text"):
+            sample[key] = ""
+    samples.clear()
+    for index in range(len(texts)):
+        texts[index] = ""
+    texts.clear()
+    gc.collect()
+
+
+def run(args: argparse.Namespace) -> tuple[Path, Path] | None:
+    if not args.data_dir.is_dir():
+        raise FileNotFoundError(f"data directory does not exist: {args.data_dir}")
+    print("Selecting and decrypting the reproducible local sample in memory...")
+    export = _extract_samples(args)
+    samples = list(export["samples"])
+    texts = _build_embedding_texts(samples)
+    try:
+        dataset = {
+            "seed": export["selection"]["seed"],
+            "corpus_sha256": export["corpus_sha256"],
+            "sample_count": len(samples),
+            "sample_ids": list(export["selection"]["selected_ids"]),
+            "eligible_rows": export["selection"]["eligible_rows"],
+            "skipped_rows": export["selection"]["skipped_rows"],
+            "database_size_bytes": export["database"]["size_bytes"],
+            "database_modified_unix_ns": export["database"]["modified_unix_ns"],
+            "embedding_input_count": len(texts),
+            "title_length": _length_summary(
+                [str(sample.get("window_title") or "") for sample in samples]
+            ),
+            "ocr_length": _length_summary(
+                [str(sample.get("ocr_text") or "") for sample in samples]
+            ),
+            "embedding_input_length": _length_summary(texts),
+        }
+        if args.extract_only:
+            print(
+                f"Extracted {len(samples)} samples; corpus SHA-256 "
+                f"{export['corpus_sha256']}. No plaintext was written to disk."
+            )
+            return None
+        if not texts:
+            raise RuntimeError("decrypted sample did not produce any BGE input text")
+
+        print("Benchmarking isolated Python ONNX and Rust worker runtimes...")
+        performance, python_vectors, rust_vectors = _run_backend_benchmarks(args, texts)
+        numeric = compare_embeddings(python_vectors, rust_vectors, args.provider)
+        del python_vectors, rust_vectors
+
+        classification = None
+        if not args.skip_classification:
+            print(
+                "Comparing production classifier categories, confidence, and branches..."
+            )
+            classification = _run_classification_comparison(args, samples)
+
+        report: dict[str, Any] = {
+            "schema_version": 1,
+            "generated_at_unix_ms": int(time.time() * 1000),
+            "environment": {
+                "platform": platform.platform(),
+                "python": platform.python_version(),
+                "logical_cpu_count": os.cpu_count(),
+                "provider": args.provider,
+                "dml_device_id": args.dml_device_id,
+                "rust_intra_threads": args.rust_intra_threads,
+                "model": _model_fingerprint(args.models_root.resolve()),
+            },
+            "configuration": {
+                "batch_sizes": args.batch_sizes,
+                "warmup": args.warmup,
+                "iterations": args.iterations,
+                "cold_runs": args.cold_runs,
+                "correctness_chunk_size": args.correctness_chunk_size,
+                "max_ocr_chars": args.max_ocr_chars,
+            },
+            "dataset": dataset,
+            "numeric_parity": numeric,
+            "performance": performance,
+            "performance_comparison": _performance_comparison(performance),
+            "classification": classification,
+            "release_gate_passed": bool(numeric["gate"]["passed"])
+            and (
+                classification is None
+                or (
+                    bool(classification["summary"]["passed"])
+                    and bool(
+                        classification["operational_contract"][
+                            "production_batch_contract_compatible"
+                        ]
+                    )
+                )
+            ),
+            "privacy": {
+                "plaintext_written_to_disk": False,
+                "report_contains_embeddings": False,
+                "report_contains_titles_ocr_or_process_names": False,
+            },
+        }
+        output_dir = args.output_dir or args.data_dir.parent / "bge-benchmark-results"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        json_path = output_dir / f"bge-benchmark-{stamp}.json"
+        markdown_path = output_dir / f"bge-benchmark-{stamp}.md"
+        assert_report_has_no_plaintext_payloads(report)
+        json_path.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+        markdown_path.write_text(_markdown_report(report), encoding="utf-8")
+        return json_path, markdown_path
+    finally:
+        _clear_plaintext(samples, texts)
+
+
+def main() -> int:
+    if sys.argv[1:] == ["--_python-runner"]:
+        return _run_internal_python_runner()
+    try:
+        result = run(parse_args())
+    except (
+        FileNotFoundError,
+        RuntimeError,
+        ValueError,
+        subprocess.SubprocessError,
+    ) as error:
+        print(f"BGE benchmark failed: {error}", file=sys.stderr)
+        return 1
+    if result:
+        json_path, markdown_path = result
+        print(f"JSON report: {json_path}")
+        print(f"Markdown report: {markdown_path}")
+        print(
+            "Decrypted database samples were kept in memory only and have been released."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/migration_oracle.py
+++ b/tools/migration_oracle.py
@@ -348,6 +348,10 @@ def _resolve_model_files(model_root: Path, reranker_variant: str) -> Dict[str, P
 def _configure_cpu_onnx(model_root: Path) -> None:
     os.environ["CARBONPAPER_USE_ONNX"] = "1"
     os.environ["CARBONPAPER_USE_DML"] = "0"
+    # The oracle defines the Python side of the migration contract. Production
+    # classification defaults to Rust, so force the legacy embedder here rather
+    # than accidentally calling back into a running application over IPC.
+    os.environ["CARBONPAPER_CLASSIFICATION_RUNTIME"] = "python"
     os.environ["CARBONPAPER_ONNX_LOAD_MODE"] = "buffer"
     os.environ["MODEL_PATH"] = str(model_root)
     os.environ["MINILM_MODEL_PATH"] = str(


### PR DESCRIPTION
## Summary

- route BGE-small-zh-v1.5 classification embeddings through the authenticated Rust semantic worker by default, preserving input order while enforcing the reverse-IPC and semantic-worker batch limits
- add foreground-priority and background-batch scheduling guards, durable OCR post-process deferral, and observable Rust failure versus completed Python-fallback diagnostics
- expose `classification_runtime = rust | python` in Advanced settings, latch the selected runtime at monitor restart, migrate the retired Rust OCR DirectML preference, and honor live game-mode GPU suppression
- add Rust/Python contract tests, privacy-preserving BGE parity and performance benchmark tooling, and update the Python-removal roadmap and localized settings copy

## Notes

- Python still owns anchor loading, scoring, thresholds, learning, and category assignment; this is the Step 10 inference bridge rather than the Milestone 5 classifier port.
- Ordinary Rust inference failures fall back to Python for that request. `foreground_busy` and `background_busy` remain explicit scheduling refusals so Python does not load a competing BGE model while shared semantic work has priority.
- The selected runtime is applied to the monitor child at spawn, so changing the rollback lever takes effect after monitor restart. The benchmark keeps decrypted samples in memory and writes no plaintext titles, OCR, process names, or vectors.
- Release evidence still needs the pinned-model numeric parity, populated-profile category/confidence comparison, latency/memory measurements, and real-profile failure/rollback soak described in the roadmap.