### PR TITLE
fix: real disk usage in storage overview (fixes #162)

### DIFF
--- a/src-tauri/src/analysis.rs
+++ b/src-tauri/src/analysis.rs
@@ -2,6 +2,7 @@
 
 use crate::monitor::MonitorState;
 use crate::resource_utils::file_in_local_appdata;
+use crate::storage::disk_totals_for_path;
 use crate::storage::StorageState;
 use serde::Serialize;
 use std::collections::VecDeque;
@@ -24,6 +25,11 @@ pub struct MemoryPoint {
 }
 
 /// Database and disk storage statistics (images, models, database sizes).
+///
+/// `disk_total_bytes` / `disk_available_bytes` describe the volume hosting the
+/// data directory, not CarbonPaper's own footprint. They are `None` when the
+/// hosting disk cannot be resolved, which the UI renders as "unknown" — a zero
+/// would otherwise be drawn as a full or empty disk.
 #[derive(Debug, Clone, Serialize)]
 pub struct StorageStats {
     pub root_path: String,
@@ -32,6 +38,8 @@ pub struct StorageStats {
     pub images_bytes: u64,
     pub database_bytes: u64,
     pub other_bytes: u64,
+    pub disk_total_bytes: Option<u64>,
+    pub disk_available_bytes: Option<u64>,
     pub cached_at_ms: u64,
 }
 
@@ -146,8 +154,29 @@ fn compute_storage_stats(data_dir: PathBuf) -> Result<StorageStats, String> {
         images_bytes,
         database_bytes,
         other_bytes,
+        // Filled in by `attach_disk_totals` on every request so the figure
+        // never ages with the directory-scan cache.
+        disk_total_bytes: None,
+        disk_available_bytes: None,
         cached_at_ms: now_ms(),
     })
+}
+
+/// Overwrite the disk fields of `stats` with a fresh reading for the volume
+/// hosting `data_dir`.
+///
+/// Directory sizes are cached for `STORAGE_CACHE_TTL` because scanning them
+/// walks the whole tree, but querying the volume is cheap and its result goes
+/// stale as soon as anything else on the machine writes a file. So this runs on
+/// every request, including cache hits. A failed lookup degrades to `None`
+/// rather than failing the whole overview, since the figure is informational.
+async fn attach_disk_totals(stats: &mut StorageStats, data_dir: PathBuf) {
+    let totals = tokio::task::spawn_blocking(move || disk_totals_for_path(&data_dir))
+        .await
+        .unwrap_or(None);
+
+    stats.disk_total_bytes = totals.map(|(total, _)| total);
+    stats.disk_available_bytes = totals.map(|(_, available)| available);
 }
 
 fn get_cached_storage_stats(state: &AnalysisState) -> Option<StorageStats> {
@@ -239,16 +268,6 @@ pub async fn get_analysis_overview(
         history.iter().cloned().collect::<Vec<_>>()
     };
 
-    // If not forcing, try to return cached stats quickly.
-    if !force_storage {
-        if let Some(stats) = get_cached_storage_stats(&state) {
-            return Ok(AnalysisOverview {
-                memory,
-                storage: stats,
-            });
-        }
-    }
-
     // 从 StorageState 获取实际的 data_dir
     let data_dir = storage_state
         .data_dir
@@ -256,10 +275,24 @@ pub async fn get_analysis_overview(
         .unwrap_or_else(|e| e.into_inner())
         .clone();
 
+    // If not forcing, try to return cached stats quickly.
+    if !force_storage {
+        if let Some(mut stats) = get_cached_storage_stats(&state) {
+            attach_disk_totals(&mut stats, data_dir).await;
+            return Ok(AnalysisOverview {
+                memory,
+                storage: stats,
+            });
+        }
+    }
+
     // Perform expensive storage computation on a blocking thread.
-    let stats = tokio::task::spawn_blocking(move || compute_storage_stats(data_dir))
-        .await
-        .map_err(|e| format!("Storage task join error: {}", e))??;
+    let mut stats = tokio::task::spawn_blocking({
+        let data_dir = data_dir.clone();
+        move || compute_storage_stats(data_dir)
+    })
+    .await
+    .map_err(|e| format!("Storage task join error: {}", e))??;
 
     // Update cache under lock.
     {
@@ -272,6 +305,8 @@ pub async fn get_analysis_overview(
             stats: stats.clone(),
         });
     }
+
+    attach_disk_totals(&mut stats, data_dir).await;
 
     Ok(AnalysisOverview {
         memory,

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -27,6 +27,7 @@ pub use derived_index::*;
 pub use derived_migration::*;
 #[allow(unused_imports)]
 pub use image_io::{read_encrypted_image_as_base64, read_image_as_base64};
+pub(crate) use policy::disk_totals_for_path;
 #[allow(unused_imports)]
 pub use semantic_cache::SEMANTIC_CACHE_IDLE_TTL;
 pub use types::*;

--- a/src-tauri/src/storage/policy.rs
+++ b/src-tauri/src/storage/policy.rs
@@ -83,7 +83,10 @@ fn strip_windows_verbatim(path: std::path::PathBuf) -> std::path::PathBuf {
     path
 }
 
-pub(super) fn disk_totals_for_path(path: &Path) -> Option<(u64, u64)> {
+/// Resolve the disk hosting `path` and return its `(total_bytes,
+/// available_bytes)`. Returns `None` when no mount point matches, which
+/// callers must treat as "unknown" rather than "zero free space".
+pub(crate) fn disk_totals_for_path(path: &Path) -> Option<(u64, u64)> {
     let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     let canonical = strip_windows_verbatim(canonical);
     let disks = Disks::new_with_refreshed_list();

--- a/src/components/settings/useStorageManagementController.js
+++ b/src/components/settings/useStorageManagementController.js
@@ -14,10 +14,21 @@ export function useStorageManagementController({ storage, onRefresh, t, monitorS
     const rootPath = storage?.root_path || '';
     const driveLetter = rootPath.charAt(0);
 
+    // The backend reports the two raw facts — capacity and free space — and used
+    // space is their difference. Either one missing means the hosting volume
+    // could not be resolved, so both stay null and the UI reads "unknown"
+    // instead of drawing a zero as an empty disk.
+    const totalSize = storage?.disk_total_bytes ?? null;
+    const availableSize = storage?.disk_available_bytes ?? null;
+    const usedSize =
+      totalSize !== null && availableSize !== null
+        ? Math.max(totalSize - availableSize, 0)
+        : null;
+
     return {
       driveLetter: driveLetter || 'C',
-      totalSize: 500 * 1024 * 1024 * 1024,
-      usedSize: 320 * 1024 * 1024 * 1024,
+      totalSize,
+      usedSize,
     };
   }, [storage]);
 

--- a/src/components/settings/useStorageManagementController.test.js
+++ b/src/components/settings/useStorageManagementController.test.js
@@ -147,4 +147,56 @@ describe('useStorageManagementController', () => {
       policy: { storage_limit: 'unlimited', retention_period: '6months' },
     });
   });
+
+  describe('diskInfo', () => {
+    const GIB = 1024 * 1024 * 1024;
+
+    const renderWithStorage = (storage) => renderHook(() => useStorageManagementController({
+      storage,
+      onRefresh: vi.fn(),
+      t,
+      monitorStatus: 'stopped',
+    }));
+
+    it('derives disk figures from the overview payload instead of a fixed placeholder', () => {
+      const { result } = renderWithStorage({
+        root_path: 'D:/CarbonPaper',
+        disk_total_bytes: 931 * GIB,
+        disk_available_bytes: 412 * GIB,
+      });
+
+      expect(result.current.diskInfo.totalSize).toBe(931 * GIB);
+      expect(result.current.diskInfo.usedSize).toBe(519 * GIB);
+      expect(result.current.diskInfo.driveLetter).toBe('D');
+    });
+
+    it('reports unknown rather than zero when the hosting volume cannot be resolved', () => {
+      const { result } = renderWithStorage({
+        root_path: 'C:/CarbonPaper',
+        disk_total_bytes: null,
+        disk_available_bytes: null,
+      });
+
+      expect(result.current.diskInfo.totalSize).toBeNull();
+      expect(result.current.diskInfo.usedSize).toBeNull();
+    });
+
+    it('shows no capacity before the first overview payload arrives', () => {
+      const { result } = renderWithStorage(null);
+
+      expect(result.current.diskInfo.totalSize).toBeNull();
+      expect(result.current.diskInfo.usedSize).toBeNull();
+      expect(result.current.diskInfo.driveLetter).toBe('C');
+    });
+
+    it('clamps used space to zero when available exceeds total', () => {
+      const { result } = renderWithStorage({
+        root_path: 'C:/CarbonPaper',
+        disk_total_bytes: 100 * GIB,
+        disk_available_bytes: 120 * GIB,
+      });
+
+      expect(result.current.diskInfo.usedSize).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## 问题

存储空间概览中的“硬盘总占用”恒为 320 GB，与实际磁盘无关。

根源在 `useStorageManagementController` 的 `diskInfo`：容量与占用这两个数字是设计阶段的占位常量（固定 500 GiB 总量、320 GiB 已用），从未接过真实数据源。因此无论用户磁盘多大、已用多少，界面都显示 320 GB，环形图外圈也恒定停在 64%。这段常量自设置页面各分区落地时就已存在，属于从未实现的路径，而不是某次改动引入的回归。

后端其实早就具备查询能力：`storage::policy::disk_totals_for_path` 一直在磁盘压力清理中用于判断可用空间。

## 修复

- 将 `disk_totals_for_path` 的可见性放宽至 crate 级别，通过既有的概览接口暴露。
- `get_analysis_overview` 在每次请求时填充磁盘容量，缓存命中的路径同样填充。目录扫描结果缓存五小时是因为遍历整棵目录树代价高昂，但查询卷的开销极小，而且只要机器上任何程序写入文件，这个数字立刻就会过时，所以它不应该跟着目录扫描一起变陈旧。
- 无法识别宿主卷时降级为 `null` 而非 `0`，界面显示为未知，避免把零画成一块空盘。
- 前端改为用后端提供的总容量与可用容量相减得出已用空间。

Fixes #162
