### PR TITLE
feat: add Office document context to snapshots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,17 @@ jobs:
       - name: Build Rust OCR worker
         run: npm run build:ml:release
 
+      - name: Build Office document worker
+        run: npm run build:office:release
+
       - name: Build Rust semantic worker
         run: npm run build:semantic-ml:release
 
       - name: Smoke test bundled Rust OCR runtime
         run: npm run verify:ml-runtime
+
+      - name: Smoke test Office document worker
+        run: npm run verify:office-runtime
 
       - name: Smoke test bundled Rust semantic runtime
         run: npm run verify:semantic-runtime
@@ -140,6 +146,8 @@ jobs:
           node scripts/bump-version.mjs $futureVersion --label ""
           npm run build:ml:release
           npm run verify:ml-runtime
+          npm run build:office:release
+          npm run verify:office-runtime
           npm run build:semantic-ml:release
           npm run verify:semantic-runtime
           npm run tauri -- build --no-bundle

--- a/package.json
+++ b/package.json
@@ -30,9 +30,13 @@
     "build:nmh:release": "node scripts/build-nmh.mjs --release",
     "build:ml": "node scripts/build-ml.mjs",
     "build:ml:release": "node scripts/build-ml.mjs --release",
+    "build:office": "node scripts/build-office.mjs",
+    "build:office:release": "node scripts/build-office.mjs --release",
+    "test:office-nativeom": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/test-office-nativeom.ps1",
     "build:semantic-ml": "node scripts/build-semantic-ml.mjs",
     "build:semantic-ml:release": "node scripts/build-semantic-ml.mjs --release",
     "verify:ml-runtime": "src-tauri\\target\\release\\carbonpaper-ml.exe --verify-models --model-dir src-tauri\\pre-bundle\\ocr-models\\ppocrv5-ch-mobile-r1",
+    "verify:office-runtime": "src-tauri\\target\\release\\carbonpaper-office.exe --probe",
     "verify:semantic-runtime": "node scripts/verify-semantic-runtime.mjs",
     "validate:semantic-runtime": "python tools/validate_rust_semantic.py",
     "prepare:release-assets": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/prepare-release-assets.ps1",
@@ -43,7 +47,7 @@
     "verify:release-bundles": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/verify-release-bundles.ps1",
     "pack:portable": "node scripts/pack-portable.mjs",
     "generate:update-signing-key": "node scripts/generate-update-signing-key.mjs",
-    "tauri:build": "npm run prepare:release-assets && node scripts/build-nmh.mjs --release && npm run build:ml:release && npm run build:semantic-ml:release && npm run verify:ml-runtime && npm run verify:semantic-runtime && tauri build && node scripts/pack-portable.mjs && npm run verify:release-bundles"
+    "tauri:build": "npm run prepare:release-assets && node scripts/build-nmh.mjs --release && npm run build:ml:release && npm run build:office:release && npm run build:semantic-ml:release && npm run verify:ml-runtime && npm run verify:office-runtime && npm run verify:semantic-runtime && tauri build && node scripts/pack-portable.mjs && npm run verify:release-bundles"
   },
   "dependencies": {
     "@tauri-apps/api": "~2.9.0",

--- a/scripts/build-office.mjs
+++ b/scripts/build-office.mjs
@@ -1,0 +1,27 @@
+// Builds the isolated Office COM worker. Tauri bundles Cargo [[bin]] targets
+// for NSIS, while the portable packer reads the binary from target/<profile>.
+import { execFileSync } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import path from 'node:path';
+
+const tauriDir = path.join(process.cwd(), 'src-tauri');
+const isRelease = process.argv.includes('--release');
+const profile = isRelease ? 'release' : 'debug';
+const args = ['build', '--bin', 'carbonpaper-office'];
+if (isRelease) args.push('--release');
+
+console.log(`Building carbonpaper-office (${profile})...`);
+try {
+  execFileSync('cargo', args, { cwd: tauriDir, stdio: 'inherit' });
+} catch {
+  console.error('Failed to build carbonpaper-office');
+  process.exit(1);
+}
+
+const source = path.join(tauriDir, 'target', profile, 'carbonpaper-office.exe');
+if (!existsSync(source)) {
+  console.error(`Office worker not found at ${source}`);
+  process.exit(1);
+}
+rmSync(path.join(tauriDir, 'pre-bundle', 'carbonpaper-office.exe'), { force: true });
+console.log(`Office worker ready at ${source}`);

--- a/scripts/pack-portable.mjs
+++ b/scripts/pack-portable.mjs
@@ -30,7 +30,7 @@ if (!existsSync(mainExe)) {
 }
 filesToPack.push({ src: mainExe, dest: `${productName}.exe` });
 
-for (const binaryName of ['carbonpaper-ml.exe', 'carbonpaper-nmh.exe']) {
+for (const binaryName of ['carbonpaper-ml.exe', 'carbonpaper-office.exe', 'carbonpaper-nmh.exe']) {
   const binaryPath = path.join(releaseDir, binaryName);
   if (!existsSync(binaryPath)) {
     console.error(`Required portable binary not found: ${binaryPath}`);
@@ -59,6 +59,7 @@ if (existsSync(preBundleDir)) {
 
 const requiredPortableEntries = [
   'carbonpaper-ml.exe',
+  'carbonpaper-office.exe',
   'carbonpaper-nmh.exe',
   'carbonpaper-semantic-worker.exe',
   'onnxruntime/1.24.2/onnxruntime.dll',

--- a/scripts/security-guards.cjs
+++ b/scripts/security-guards.cjs
@@ -40,6 +40,7 @@ const COMMAND_TIERS = {
   'commands::storage::storage_get_thumbnail_warmup_status': 'session_required',
   'commands::storage::storage_cancel_thumbnail_warmup': 'session_required',
   'commands::storage::storage_get_screenshot_details': 'session_required',
+  'office_runtime::office_resume_document': 'session_required',
   'commands::storage::storage_delete_screenshot': 'session_required',
   'commands::storage::storage_delete_by_time_range': 'session_required',
   'commands::storage::storage_list_processes': 'session_required',

--- a/scripts/test-office-nativeom.ps1
+++ b/scripts/test-office-nativeom.ps1
@@ -1,0 +1,510 @@
+[CmdletBinding()]
+param(
+    [string]$RootDir,
+    [string]$WorkerPath,
+    [ValidateSet("word", "excel", "power_point")]
+    [string[]]$Applications = @("word", "excel", "power_point")
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+if ([string]::IsNullOrWhiteSpace($RootDir)) {
+    $RootDir = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+} else {
+    $RootDir = (Resolve-Path $RootDir).Path
+}
+
+if ([string]::IsNullOrWhiteSpace($WorkerPath)) {
+    $WorkerPath = Join-Path $RootDir "src-tauri\target\debug\carbonpaper-office.exe"
+}
+$WorkerPath = [System.IO.Path]::GetFullPath($WorkerPath)
+if (-not (Test-Path -LiteralPath $WorkerPath -PathType Leaf)) {
+    throw "Office worker is missing: $WorkerPath. Run npm run build:office first."
+}
+
+if (-not ("CarbonPaper.OfficeProbe.Win32" -as [type])) {
+    Add-Type -TypeDefinition @"
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace CarbonPaper.OfficeProbe {
+    public static class Win32 {
+        private delegate bool EnumChildProc(IntPtr hwnd, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        private static extern bool EnumChildWindows(
+            IntPtr parent,
+            EnumChildProc callback,
+            IntPtr lParam
+        );
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern int GetClassName(
+            IntPtr hwnd,
+            StringBuilder className,
+            int maxCount
+        );
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern int GetWindowText(
+            IntPtr hwnd,
+            StringBuilder text,
+            int maxCount
+        );
+
+        [DllImport("user32.dll")]
+        private static extern uint GetWindowThreadProcessId(
+            IntPtr hwnd,
+            out uint processId
+        );
+
+        [DllImport("user32.dll")]
+        private static extern bool IsWindowVisible(IntPtr hwnd);
+
+        public static long FindChild(long rootHwnd, uint expectedPid, string[] expectedClasses) {
+            long first = 0;
+            int firstPriority = Int32.MaxValue;
+            long visible = 0;
+            int visiblePriority = Int32.MaxValue;
+            EnumChildWindows(new IntPtr(rootHwnd), (hwnd, _) => {
+                uint pid;
+                GetWindowThreadProcessId(hwnd, out pid);
+                if (pid != expectedPid) return true;
+
+                var className = new StringBuilder(256);
+                GetClassName(hwnd, className, className.Capacity);
+                int priority = Array.FindIndex(expectedClasses, candidate => String.Equals(
+                    className.ToString(),
+                    candidate,
+                    StringComparison.OrdinalIgnoreCase
+                ));
+                if (priority < 0) return true;
+
+                if (priority < firstPriority) {
+                    first = hwnd.ToInt64();
+                    firstPriority = priority;
+                }
+                if (IsWindowVisible(hwnd) && priority < visiblePriority) {
+                    visible = hwnd.ToInt64();
+                    visiblePriority = priority;
+                }
+                return true;
+            }, IntPtr.Zero);
+            return visible != 0 ? visible : first;
+        }
+
+        public static string DescribeChildClasses(long rootHwnd, uint expectedPid) {
+            var classes = new List<string>();
+            EnumChildWindows(new IntPtr(rootHwnd), (hwnd, _) => {
+                uint pid;
+                GetWindowThreadProcessId(hwnd, out pid);
+                if (pid != expectedPid) return true;
+
+                var className = new StringBuilder(256);
+                GetClassName(hwnd, className, className.Capacity);
+                var value = className.ToString();
+                if (value.Length > 0 && !classes.Contains(value)) {
+                    classes.Add(value);
+                }
+                return true;
+            }, IntPtr.Zero);
+            return String.Join(", ", classes);
+        }
+
+        public static string WindowTitle(long hwnd) {
+            var title = new StringBuilder(512);
+            GetWindowText(new IntPtr(hwnd), title, title.Capacity);
+            return title.ToString();
+        }
+
+        public static uint WindowPid(long hwnd) {
+            uint pid;
+            GetWindowThreadProcessId(new IntPtr(hwnd), out pid);
+            return pid;
+        }
+    }
+}
+"@
+}
+
+function Read-ExactBytes {
+    param(
+        [Parameter(Mandatory = $true)][System.IO.Stream]$Stream,
+        [Parameter(Mandatory = $true)][int]$Count,
+        [int]$TimeoutMs = 10000
+    )
+
+    $buffer = [byte[]]::new($Count)
+    $offset = 0
+    while ($offset -lt $Count) {
+        $task = $Stream.ReadAsync($buffer, $offset, $Count - $offset)
+        if (-not $task.Wait($TimeoutMs)) {
+            throw "Timed out reading Office worker output"
+        }
+        $read = $task.Result
+        if ($read -le 0) {
+            throw "Office worker closed its output"
+        }
+        $offset += $read
+    }
+    return $buffer
+}
+
+function Read-OfficeFrame {
+    param([Parameter(Mandatory = $true)][System.IO.Stream]$Stream)
+
+    $lengthBytes = Read-ExactBytes -Stream $Stream -Count 4
+    $length = [BitConverter]::ToUInt32($lengthBytes, 0)
+    if ($length -lt 1 -or $length -gt 65536) {
+        throw "Invalid Office worker frame length: $length"
+    }
+    $body = Read-ExactBytes -Stream $Stream -Count ([int]$length)
+    return [Text.Encoding]::UTF8.GetString($body)
+}
+
+function Write-OfficeFrame {
+    param(
+        [Parameter(Mandatory = $true)][System.IO.Stream]$Stream,
+        [Parameter(Mandatory = $true)][string]$Json
+    )
+
+    $body = [Text.Encoding]::UTF8.GetBytes($Json)
+    if ($body.Length -gt 65536) {
+        throw "Office worker request exceeds the 64 KiB protocol limit"
+    }
+    $lengthBytes = [BitConverter]::GetBytes([uint32]$body.Length)
+    $Stream.Write($lengthBytes, 0, $lengthBytes.Length)
+    $Stream.Write($body, 0, $body.Length)
+    $Stream.Flush()
+}
+
+function Wait-OfficeWindowContext {
+    param(
+        [Parameter(Mandatory = $true)][scriptblock]$GetRootHwnd,
+        [Parameter(Mandatory = $true)][string[]]$NativeClasses,
+        [int]$TimeoutMs = 10000
+    )
+
+    $nativeClassLabel = $NativeClasses -join "/"
+    Write-Verbose "Waiting for a stable $nativeClassLabel NativeOM surface"
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
+    $previous = $null
+    $attempt = 0
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $attempt++
+        $rootHwnd = [long](& $GetRootHwnd)
+        if ($rootHwnd -ne 0) {
+            $windowPid = [CarbonPaper.OfficeProbe.Win32]::WindowPid($rootHwnd)
+            $title = [CarbonPaper.OfficeProbe.Win32]::WindowTitle($rootHwnd)
+            $documentHwnd = [CarbonPaper.OfficeProbe.Win32]::FindChild(
+                $rootHwnd,
+                $windowPid,
+                $NativeClasses
+            )
+            if ($windowPid -ne 0 -and $documentHwnd -ne 0 -and -not [string]::IsNullOrEmpty($title)) {
+                $current = "$rootHwnd|$documentHwnd|$windowPid|$title"
+                if ($current -eq $previous) {
+                    Write-Verbose "Found stable $nativeClassLabel surface root=$rootHwnd document=$documentHwnd pid=$windowPid"
+                    return [pscustomobject]@{
+                        RootHwnd = $rootHwnd
+                        DocumentHwnd = $documentHwnd
+                        Pid = $windowPid
+                        Title = $title
+                    }
+                }
+                $previous = $current
+            }
+        }
+        if (($attempt % 5) -eq 0) {
+            Write-Verbose "NativeOM wait attempt=$attempt root=$rootHwnd"
+            if ($attempt -eq 5 -and $rootHwnd -ne 0) {
+                $rootPid = [CarbonPaper.OfficeProbe.Win32]::WindowPid($rootHwnd)
+                $classes = [CarbonPaper.OfficeProbe.Win32]::DescribeChildClasses(
+                    $rootHwnd,
+                    $rootPid
+                )
+                Write-Verbose "NativeOM child classes: $classes"
+            }
+        }
+        Start-Sleep -Milliseconds 200
+    }
+    throw "Office window did not expose a stable $nativeClassLabel NativeOM surface"
+}
+
+function Invoke-OfficeResolution {
+    param(
+        [Parameter(Mandatory = $true)][string]$Application,
+        [Parameter(Mandatory = $true)]$WindowContext,
+        [Parameter(Mandatory = $true)][string]$ExpectedPath
+    )
+
+    Write-Verbose "Starting Office worker for $Application"
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $WorkerPath
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardInput = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $worker = [Diagnostics.Process]::Start($startInfo)
+
+    try {
+        $stdin = $worker.StandardInput.BaseStream
+        $stdout = $worker.StandardOutput.BaseStream
+        $ready = Read-OfficeFrame -Stream $stdout | ConvertFrom-Json
+        if ($ready.status -ne "ready" -or $ready.protocol_version -ne 1) {
+            throw "Office worker returned an invalid handshake"
+        }
+        Write-Verbose "Office worker handshake completed for $Application"
+
+        $request = @{
+            command = "resolve"
+            request_id = 1
+            generation = 1
+            application = $Application
+            root_hwnd = $WindowContext.RootHwnd
+            document_hwnd = $WindowContext.DocumentHwnd
+            pid = $WindowContext.Pid
+            title = $WindowContext.Title
+        } | ConvertTo-Json -Compress
+        Write-OfficeFrame -Stream $stdin -Json $request
+        Write-Verbose "Sent NativeOM resolution request for $Application"
+        $response = Read-OfficeFrame -Stream $stdout | ConvertFrom-Json
+
+        if ($response.status -ne "resolved" -or $null -eq $response.document) {
+            $details = $response | ConvertTo-Json -Compress -Depth 8
+            throw "Office NativeOM resolution failed: $details"
+        }
+        if ($response.document.application -ne $Application) {
+            throw "Office worker returned the wrong application"
+        }
+        if ($response.document.kind -ne "local_file") {
+            throw "Office worker returned $($response.document.kind), expected local_file"
+        }
+
+        $expected = [System.IO.Path]::GetFullPath($ExpectedPath)
+        $actual = [System.IO.Path]::GetFullPath([string]$response.document.locator)
+        if (-not $actual.Equals($expected, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Office locator mismatch: expected $expected, got $actual"
+        }
+
+        Write-Verbose "Resolved $Application document in $($response.elapsed_ms) ms"
+        return [pscustomobject]@{
+            application = $Application
+            display_name = [string]$response.document.display_name
+            kind = [string]$response.document.kind
+            native_hwnd = [long]$WindowContext.DocumentHwnd
+            elapsed_ms = [double]$response.elapsed_ms
+            locator_matches = $true
+        }
+    } finally {
+        if (-not $worker.HasExited) {
+            try { $worker.Kill() } catch {}
+            try { $worker.WaitForExit(3000) | Out-Null } catch {}
+        }
+        $worker.Dispose()
+    }
+}
+
+function Release-ComObject {
+    param($Value)
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+
+function Assert-NoOfficeProcess {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProcessName,
+        [Parameter(Mandatory = $true)][string]$ApplicationName
+    )
+
+    if (Get-Process -Name $ProcessName -ErrorAction SilentlyContinue) {
+        throw "$ApplicationName must be closed before running its NativeOM integration probe"
+    }
+}
+
+function Find-OfficeTemplate {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$Patterns
+    )
+
+    $roots = @(
+        (Join-Path ${env:ProgramFiles} "Microsoft Office\root\Templates"),
+        (Join-Path ${env:ProgramFiles(x86)} "Microsoft Office\root\Templates"),
+        (Join-Path ${env:ProgramFiles} "Microsoft Office\root\Office16\2052"),
+        (Join-Path ${env:ProgramFiles(x86)} "Microsoft Office\root\Office16\2052")
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and (Test-Path -LiteralPath $_) }
+
+    foreach ($root in $roots) {
+        foreach ($pattern in $Patterns) {
+            $match = Get-ChildItem -LiteralPath $root -Recurse -File -Filter $pattern -ErrorAction SilentlyContinue |
+                Select-Object -First 1
+            if ($null -ne $match) {
+                return $match.FullName
+            }
+        }
+    }
+    throw "No installed Office template matched: $($Patterns -join ', ')"
+}
+
+function Test-WordNativeOm {
+    param([Parameter(Mandatory = $true)][string]$TempDir)
+
+    $application = $null
+    $document = $null
+    $window = $null
+    try {
+        Assert-NoOfficeProcess -ProcessName "WINWORD" -ApplicationName "Word"
+        $source = Find-OfficeTemplate -Patterns @("*.dotx", "*.dotm")
+        $path = Join-Path $TempDir "CarbonPaper Word Probe.dotx"
+        [IO.File]::Copy($source, $path, $true)
+        Write-Verbose "Opening Word template copy $path"
+        Write-Verbose "Creating Word automation instance"
+        $application = New-Object -ComObject Word.Application
+        Write-Verbose "Word automation instance created"
+        $application.DisplayAlerts = 0
+        $application.Visible = $true
+        Write-Verbose "Opening Word document"
+        $document = $application.Documents.Open($path, $false, $true)
+        Write-Verbose "Word document opened"
+        $window = $application.ActiveWindow
+        $window.WindowState = 2
+        $context = Wait-OfficeWindowContext -NativeClasses @("_WwG") -GetRootHwnd {
+            [long]$window.Hwnd
+        }
+        return Invoke-OfficeResolution -Application "word" -WindowContext $context -ExpectedPath $path
+    } finally {
+        if ($null -ne $document) {
+            try { $document.Close(0) } catch { Write-Verbose "Word document close failed: $($_.Exception.Message)" }
+        }
+        if ($null -ne $application) {
+            try { $application.Quit() } catch { Write-Verbose "Word application quit failed: $($_.Exception.Message)" }
+        }
+        Release-ComObject $window
+        Release-ComObject $document
+        Release-ComObject $application
+    }
+}
+
+function Test-ExcelNativeOm {
+    param([Parameter(Mandatory = $true)][string]$TempDir)
+
+    $application = $null
+    $workbook = $null
+    try {
+        Assert-NoOfficeProcess -ProcessName "EXCEL" -ApplicationName "Excel"
+        $source = Find-OfficeTemplate -Patterns @("*.xltx", "*.xltm")
+        $path = Join-Path $TempDir "CarbonPaper Excel Probe.xltx"
+        [IO.File]::Copy($source, $path, $true)
+        Write-Verbose "Using Excel template source $source"
+        Write-Verbose "Opening Excel template copy $path"
+        Write-Verbose "Creating Excel automation instance"
+        $application = New-Object -ComObject Excel.Application
+        Write-Verbose "Excel automation instance created"
+        $application.DisplayAlerts = $false
+        $application.Visible = $true
+        Write-Verbose "Opening Excel workbook"
+        # The Editable argument makes Excel open an .xltx as the template
+        # itself; without it Excel creates a new unsaved workbook.
+        $missing = [Type]::Missing
+        $workbook = $application.Workbooks.Open(
+            $path,
+            0,
+            $false,
+            $missing,
+            $missing,
+            $missing,
+            $false,
+            $missing,
+            $missing,
+            $true
+        )
+        Write-Verbose "Excel workbook opened"
+        $application.WindowState = -4140
+        $context = Wait-OfficeWindowContext -NativeClasses @("EXCEL7") -GetRootHwnd {
+            [long]$application.Hwnd
+        }
+        return Invoke-OfficeResolution -Application "excel" -WindowContext $context -ExpectedPath $path
+    } finally {
+        if ($null -ne $workbook) {
+            try { $workbook.Close($false) } catch {}
+        }
+        if ($null -ne $application) {
+            try { $application.Quit() } catch {}
+        }
+        Release-ComObject $workbook
+        Release-ComObject $application
+    }
+}
+
+function Test-PowerPointNativeOm {
+    param([Parameter(Mandatory = $true)][string]$TempDir)
+
+    $application = $null
+    $presentation = $null
+    $window = $null
+    try {
+        Assert-NoOfficeProcess -ProcessName "POWERPNT" -ApplicationName "PowerPoint"
+        $source = Find-OfficeTemplate -Patterns @("*.potx", "*.potm")
+        $path = Join-Path $TempDir "CarbonPaper PowerPoint Probe.potx"
+        [IO.File]::Copy($source, $path, $true)
+        Write-Verbose "Using PowerPoint template source $source"
+        Write-Verbose "Opening PowerPoint template copy $path"
+        Write-Verbose "Creating PowerPoint automation instance"
+        $application = New-Object -ComObject PowerPoint.Application
+        Write-Verbose "PowerPoint automation instance created"
+        $application.Visible = -1
+        Write-Verbose "Opening PowerPoint presentation"
+        $presentation = $application.Presentations.Open($path)
+        Write-Verbose "PowerPoint presentation opened"
+        $window = $application.ActiveWindow
+        $powerPointProcess = Get-Process -Name "POWERPNT" -ErrorAction Stop |
+            Select-Object -First 1
+        $context = Wait-OfficeWindowContext -NativeClasses @("paneClassDC", "mdiClass") -GetRootHwnd {
+            $powerPointProcess.Refresh()
+            [long]$powerPointProcess.MainWindowHandle
+        }
+        return Invoke-OfficeResolution -Application "power_point" -WindowContext $context -ExpectedPath $path
+    } finally {
+        if ($null -ne $presentation) {
+            try { $presentation.Close() } catch {}
+        }
+        if ($null -ne $application) {
+            try { $application.Quit() } catch {}
+        }
+        Release-ComObject $window
+        Release-ComObject $presentation
+        Release-ComObject $application
+    }
+}
+
+$tempRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$tempDir = Join-Path $tempRoot ("carbonpaper-office-nativeom-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+try {
+    $results = foreach ($application in $Applications) {
+        Write-Verbose "Beginning $application NativeOM probe"
+        switch ($application) {
+            "word" { Test-WordNativeOm -TempDir $tempDir }
+            "excel" { Test-ExcelNativeOm -TempDir $tempDir }
+            "power_point" { Test-PowerPointNativeOm -TempDir $tempDir }
+        }
+    }
+    $results | ConvertTo-Json -Compress
+} finally {
+    [GC]::Collect()
+    [GC]::WaitForPendingFinalizers()
+    $resolvedTemp = [System.IO.Path]::GetFullPath($tempDir)
+    if (
+        (Test-Path -LiteralPath $resolvedTemp) -and
+        $resolvedTemp.StartsWith($tempRoot, [StringComparison]::OrdinalIgnoreCase)
+    ) {
+        Remove-Item -LiteralPath $resolvedTemp -Recurse -Force
+    }
+}

--- a/scripts/update-smoke.ps1
+++ b/scripts/update-smoke.ps1
@@ -77,6 +77,28 @@ function Assert-UpdatedRustOcrRuntime {
     }
 }
 
+function Assert-UpdatedOfficeRuntime {
+    param([Parameter(Mandatory = $true)][string]$InstallDir)
+
+    $worker = Join-Path $InstallDir "carbonpaper-office.exe"
+    if (-not (Test-Path -LiteralPath $worker -PathType Leaf)) {
+        throw "Updated installation is missing carbonpaper-office.exe: $worker"
+    }
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $probeOutput = & $worker --probe 2>&1
+        $workerExitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    $probeText = $probeOutput -join "`n"
+    if ($workerExitCode -ne 0 -or $probeText -notmatch '"status"\s*:\s*"ready"' -or $probeText -notmatch '"apartment"\s*:\s*"sta"') {
+        throw "Updated Office worker failed STA probe (exit $workerExitCode): $probeText"
+    }
+}
+
 function Compare-SemVerCore {
     param(
         [Parameter(Mandatory = $true)][string]$Left,
@@ -548,6 +570,7 @@ try {
                     throw "Updated app reported version $($result.current_version), expected $ExpectedAppVersion."
                 }
                 Assert-UpdatedRustOcrRuntime -RepoRoot $repoRoot -InstallDir (Split-Path -Parent $oldExe)
+                Assert-UpdatedOfficeRuntime -InstallDir (Split-Path -Parent $oldExe)
                 if (Test-Path -LiteralPath $updateErrorLog) {
                     $updateError = Get-Content -LiteralPath $updateErrorLog -Raw
                     throw "Update script wrote update_error.log: $updateError"

--- a/scripts/verify-release-assets.mjs
+++ b/scripts/verify-release-assets.mjs
@@ -121,11 +121,17 @@ assertIncludes(buildRs, 'cargo:rerun-if-changed=../aria2c.exe', 'build.rs aria2 
 const tauriConf = JSON.parse(readText(path.join('src-tauri', 'tauri.conf.json')));
 assertEqual(tauriConf.bundle?.resources?.['pre-bundle'], '.', 'Tauri pre-bundle resource mapping');
 assertIncludes(tauriConf.build?.beforeBuildCommand ?? '', 'npm run test:release-assets', 'Tauri release asset build gate');
+assertIncludes(tauriConf.build?.beforeDevCommand ?? '', 'npm run build:office', 'Tauri development Office worker build');
 
 const mlBuild = readText(path.join('scripts', 'build-ml.mjs'));
 assertIncludes(mlBuild, "'carbonpaper-ml.exe'", 'ML worker build output');
 assertIncludes(mlBuild, "path.join(tauriDir, 'target', profile", 'ML worker target destination');
 assertIncludes(mlBuild, "rmSync(path.join(tauriDir, 'pre-bundle', 'carbonpaper-ml.exe')", 'ML worker stale pre-bundle cleanup');
+
+const officeBuild = readText(path.join('scripts', 'build-office.mjs'));
+assertIncludes(officeBuild, "'carbonpaper-office.exe'", 'Office worker build output');
+assertIncludes(officeBuild, "path.join(tauriDir, 'target', profile", 'Office worker target destination');
+assertIncludes(officeBuild, "rmSync(path.join(tauriDir, 'pre-bundle', 'carbonpaper-office.exe')", 'Office worker stale pre-bundle cleanup');
 
 const nmhBuild = readText(path.join('scripts', 'build-nmh.mjs'));
 assertIncludes(nmhBuild, "path.join(tauriDir, 'target', profile", 'NMH target destination');
@@ -139,6 +145,7 @@ const packPortable = readText(path.join('scripts', 'pack-portable.mjs'));
 assertIncludes(packPortable, "const preBundleDir = path.join(tauriDir, 'pre-bundle');", 'portable pre-bundle input');
 assertIncludes(packPortable, 'await walkDir(preBundleDir, \'\');', 'portable recursive pre-bundle packaging');
 assertIncludes(packPortable, "'carbonpaper-ml.exe'", 'portable required ML worker');
+assertIncludes(packPortable, "'carbonpaper-office.exe'", 'portable required Office worker');
 assertIncludes(packPortable, "'carbonpaper-semantic-worker.exe'", 'portable required semantic worker');
 assertIncludes(packPortable, 'onnxruntime/1.24.2/onnxruntime.dll', 'portable semantic ONNX runtime');
 assertIncludes(packPortable, 'ocr-models/ppocrv5-ch-mobile-r1', 'portable required OCR model directory');
@@ -146,20 +153,28 @@ assertIncludes(packPortable, 'ocr-models/ppocrv5-ch-mobile-r1', 'portable requir
 const releaseWorkflow = readText(path.join('.github', 'workflows', 'release.yml'));
 assertIncludes(releaseWorkflow, 'npm run prepare:release-assets', 'release workflow asset preparation');
 assertIncludes(releaseWorkflow, 'npm run build:ml:release', 'release workflow ML worker build');
+assertIncludes(releaseWorkflow, 'npm run build:office:release', 'release workflow Office worker build');
+assertIncludes(releaseWorkflow, 'npm run verify:office-runtime', 'release workflow Office worker smoke test');
 assertIncludes(releaseWorkflow, 'npm run build:semantic-ml:release', 'release workflow semantic worker build');
 assertIncludes(releaseWorkflow, 'npm run verify:semantic-runtime', 'release workflow semantic smoke test');
 assertIncludes(releaseWorkflow, 'npm run test:release-assets', 'release workflow asset verification');
 assertBefore(releaseWorkflow, 'npm run prepare:release-assets', 'Build Tauri draft release', 'release workflow order');
 assertBefore(releaseWorkflow, 'npm run build:ml:release', 'Build Tauri draft release', 'release workflow ML order');
+assertBefore(releaseWorkflow, 'npm run build:office:release', 'Build Tauri draft release', 'release workflow Office order');
 assertBefore(releaseWorkflow, 'npm run build:semantic-ml:release', 'Build Tauri draft release', 'release workflow semantic ML order');
 assertBefore(releaseWorkflow, 'npm run test:release-assets', 'Build Tauri draft release', 'release workflow verification order');
 
 const packageJson = JSON.parse(readText('package.json'));
 assertIncludes(packageJson.scripts?.['tauri:build'] ?? '', 'npm run prepare:release-assets', 'local tauri:build asset preparation');
 assertIncludes(packageJson.scripts?.['tauri:build'] ?? '', 'npm run build:ml:release', 'local tauri:build ML worker preparation');
+assertIncludes(packageJson.scripts?.['tauri:build'] ?? '', 'npm run build:office:release', 'local tauri:build Office worker preparation');
 assertIncludes(packageJson.scripts?.['tauri:build'] ?? '', 'npm run build:semantic-ml:release', 'local tauri:build semantic worker preparation');
 assertIncludes(packageJson.scripts?.['tauri:build'] ?? '', 'npm run verify:semantic-runtime', 'local tauri:build semantic smoke test');
 assertIncludes(packageJson.scripts?.['tauri:build'] ?? '', 'npm run verify:ml-runtime', 'local tauri:build ML worker smoke test');
+assertIncludes(packageJson.scripts?.['tauri:build'] ?? '', 'npm run verify:office-runtime', 'local tauri:build Office worker smoke test');
+assertIncludes(packageJson.scripts?.['build:office'] ?? '', 'scripts/build-office.mjs', 'Office worker development build command');
+assertIncludes(packageJson.scripts?.['build:office:release'] ?? '', 'scripts/build-office.mjs --release', 'Office worker release build command');
+assertIncludes(packageJson.scripts?.['verify:office-runtime'] ?? '', 'carbonpaper-office.exe --probe', 'Office worker verification command');
 assertIncludes(packageJson.scripts?.['verify:ml-runtime'] ?? '', '--verify-models', 'ML worker verification command');
 assertIncludes(packageJson.scripts?.['verify:release-bundles'] ?? '', 'verify-release-bundles.ps1', 'release bundle verification command');
 assertIncludes(packageJson.scripts?.['tauri:build'] ?? '', 'npm run verify:release-bundles', 'local bundle verification gate');

--- a/scripts/verify-release-bundles.ps1
+++ b/scripts/verify-release-bundles.ps1
@@ -49,7 +49,7 @@ try {
     if ($duplicates) {
         throw "Portable bundle contains duplicate entries: $($duplicates.Name -join ', ')"
     }
-    foreach ($required in @("carbonpaper.exe", "carbonpaper-ml.exe", "carbonpaper-nmh.exe", "carbonpaper-semantic-worker.exe")) {
+    foreach ($required in @("carbonpaper.exe", "carbonpaper-ml.exe", "carbonpaper-office.exe", "carbonpaper-nmh.exe", "carbonpaper-semantic-worker.exe")) {
         if (-not $archive.GetEntry($required)) {
             throw "Portable bundle is missing $required"
         }
@@ -110,7 +110,7 @@ if (-not $sevenZip) {
 }
 
 $listing = @(& $sevenZip.Source l $installer)
-foreach ($required in @("carbonpaper-ml.exe", "carbonpaper-nmh.exe", "carbonpaper-semantic-worker.exe")) {
+foreach ($required in @("carbonpaper-ml.exe", "carbonpaper-office.exe", "carbonpaper-nmh.exe", "carbonpaper-semantic-worker.exe")) {
     $count = @($listing | Where-Object { $_ -match ("\s" + [regex]::Escape($required) + "$") }).Count
     if ($count -ne 1) {
         throw "NSIS installer must contain exactly one $required entry; found $count"
@@ -173,6 +173,11 @@ try {
     if ($workerExitCode -ne 0 -or ($output -join "`n") -notmatch '"model_id":"ppocrv5-ch-mobile"') {
         throw "Extracted NSIS Rust OCR runtime verification failed: $($output -join "`n")"
     }
+    $officeWorker = Join-Path $extractDir "carbonpaper-office.exe"
+    $officeOutput = & $officeWorker --probe 2>&1
+    if ($LASTEXITCODE -ne 0 -or ($officeOutput -join "`n") -notmatch '"status"\s*:\s*"ready"' -or ($officeOutput -join "`n") -notmatch '"apartment"\s*:\s*"sta"') {
+        throw "Extracted NSIS Office worker failed STA probe: $($officeOutput -join "`n")"
+    }
 } finally {
     $resolvedExtractDir = [System.IO.Path]::GetFullPath($extractDir)
     if ((Test-Path -LiteralPath $resolvedExtractDir) -and $resolvedExtractDir.StartsWith($tempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
@@ -180,4 +185,4 @@ try {
     }
 }
 
-Write-Host "Portable and NSIS Rust OCR/semantic runtime bundles verified."
+Write-Host "Portable and NSIS Rust OCR/Office/semantic runtime bundles verified."

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,10 @@ path = "src/bin/nmh.rs"
 name = "carbonpaper-ml"
 path = "src/bin/ml.rs"
 
+[[bin]]
+name = "carbonpaper-office"
+path = "src/bin/office.rs"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 walkdir = "2.5.0"
@@ -88,6 +92,9 @@ windows = { version = "0.58", features = [
     "Win32_System_SystemServices",
     "Win32_System_SystemInformation",
     "Win32_System_Threading",
+    "Win32_System_Com",
+    "Win32_System_Ole",
+    "Win32_System_Variant",
     "Win32_System_Pipes",
     "Win32_System_JobObjects",
     "Win32_System_Diagnostics_ToolHelp",
@@ -97,6 +104,7 @@ windows = { version = "0.58", features = [
     "Win32_Graphics_Dxgi_Common",
     "Win32_System_Performance",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Accessibility",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",
     "Win32_Graphics_Gdi",

--- a/src-tauri/src/bin/office.rs
+++ b/src-tauri/src/bin/office.rs
@@ -1,0 +1,123 @@
+//! Isolated STA worker for Microsoft Office document discovery.
+
+#[path = "../office_com.rs"]
+mod office_com;
+#[allow(dead_code)]
+#[path = "../office_protocol.rs"]
+mod office_protocol;
+#[allow(dead_code)]
+#[path = "../office_window.rs"]
+mod office_window;
+
+use office_protocol::{
+    read_request, write_response, OfficeRequest, OfficeResponse, OFFICE_PROTOCOL_VERSION,
+};
+use std::io::{BufReader, BufWriter};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::time::Instant;
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .without_time()
+        .init();
+
+    let apartment = match office_com::OfficeComApartment::initialize() {
+        Ok(apartment) => apartment,
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(2);
+        }
+    };
+
+    if std::env::args().any(|arg| arg == "--probe") {
+        println!(
+            "{}",
+            serde_json::json!({
+                "status": "ready",
+                "protocol_version": OFFICE_PROTOCOL_VERSION,
+                "worker_version": env!("CARGO_PKG_VERSION"),
+                "apartment": "sta"
+            })
+        );
+        drop(apartment);
+        return;
+    }
+
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut reader = BufReader::new(stdin.lock());
+    let mut writer = BufWriter::new(stdout.lock());
+    if let Err(error) = write_response(
+        &mut writer,
+        &OfficeResponse::Ready {
+            protocol_version: OFFICE_PROTOCOL_VERSION,
+            worker_version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+    ) {
+        eprintln!("failed to send Office worker handshake: {error}");
+        return;
+    }
+
+    loop {
+        let request = match read_request(&mut reader) {
+            Ok(request) => request,
+            Err(error) => {
+                tracing::debug!("Office worker transport closed: {error}");
+                break;
+            }
+        };
+        let request_id = request.request_id();
+        let should_shutdown = matches!(request, OfficeRequest::Shutdown { .. });
+        let response = match request {
+            OfficeRequest::Ping { request_id } => OfficeResponse::Pong { request_id },
+            OfficeRequest::Shutdown { request_id } => OfficeResponse::ShuttingDown { request_id },
+            OfficeRequest::Resolve {
+                request_id,
+                generation,
+                application,
+                root_hwnd,
+                document_hwnd,
+                pid,
+                title,
+            } => {
+                let started = Instant::now();
+                match catch_unwind(AssertUnwindSafe(|| {
+                    office_com::resolve_document(application, root_hwnd, document_hwnd, pid, &title)
+                })) {
+                    Ok(Ok((resolved_hwnd, document))) => OfficeResponse::Resolved {
+                        request_id,
+                        generation,
+                        document_hwnd: resolved_hwnd,
+                        document,
+                        elapsed_ms: started.elapsed().as_secs_f64() * 1000.0,
+                    },
+                    Ok(Err(error)) => OfficeResponse::Error {
+                        request_id,
+                        generation: Some(generation),
+                        kind: error.kind,
+                        message: error.message.chars().take(4096).collect(),
+                        elapsed_ms: started.elapsed().as_secs_f64() * 1000.0,
+                    },
+                    Err(_) => OfficeResponse::Error {
+                        request_id,
+                        generation: Some(generation),
+                        kind: "panic".to_string(),
+                        message: "Office automation worker panicked while resolving a document"
+                            .to_string(),
+                        elapsed_ms: started.elapsed().as_secs_f64() * 1000.0,
+                    },
+                }
+            }
+        };
+
+        if let Err(error) = write_response(&mut writer, &response) {
+            eprintln!("failed to write Office response for request {request_id}: {error}");
+            break;
+        }
+        if should_shutdown {
+            break;
+        }
+    }
+}

--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -4,6 +4,8 @@
 //! applies exclusion and activity policy, and commits encoded frames to storage.
 
 use crate::monitor::MonitorState;
+use crate::office_protocol::OfficeApplication;
+use crate::office_runtime::{OfficeCaptureContext, OfficeRuntimeState};
 use crate::storage::{OcrResultInput, SaveScreenshotRequest, StorageState};
 use base64::Engine;
 use image::codecs::jpeg::JpegEncoder;
@@ -377,6 +379,102 @@ pub struct ActiveWindowInfo {
     title: String,
     rect: RECT,
     pid: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ActiveWindowFingerprint {
+    hwnd_raw: isize,
+    pid: u32,
+    title: String,
+    office_document_hwnd: Option<i64>,
+}
+
+impl ActiveWindowFingerprint {
+    fn new(info: &ActiveWindowInfo, office_document_hwnd: Option<i64>) -> Self {
+        Self {
+            hwnd_raw: info.hwnd_raw,
+            pid: info.pid,
+            // Window titles are part of the Office identity because a reused
+            // Office root HWND can switch documents without changing handles.
+            // Keep non-Office fingerprints title-free so dynamic browser,
+            // terminal, or media titles do not create artificial focus scans.
+            title: office_document_hwnd
+                .is_some()
+                .then(|| info.title.clone())
+                .unwrap_or_default(),
+            office_document_hwnd,
+        }
+    }
+
+    fn matches_window_info(&self, info: &ActiveWindowInfo) -> bool {
+        self.hwnd_raw == info.hwnd_raw
+            && self.pid == info.pid
+            && (self.office_document_hwnd.is_none() || self.title == info.title)
+    }
+
+    fn storage_image_hash(&self, image_bytes: &[u8]) -> String {
+        let content_hash = md5_hash(image_bytes);
+        let Some(document_hwnd) = self.office_document_hwnd else {
+            return content_hash;
+        };
+
+        // `screenshots.image_hash` is globally unique for historical storage
+        // and vector-index contracts. Scope identical Office frames to the
+        // native document window so two documents with the same pixels still
+        // remain separate timeline records without changing that schema.
+        let scope = format!(
+            "office\0{}\0{}\0{}\0{}\0{}",
+            self.hwnd_raw, document_hwnd, self.pid, self.title, content_hash,
+        );
+        md5_hash(scope.as_bytes())
+    }
+}
+
+struct ProcessIdentity {
+    pid: u32,
+    hwnd_raw: isize,
+    path: String,
+    name: String,
+    refreshed_at: std::time::Instant,
+}
+
+const PROCESS_IDENTITY_FAILURE_TTL: std::time::Duration = std::time::Duration::from_secs(2);
+
+impl ProcessIdentity {
+    fn should_refresh(&self, info: &ActiveWindowInfo) -> bool {
+        self.pid != info.pid
+            || self.hwnd_raw != info.hwnd_raw
+            || (self.path.is_empty() && self.refreshed_at.elapsed() >= PROCESS_IDENTITY_FAILURE_TTL)
+    }
+}
+
+fn process_identity_for_window(
+    info: &ActiveWindowInfo,
+    cache: &mut Option<ProcessIdentity>,
+) -> (String, String) {
+    if cache
+        .as_ref()
+        .is_none_or(|identity| identity.should_refresh(info))
+    {
+        let path = get_process_path_from_pid(info.pid).unwrap_or_default();
+        let name = if path.is_empty() {
+            String::new()
+        } else {
+            get_process_name_from_path(&path)
+        };
+        *cache = Some(ProcessIdentity {
+            pid: info.pid,
+            hwnd_raw: info.hwnd_raw,
+            path,
+            name,
+            refreshed_at: std::time::Instant::now(),
+        });
+    }
+
+    let identity = cache
+        .as_ref()
+        .expect("process identity cache is populated for the requested PID");
+    (identity.path.clone(), identity.name.clone())
 }
 
 /// Retrieves information about the currently focused foreground window,
@@ -1309,7 +1407,7 @@ pub async fn run_capture_loop(
 ) {
     tracing::info!("Rust capture loop started");
 
-    let mut last_hwnd_raw: isize = 0;
+    let mut last_window_fingerprint: Option<ActiveWindowFingerprint> = None;
     // Use checked_sub to avoid panic when system uptime < 999s (Instant can't go before boot)
     let mut last_capture_time = std::time::Instant::now()
         .checked_sub(std::time::Duration::from_secs(999))
@@ -1317,6 +1415,8 @@ pub async fn run_capture_loop(
     let mut force_first_capture = true;
     let mut history_hashes: Vec<DHash> = Vec::new();
     let mut icon_cache: HashMap<String, Option<String>> = HashMap::new();
+    let mut current_process_identity: Option<ProcessIdentity> = None;
+    let office_runtime = app.state::<Arc<OfficeRuntimeState>>().inner().clone();
 
     // Load config
     let (
@@ -1366,12 +1466,11 @@ pub async fn run_capture_loop(
         }
 
         // Get active window
-        let window_info = match get_active_window_info() {
+        let mut window_info = match get_active_window_info() {
             Some(info) => info,
             None => continue,
         };
-
-        let current_hwnd_raw = window_info.hwnd_raw;
+        let base_window_fingerprint = ActiveWindowFingerprint::new(&window_info, None);
 
         // Exclusion check
         {
@@ -1380,10 +1479,31 @@ pub async fn run_capture_loop(
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
             if is_excluded(&window_info, &settings) {
-                last_hwnd_raw = current_hwnd_raw;
+                last_window_fingerprint = Some(base_window_fingerprint);
                 continue;
             }
         }
+
+        // Process lookup and native child-window fingerprinting are cheap Win32
+        // operations. They happen before OCR/dHash early exits so Office document
+        // switches are observed even when no screenshot is written.
+        let (mut process_path, mut process_name) =
+            process_identity_for_window(&window_info, &mut current_process_identity);
+        let mut office_context: Option<OfficeCaptureContext> =
+            OfficeApplication::from_process_name(&process_name).and_then(|application| {
+                office_runtime.observe_window(
+                    application,
+                    window_info.hwnd_raw as i64,
+                    window_info.pid,
+                    &window_info.title,
+                )
+            });
+        let mut current_window_fingerprint = ActiveWindowFingerprint::new(
+            &window_info,
+            office_context
+                .as_ref()
+                .map(OfficeCaptureContext::document_hwnd),
+        );
 
         // Raw RGB frames are never queued. Keep capture and OCR strictly single-flight.
         let in_flight = capture_state.in_flight_ocr_count.load(Ordering::SeqCst);
@@ -1395,7 +1515,7 @@ pub async fn run_capture_loop(
         let mut scan_reason = "";
 
         // Focus change detection
-        if current_hwnd_raw != last_hwnd_raw {
+        if last_window_fingerprint.as_ref() != Some(&current_window_fingerprint) {
             should_capture = true;
             scan_reason = "focus_change";
         }
@@ -1406,7 +1526,7 @@ pub async fn run_capture_loop(
         }
 
         if !should_capture {
-            last_hwnd_raw = current_hwnd_raw;
+            last_window_fingerprint = Some(current_window_fingerprint);
             continue;
         }
 
@@ -1429,11 +1549,54 @@ pub async fn run_capture_loop(
             {
                 continue;
             }
+
+            // Never capture with the pre-sleep HWND/title. If focus or document
+            // title changed during stabilization, let the next poll establish a
+            // fresh 500 ms stable interval and observation generation.
+            let stabilized = match get_active_window_info() {
+                Some(info) => info,
+                None => continue,
+            };
+            if !current_window_fingerprint.matches_window_info(&stabilized) {
+                continue;
+            }
+            let settings = capture_state
+                .exclusion_settings
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if is_excluded(&stabilized, &settings) {
+                last_window_fingerprint = Some(current_window_fingerprint);
+                continue;
+            }
+            drop(settings);
+            window_info = stabilized;
+            (process_path, process_name) =
+                process_identity_for_window(&window_info, &mut current_process_identity);
+            let stabilized_office_context = OfficeApplication::from_process_name(&process_name)
+                .and_then(|application| {
+                    office_runtime.observe_window(
+                        application,
+                        window_info.hwnd_raw as i64,
+                        window_info.pid,
+                        &window_info.title,
+                    )
+                });
+            let stabilized_window_fingerprint = ActiveWindowFingerprint::new(
+                &window_info,
+                stabilized_office_context
+                    .as_ref()
+                    .map(OfficeCaptureContext::document_hwnd),
+            );
+            if stabilized_window_fingerprint != current_window_fingerprint {
+                continue;
+            }
+            office_context = stabilized_office_context;
+            current_window_fingerprint = stabilized_window_fingerprint;
         }
 
         // Capture screenshot
         let captured = match capture_foreground_window(
-            current_hwnd_raw,
+            window_info.hwnd_raw,
             &window_info.rect,
             max_side,
             jpeg_quality,
@@ -1441,16 +1604,19 @@ pub async fn run_capture_loop(
         ) {
             Some(c) => c,
             None => {
-                last_hwnd_raw = current_hwnd_raw;
+                last_window_fingerprint = Some(current_window_fingerprint);
                 continue;
             }
         };
 
         // dHash dedup
         let current_hash = compute_dhash(&captured.rgb_image, 16);
-        if is_redundant(&current_hash, &history_hashes, dhash_threshold) {
+        let preserve_office_context = scan_reason == "focus_change"
+            && current_window_fingerprint.office_document_hwnd.is_some();
+        if !preserve_office_context && is_redundant(&current_hash, &history_hashes, dhash_threshold)
+        {
             last_capture_time = std::time::Instant::now();
-            last_hwnd_raw = current_hwnd_raw;
+            last_window_fingerprint = Some(current_window_fingerprint);
             continue;
         }
 
@@ -1459,14 +1625,6 @@ pub async fn run_capture_loop(
         if history_hashes.len() > dhash_history_size {
             history_hashes.remove(0);
         }
-
-        // Get process metadata
-        let process_path = get_process_path_from_pid(window_info.pid).unwrap_or_default();
-        let process_name = if !process_path.is_empty() {
-            get_process_name_from_path(&process_path)
-        } else {
-            String::new()
-        };
 
         // Route to a registered browser-extension session (matched by the
         // foreground window's PID) when extension enhancement is enabled.
@@ -1486,7 +1644,7 @@ pub async fn run_capture_loop(
                     // Extension confirmed it received the capture request;
                     // skip normal capture for this frame.
                     last_capture_time = std::time::Instant::now();
-                    last_hwnd_raw = current_hwnd_raw;
+                    last_window_fingerprint = Some(current_window_fingerprint);
                     continue;
                 }
                 Err(e) => {
@@ -1515,7 +1673,7 @@ pub async fn run_capture_loop(
         };
 
         // Compute image hash (MD5)
-        let image_hash = md5_hash(&captured.jpeg_bytes);
+        let image_hash = current_window_fingerprint.storage_image_hash(&captured.jpeg_bytes);
 
         let ts_str = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
 
@@ -1557,7 +1715,7 @@ pub async fn run_capture_loop(
                 "OCR slot was claimed while capture was being prepared; dropping frame"
             );
             last_capture_time = std::time::Instant::now();
-            last_hwnd_raw = current_hwnd_raw;
+            last_window_fingerprint = Some(current_window_fingerprint);
             continue;
         };
 
@@ -1577,13 +1735,18 @@ pub async fn run_capture_loop(
             visible_links: None,
         };
 
+        // Read before the row is written, and again in `associate_screenshot`
+        // after it. Two equal readings mean no database swap happened around
+        // the insert, which is what makes the returned id attributable to the
+        // database that is open now.
+        let db_generation_before_save = storage.db_generation();
         let screenshot_id =
             match storage.save_screenshot_temp_bytes(&save_request, &captured.jpeg_bytes) {
                 Ok(resp) => {
                     if resp.status == "duplicate" {
                         tracing::debug!("Duplicate screenshot, skipping OCR");
                         last_capture_time = std::time::Instant::now();
-                        last_hwnd_raw = current_hwnd_raw;
+                        last_window_fingerprint = Some(current_window_fingerprint);
                         continue;
                     }
                     match resp.screenshot_id {
@@ -1591,7 +1754,7 @@ pub async fn run_capture_loop(
                         None => {
                             tracing::error!("save_screenshot_temp returned no ID");
                             last_capture_time = std::time::Instant::now();
-                            last_hwnd_raw = current_hwnd_raw;
+                            last_window_fingerprint = Some(current_window_fingerprint);
                             continue;
                         }
                     }
@@ -1599,10 +1762,19 @@ pub async fn run_capture_loop(
                 Err(e) => {
                     tracing::error!("save_screenshot_temp failed: {}", e);
                     last_capture_time = std::time::Instant::now();
-                    last_hwnd_raw = current_hwnd_raw;
+                    last_window_fingerprint = Some(current_window_fingerprint);
                     continue;
                 }
             };
+        if let Some(context) = office_context {
+            office_runtime.associate_screenshot(
+                app.clone(),
+                storage.clone(),
+                screenshot_id,
+                context,
+                db_generation_before_save,
+            );
+        }
         capture_state
             .startup_pending_cleanup_cancelled
             .store(true, Ordering::SeqCst);
@@ -1637,7 +1809,7 @@ pub async fn run_capture_loop(
         });
 
         last_capture_time = std::time::Instant::now();
-        last_hwnd_raw = current_hwnd_raw;
+        last_window_fingerprint = Some(current_window_fingerprint);
     }
 
     capture_state.clear_wgc_session("capture_loop_ended");
@@ -2032,6 +2204,104 @@ pub(crate) fn md5_hash(data: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn office_document_hwnd_participates_in_focus_fingerprint() {
+        let window = ActiveWindowInfo {
+            hwnd_raw: 100,
+            title: "Roadmap - PowerPoint".to_string(),
+            rect: RECT::default(),
+            pid: 200,
+        };
+        let first = ActiveWindowFingerprint::new(&window, Some(300));
+        let second = ActiveWindowFingerprint::new(&window, Some(301));
+
+        assert!(first.matches_window_info(&window));
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn office_storage_hash_scopes_identical_frames_to_document_windows() {
+        let window = ActiveWindowInfo {
+            hwnd_raw: 100,
+            title: "Roadmap - PowerPoint".to_string(),
+            rect: RECT::default(),
+            pid: 200,
+        };
+        let first = ActiveWindowFingerprint::new(&window, Some(300));
+        let same = ActiveWindowFingerprint::new(&window, Some(300));
+        let other = ActiveWindowFingerprint::new(&window, Some(301));
+        let bytes = b"same pixels";
+
+        assert_eq!(
+            first.storage_image_hash(bytes),
+            same.storage_image_hash(bytes)
+        );
+        assert_ne!(
+            first.storage_image_hash(bytes),
+            other.storage_image_hash(bytes)
+        );
+        assert_eq!(
+            ActiveWindowFingerprint::new(&window, None).storage_image_hash(bytes),
+            md5_hash(bytes)
+        );
+    }
+
+    #[test]
+    fn non_office_title_changes_do_not_trigger_focus_identity_changes() {
+        let first_window = ActiveWindowInfo {
+            hwnd_raw: 100,
+            title: "Terminal - bash".to_string(),
+            rect: RECT::default(),
+            pid: 200,
+        };
+        let second_window = ActiveWindowInfo {
+            hwnd_raw: first_window.hwnd_raw,
+            title: "Terminal - cargo test".to_string(),
+            rect: RECT::default(),
+            pid: first_window.pid,
+        };
+
+        assert_eq!(
+            ActiveWindowFingerprint::new(&first_window, None),
+            ActiveWindowFingerprint::new(&second_window, None)
+        );
+        assert!(
+            ActiveWindowFingerprint::new(&first_window, None).matches_window_info(&second_window)
+        );
+    }
+
+    #[test]
+    fn failed_process_identity_lookup_retries_and_window_changes_invalidate() {
+        let window = ActiveWindowInfo {
+            hwnd_raw: 100,
+            title: "Document1 - Word".to_string(),
+            rect: RECT::default(),
+            pid: 200,
+        };
+        let recent_failure = ProcessIdentity {
+            pid: window.pid,
+            hwnd_raw: window.hwnd_raw,
+            path: String::new(),
+            name: String::new(),
+            refreshed_at: std::time::Instant::now(),
+        };
+        assert!(!recent_failure.should_refresh(&window));
+
+        let expired_failure = ProcessIdentity {
+            refreshed_at: std::time::Instant::now()
+                .checked_sub(PROCESS_IDENTITY_FAILURE_TTL)
+                .unwrap(),
+            ..recent_failure
+        };
+        assert!(expired_failure.should_refresh(&window));
+
+        let replacement_window = ActiveWindowInfo {
+            hwnd_raw: 101,
+            ..window
+        };
+        assert!(expired_failure.should_refresh(&replacement_window));
+    }
 
     #[test]
     fn test_hamming_distance_identical() {

--- a/src-tauri/src/commands/migration.rs
+++ b/src-tauri/src/commands/migration.rs
@@ -254,12 +254,33 @@ pub async fn storage_migrate_data_dir(
 ) -> Result<serde_json::Value, String> {
     super::check_auth_required(&credential_state)?;
 
+    // Unlike backup export/import, this path never stops the monitor: capture,
+    // Office observation and resolution all keep running while the database is
+    // closed, the files are moved, and a database at the new location is
+    // opened — possibly a different one, when only the configuration moves.
+    let office_runtime = app_handle
+        .state::<Arc<crate::office_runtime::OfficeRuntimeState>>()
+        .inner()
+        .clone();
+    let was_active = office_runtime.is_active();
+    office_runtime
+        .quiesce(std::time::Duration::from_secs(5))
+        .await;
+
     let state = state.inner().clone();
-    tokio::task::spawn_blocking(move || {
+    let outcome = tokio::task::spawn_blocking(move || {
         state.migrate_data_dir_blocking(app_handle, target, migrate_data_files)
     })
     .await
-    .map_err(|e| format!("Task join error: {:?}", e))?
+    .map_err(|e| format!("Task join error: {:?}", e));
+
+    // Capture was never stopped, so observation resumes with the migration —
+    // against the database that is now open.
+    if was_active {
+        office_runtime.resume();
+    }
+
+    outcome?
 }
 
 /// Requests cancellation of an active data-directory migration.
@@ -338,6 +359,13 @@ pub async fn storage_export_backup(
             app_handle.clone(),
         )
         .await;
+        // `stop_monitor_impl` already drains Office, but its result is
+        // discarded above; do not let a failure there leave association
+        // writes in flight across the close below.
+        app_handle
+            .state::<Arc<crate::office_runtime::OfficeRuntimeState>>()
+            .quiesce(std::time::Duration::from_secs(5))
+            .await;
         state.shutdown()?;
 
         // 2. Get Master Key
@@ -540,6 +568,13 @@ pub async fn storage_import_backup(
             app_handle.clone(),
         )
         .await;
+        // The restored database numbers its screenshots independently, so an
+        // association write that survived this point would attach a document
+        // to whichever unrelated screenshot reuses the id.
+        app_handle
+            .state::<Arc<crate::office_runtime::OfficeRuntimeState>>()
+            .quiesce(std::time::Duration::from_secs(5))
+            .await;
         state.shutdown()?;
 
         // 2. Open ZIP

--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -765,7 +765,9 @@ pub fn storage_cancel_thumbnail_warmup(
 /// Returns a screenshot record and all associated OCR rows selected by `id` or `path`.
 ///
 /// Authentication: required. Returns `{ "status": "success" | "not_found",
-/// "record", "ocr_results" }`. Frontend: `lib/monitor_api.js`.
+/// "record", "ocr_results", "document_ref" }`. The document view deliberately
+/// omits the encrypted locator; only the authenticated resume command reads it.
+/// Frontend: `lib/monitor_api.js`.
 #[tauri::command]
 pub async fn storage_get_screenshot_details(
     credential_state: tauri::State<'_, Arc<CredentialManagerState>>,
@@ -788,16 +790,29 @@ pub async fn storage_get_screenshot_details(
         match &record {
             Some(r) => {
                 let ocr_results = state.get_screenshot_ocr_results(r.id)?;
+                let document_ref = match state.get_screenshot_document_ref(r.id) {
+                    Ok(reference) => reference.map(|reference| reference.public_view()),
+                    Err(error) => {
+                        tracing::warn!(
+                            "[OFFICE:STORAGE] ignoring unreadable document reference for screenshot {}: {}",
+                            r.id,
+                            error
+                        );
+                        None
+                    }
+                };
                 Ok(serde_json::json!({
                     "status": "success",
                     "record": record,
-                    "ocr_results": ocr_results
+                    "ocr_results": ocr_results,
+                    "document_ref": document_ref
                 }))
             }
             None => Ok(serde_json::json!({
                 "status": "not_found",
                 "record": null,
-                "ocr_results": []
+                "ocr_results": [],
+                "document_ref": null
             })),
         }
     })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,9 @@ mod model_management;
 mod monitor;
 mod monitor_ipc;
 mod native_messaging;
+mod office_protocol;
+mod office_runtime;
+mod office_window;
 mod power;
 mod python;
 mod python_launcher;
@@ -797,6 +800,7 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .manage(MonitorState::new())
         .manage(Arc::new(ml_runtime::MlRuntimeState::new()))
+        .manage(Arc::new(office_runtime::OfficeRuntimeState::new()))
         .manage(Arc::new(semantic_runtime::SemanticRuntimeState::new()))
         .manage(Arc::new(minilm_migration::MinilmMigrationState::new()))
         .manage(Arc::new(clip_migration::ClipMigrationState::new()))
@@ -869,6 +873,13 @@ pub fn run() {
 
                 analysis::start_memory_sampler(app.handle().clone());
                 logging::spawn_maintenance_task(data_dir.clone());
+
+                let office_runtime = app
+                    .state::<Arc<office_runtime::OfficeRuntimeState>>()
+                    .inner()
+                    .clone();
+                let office_storage = app.state::<Arc<StorageState>>().inner().clone();
+                office_runtime.start(app.handle().clone(), office_storage);
 
                 tracing::info!(
                     r#"
@@ -1156,6 +1167,7 @@ pub fn run() {
             ml_runtime::download_rust_ocr_model,
             ml_runtime::take_ocr_model_repair_request,
             ml_runtime::debug_trigger_ocr_model_repair_notification,
+            office_runtime::office_resume_document,
             semantic_runtime::get_ml_semantic_status,
             semantic_runtime::get_background_index_progress,
             semantic_runtime::restart_ml_semantic_worker,

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -2087,6 +2087,10 @@ fn spawn_capture_loop(app: &AppHandle) {
     capture_state
         .startup_pending_cleanup_cancelled
         .store(false, Ordering::SeqCst);
+    // Office observation follows capture; `stop_monitor_impl` and the storage
+    // migrations close this gate.
+    app.state::<Arc<crate::office_runtime::OfficeRuntimeState>>()
+        .resume();
 
     // Load exclusion settings from disk
     {
@@ -2210,6 +2214,15 @@ pub async fn stop_monitor_impl(
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     }
+
+    // Office association writes carry screenshot ids that only mean something
+    // in the current database, and stopping the monitor is what backup and
+    // data-directory switches do before they replace it. Drain before those
+    // writes can outlive the database they were collected from, and release
+    // the worker so it stops talking to Office once capture has stopped.
+    app.state::<Arc<crate::office_runtime::OfficeRuntimeState>>()
+        .quiesce(tokio::time::Duration::from_secs(5))
+        .await;
 
     // 2. Best-effort stop signal to Python. Do not let a broken worker or pipe
     // handler hold the UI in LOADING during an intentional terminate/restart.

--- a/src-tauri/src/office_com.rs
+++ b/src-tauri/src/office_com.rs
@@ -1,0 +1,402 @@
+//! STA Office automation used only by the isolated Office worker process.
+
+use crate::office_protocol::{
+    OfficeApplication, OfficeDocumentKind, OfficeDocumentRef, MAX_OFFICE_DISPLAY_NAME_CHARS,
+    MAX_OFFICE_LOCATOR_CHARS,
+};
+use crate::office_window::validate_office_window_context;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use windows::core::{Interface, BSTR, GUID, PCWSTR, VARIANT};
+use windows::Win32::Foundation::{HWND, RPC_E_CALL_REJECTED, RPC_E_SERVERCALL_RETRYLATER};
+use windows::Win32::System::Com::{
+    CoInitializeEx, CoUninitialize, IDispatch, COINIT_APARTMENTTHREADED, DISPATCH_PROPERTYGET,
+    DISPPARAMS,
+};
+use windows::Win32::System::Variant::{VT_DISPATCH, VT_EMPTY, VT_NULL, VT_UNKNOWN};
+use windows::Win32::UI::Accessibility::AccessibleObjectFromWindow;
+use windows::Win32::UI::WindowsAndMessaging::OBJID_NATIVEOM;
+
+const PROPERTY_RETRY_DELAYS_MS: &[u64] = &[0, 40, 80, 160, 320];
+const LOCALE_USER_DEFAULT: u32 = 0x0400;
+
+#[derive(Debug)]
+pub struct OfficeComError {
+    pub kind: String,
+    pub message: String,
+}
+
+impl OfficeComError {
+    fn new(kind: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            message: message.into(),
+        }
+    }
+}
+
+/// RAII guard proving that the worker's request thread is an STA.
+pub struct OfficeComApartment;
+
+impl OfficeComApartment {
+    pub fn initialize() -> Result<Self, String> {
+        // SAFETY: the helper initializes COM once on its main thread and the
+        // returned guard calls CoUninitialize on that same thread.
+        unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) }
+            .ok()
+            .map_err(|error| format!("failed to initialize Office STA COM apartment: {error:?}"))?;
+        Ok(Self)
+    }
+}
+
+impl Drop for OfficeComApartment {
+    fn drop(&mut self) {
+        // SAFETY: paired with the successful CoInitializeEx call above.
+        unsafe { CoUninitialize() };
+    }
+}
+
+/// Resolve the document represented by a verified Office native view window.
+pub fn resolve_document(
+    application: OfficeApplication,
+    root_hwnd: i64,
+    requested_document_hwnd: i64,
+    pid: u32,
+    title: &str,
+) -> Result<(i64, Option<OfficeDocumentRef>), OfficeComError> {
+    if !validate_office_window_context(root_hwnd, requested_document_hwnd, pid, application, title)
+    {
+        return Err(OfficeComError::new(
+            "window_changed",
+            "Office window context changed before COM resolution",
+        ));
+    }
+
+    // Do not substitute a newly discovered child HWND here. The parent captured
+    // a specific document surface and will associate the result with that
+    // fingerprint; resolving a replacement child could bind the wrong document.
+    let document_hwnd = requested_document_hwnd;
+
+    let native = native_object(document_hwnd)?;
+    let document = match application {
+        OfficeApplication::Word => property_dispatch_optional(&native, "Document")?,
+        OfficeApplication::Excel => resolve_excel_workbook(&native)?,
+        OfficeApplication::PowerPoint => property_dispatch_optional(&native, "Presentation")?,
+    };
+
+    let Some(document) = document else {
+        if !validate_office_window_context(root_hwnd, document_hwnd, pid, application, title) {
+            return Err(OfficeComError::new(
+                "window_changed",
+                "Office window context changed during COM resolution",
+            ));
+        }
+        return Ok((document_hwnd, None));
+    };
+    let reference = read_document_reference(application, &document)?;
+    if !validate_office_window_context(root_hwnd, document_hwnd, pid, application, title) {
+        return Err(OfficeComError::new(
+            "window_changed",
+            "Office window context changed during COM resolution",
+        ));
+    }
+    Ok((document_hwnd, reference))
+}
+
+fn resolve_excel_workbook(window: &IDispatch) -> Result<Option<IDispatch>, OfficeComError> {
+    if let Some(sheet) = property_dispatch_optional(window, "ActiveSheet")? {
+        if let Some(workbook) = property_dispatch_optional(&sheet, "Parent")? {
+            return Ok(Some(workbook));
+        }
+    }
+
+    let Some(application) = property_dispatch_optional(window, "Application")? else {
+        return Ok(None);
+    };
+    property_dispatch_optional(&application, "ActiveWorkbook")
+}
+
+fn read_document_reference(
+    application: OfficeApplication,
+    document: &IDispatch,
+) -> Result<Option<OfficeDocumentRef>, OfficeComError> {
+    let name = property_string(document, "Name")?.trim().to_string();
+    if name.is_empty() {
+        return Ok(None);
+    }
+    if name.chars().count() > MAX_OFFICE_DISPLAY_NAME_CHARS {
+        return Err(OfficeComError::new(
+            "limit_exceeded",
+            "Office document name exceeds the protocol limit",
+        ));
+    }
+
+    let path = property_string(document, "Path")?.trim().to_string();
+    let full_name = property_string(document, "FullName")?.trim().to_string();
+    let (kind, locator) = classify_locator(&name, &path, &full_name)?;
+    let reference = OfficeDocumentRef {
+        provider: "office_nativeom".to_string(),
+        application,
+        kind,
+        display_name: name,
+        locator,
+        observed_at_ms: chrono::Utc::now().timestamp_millis(),
+        confidence: "exact".to_string(),
+    };
+    reference
+        .validate()
+        .map_err(|message| OfficeComError::new("invalid_document", message))?;
+    Ok(Some(reference))
+}
+
+fn classify_locator(
+    name: &str,
+    path: &str,
+    full_name: &str,
+) -> Result<(OfficeDocumentKind, Option<String>), OfficeComError> {
+    let full_is_cloud = is_http_locator(full_name);
+    let path_is_cloud = is_http_locator(path);
+    let full_is_local = !full_name.is_empty() && Path::new(full_name).is_absolute();
+
+    let result = if full_is_cloud {
+        (
+            OfficeDocumentKind::CloudDocument,
+            Some(full_name.to_string()),
+        )
+    } else if path_is_cloud {
+        let locator = if full_name.is_empty() || full_name == name {
+            format!("{}/{}", path.trim_end_matches('/'), name)
+        } else {
+            full_name.to_string()
+        };
+        (OfficeDocumentKind::CloudDocument, Some(locator))
+    } else if full_is_local {
+        (OfficeDocumentKind::LocalFile, Some(full_name.to_string()))
+    } else if !path.is_empty() && Path::new(path).is_absolute() {
+        let locator = PathBuf::from(path).join(name).to_string_lossy().to_string();
+        (OfficeDocumentKind::LocalFile, Some(locator))
+    } else {
+        (OfficeDocumentKind::Unsaved, None)
+    };
+
+    if let Some(locator) = &result.1 {
+        if locator.chars().count() > MAX_OFFICE_LOCATOR_CHARS {
+            return Err(OfficeComError::new(
+                "limit_exceeded",
+                "Office document locator exceeds the protocol limit",
+            ));
+        }
+    }
+    Ok(result)
+}
+
+fn is_http_locator(value: &str) -> bool {
+    value.starts_with("https://") || value.starts_with("http://")
+}
+
+fn native_object(document_hwnd: i64) -> Result<IDispatch, OfficeComError> {
+    let hwnd_raw = isize::try_from(document_hwnd)
+        .map_err(|_| OfficeComError::new("invalid_window", "Office HWND does not fit isize"))?;
+    let hwnd = HWND(hwnd_raw as *mut _);
+    let mut raw = std::ptr::null_mut();
+
+    for (index, delay_ms) in PROPERTY_RETRY_DELAYS_MS.iter().copied().enumerate() {
+        if delay_ms > 0 {
+            std::thread::sleep(Duration::from_millis(delay_ms));
+        }
+        // SAFETY: the HWND was validated immediately before this call; `raw`
+        // receives one owned IDispatch reference when the call succeeds.
+        match unsafe {
+            AccessibleObjectFromWindow(hwnd, OBJID_NATIVEOM.0 as u32, &IDispatch::IID, &mut raw)
+        } {
+            Ok(()) if !raw.is_null() => {
+                // SAFETY: AccessibleObjectFromWindow returned an owned pointer
+                // for IID_IDispatch, transferred into the RAII interface wrapper.
+                return Ok(unsafe { IDispatch::from_raw(raw) });
+            }
+            Ok(()) => {
+                return Err(OfficeComError::new(
+                    "native_object_unavailable",
+                    "Office returned a null native object",
+                ));
+            }
+            Err(error)
+                if is_retryable_call(&error) && index + 1 < PROPERTY_RETRY_DELAYS_MS.len() =>
+            {
+                continue;
+            }
+            Err(error) => return Err(map_com_error("AccessibleObjectFromWindow", error)),
+        }
+    }
+    Err(OfficeComError::new(
+        "call_rejected",
+        "Office native object call remained busy after retries",
+    ))
+}
+
+fn property_dispatch_optional(
+    dispatch: &IDispatch,
+    name: &str,
+) -> Result<Option<IDispatch>, OfficeComError> {
+    let value = invoke_property(dispatch, name)?;
+    let variant_type = variant_type(&value);
+    if variant_type == VT_EMPTY.0 || variant_type == VT_NULL.0 {
+        return Ok(None);
+    }
+    variant_into_dispatch(value).map(Some)
+}
+
+fn property_string(dispatch: &IDispatch, name: &str) -> Result<String, OfficeComError> {
+    let value = invoke_property(dispatch, name)?;
+    let variant_type = variant_type(&value);
+    if variant_type == VT_EMPTY.0 || variant_type == VT_NULL.0 {
+        return Ok(String::new());
+    }
+    BSTR::try_from(&value)
+        .map(|value| value.to_string())
+        .map_err(|error| {
+            OfficeComError::new(
+                "invalid_property",
+                format!("Office property {name} was not text: {error:?}"),
+            )
+        })
+}
+
+fn invoke_property(dispatch: &IDispatch, name: &str) -> Result<VARIANT, OfficeComError> {
+    for (index, delay_ms) in PROPERTY_RETRY_DELAYS_MS.iter().copied().enumerate() {
+        if delay_ms > 0 {
+            std::thread::sleep(Duration::from_millis(delay_ms));
+        }
+        match invoke_property_once(dispatch, name) {
+            Ok(value) => return Ok(value),
+            Err(error)
+                if is_retryable_call(&error) && index + 1 < PROPERTY_RETRY_DELAYS_MS.len() =>
+            {
+                continue;
+            }
+            Err(error) => return Err(map_com_error(name, error)),
+        }
+    }
+    Err(OfficeComError::new(
+        "call_rejected",
+        format!("Office property {name} remained busy after retries"),
+    ))
+}
+
+fn invoke_property_once(dispatch: &IDispatch, name: &str) -> windows::core::Result<VARIANT> {
+    let wide_name = name
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let name_ptr = PCWSTR(wide_name.as_ptr());
+    let iid_null = GUID::zeroed();
+    let mut dispid = 0;
+    let parameters = DISPPARAMS::default();
+    let mut result = VARIANT::new();
+
+    // SAFETY: all pointers reference stack data valid for the synchronous COM
+    // calls; no arguments are supplied for a DISPATCH_PROPERTYGET invocation.
+    unsafe {
+        dispatch.GetIDsOfNames(&iid_null, &name_ptr, 1, LOCALE_USER_DEFAULT, &mut dispid)?;
+        dispatch.Invoke(
+            dispid,
+            &iid_null,
+            LOCALE_USER_DEFAULT,
+            DISPATCH_PROPERTYGET,
+            &parameters,
+            Some(&mut result),
+            None,
+            None,
+        )?;
+    }
+    Ok(result)
+}
+
+fn variant_type(value: &VARIANT) -> u16 {
+    // SAFETY: every initialized VARIANT has a readable discriminator.
+    unsafe { value.as_raw().Anonymous.Anonymous.vt }
+}
+
+fn variant_into_dispatch(value: VARIANT) -> Result<IDispatch, OfficeComError> {
+    let variant_type = variant_type(&value);
+    if variant_type == VT_DISPATCH.0 {
+        // SAFETY: the discriminator proves the active union member is pdispVal.
+        let raw = unsafe { value.as_raw().Anonymous.Anonymous.Anonymous.pdispVal };
+        if raw.is_null() {
+            return Err(OfficeComError::new(
+                "invalid_property",
+                "Office returned a null IDispatch property",
+            ));
+        }
+        std::mem::forget(value);
+        // SAFETY: ownership of the VARIANT's IDispatch reference is transferred
+        // into this wrapper after suppressing VariantClear.
+        return Ok(unsafe { IDispatch::from_raw(raw) });
+    }
+    if variant_type == VT_UNKNOWN.0 {
+        // SAFETY: the discriminator proves the active union member is punkVal.
+        let raw = unsafe { value.as_raw().Anonymous.Anonymous.Anonymous.punkVal };
+        if raw.is_null() {
+            return Err(OfficeComError::new(
+                "invalid_property",
+                "Office returned a null IUnknown property",
+            ));
+        }
+        std::mem::forget(value);
+        // SAFETY: ownership is transferred from the VARIANT into IUnknown.
+        let unknown = unsafe { windows::core::IUnknown::from_raw(raw) };
+        return unknown.cast::<IDispatch>().map_err(|error| {
+            OfficeComError::new(
+                "invalid_property",
+                format!("Office object does not implement IDispatch: {error:?}"),
+            )
+        });
+    }
+    Err(OfficeComError::new(
+        "invalid_property",
+        format!("Office object property used unsupported VARIANT type {variant_type}"),
+    ))
+}
+
+fn is_retryable_call(error: &windows::core::Error) -> bool {
+    error.code() == RPC_E_CALL_REJECTED || error.code() == RPC_E_SERVERCALL_RETRYLATER
+}
+
+fn map_com_error(operation: &str, error: windows::core::Error) -> OfficeComError {
+    let kind = if is_retryable_call(&error) {
+        "call_rejected"
+    } else {
+        "automation_failed"
+    };
+    OfficeComError::new(kind, format!("Office {operation} failed: {error:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_local_cloud_and_unsaved_documents() {
+        assert_eq!(
+            classify_locator("Report.docx", r"C:\\Work", r"C:\\Work\\Report.docx").unwrap(),
+            (
+                OfficeDocumentKind::LocalFile,
+                Some(r"C:\\Work\\Report.docx".to_string())
+            )
+        );
+        assert_eq!(
+            classify_locator(
+                "Report.docx",
+                "https://tenant.sharepoint.com/docs",
+                "https://tenant.sharepoint.com/docs/Report.docx"
+            )
+            .unwrap()
+            .0,
+            OfficeDocumentKind::CloudDocument
+        );
+        assert_eq!(
+            classify_locator("Document1", "", "Document1").unwrap(),
+            (OfficeDocumentKind::Unsaved, None)
+        );
+    }
+}

--- a/src-tauri/src/office_protocol.rs
+++ b/src-tauri/src/office_protocol.rs
@@ -1,0 +1,467 @@
+//! Bounded protocol shared by CarbonPaper and the isolated Office automation worker.
+//!
+//! The worker is deliberately a separate process because Office COM calls have no
+//! dependable upper latency bound.  The desktop process owns deadlines and may kill
+//! the worker; this module keeps the local transport small and validates every frame
+//! before either side allocates or trusts it.
+
+use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
+
+pub const OFFICE_PROTOCOL_VERSION: u32 = 1;
+pub const MAX_OFFICE_FRAME_BYTES: usize = 64 * 1024;
+pub const MAX_OFFICE_DISPLAY_NAME_CHARS: usize = 1024;
+pub const MAX_OFFICE_TITLE_CHARS: usize = 1024;
+pub const MAX_OFFICE_LOCATOR_CHARS: usize = 32 * 1024;
+pub const MAX_OFFICE_ERROR_CHARS: usize = 4096;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OfficeApplication {
+    Word,
+    Excel,
+    PowerPoint,
+}
+
+impl OfficeApplication {
+    pub fn from_process_name(process_name: &str) -> Option<Self> {
+        match process_name.trim().to_ascii_lowercase().as_str() {
+            "winword" | "winword.exe" => Some(Self::Word),
+            "excel" | "excel.exe" => Some(Self::Excel),
+            "powerpnt" | "powerpnt.exe" => Some(Self::PowerPoint),
+            _ => None,
+        }
+    }
+
+    pub fn native_window_classes(self) -> &'static [&'static str] {
+        match self {
+            Self::Word => &["_WwG"],
+            Self::Excel => &["EXCEL7"],
+            // Current Microsoft 365 builds may expose the editable document
+            // surface as mdiClass while older builds use paneClassDC.
+            Self::PowerPoint => &["paneClassDC", "mdiClass"],
+        }
+    }
+
+    pub fn native_window_class_priority(self, class_name: &str) -> Option<usize> {
+        self.native_window_classes()
+            .iter()
+            .position(|candidate| candidate.eq_ignore_ascii_case(class_name))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OfficeDocumentKind {
+    LocalFile,
+    CloudDocument,
+    Unsaved,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OfficeDocumentRef {
+    pub provider: String,
+    pub application: OfficeApplication,
+    pub kind: OfficeDocumentKind,
+    pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locator: Option<String>,
+    pub observed_at_ms: i64,
+    pub confidence: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OfficeDocumentRefView {
+    pub provider: String,
+    pub application: OfficeApplication,
+    pub kind: OfficeDocumentKind,
+    pub display_name: String,
+    pub observed_at_ms: i64,
+    pub confidence: String,
+    pub resumable: bool,
+}
+
+impl OfficeDocumentRef {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.provider != "office_nativeom" {
+            return Err("invalid_response: unsupported Office document provider".to_string());
+        }
+        if self.confidence != "exact" {
+            return Err("invalid_response: unsupported Office confidence".to_string());
+        }
+        if self.observed_at_ms <= 0 {
+            return Err("invalid_response: Office observation timestamp is invalid".to_string());
+        }
+        let display_chars = self.display_name.chars().count();
+        if self.display_name.trim().is_empty() || display_chars > MAX_OFFICE_DISPLAY_NAME_CHARS {
+            return Err("invalid_response: Office display name is empty or too long".to_string());
+        }
+        if let Some(locator) = &self.locator {
+            if locator.trim().is_empty() || locator.chars().count() > MAX_OFFICE_LOCATOR_CHARS {
+                return Err(
+                    "invalid_response: Office document locator is empty or too long".to_string(),
+                );
+            }
+        }
+        match self.kind {
+            OfficeDocumentKind::Unsaved if self.locator.is_some() => {
+                Err("invalid_response: unsaved Office document has a locator".to_string())
+            }
+            OfficeDocumentKind::LocalFile | OfficeDocumentKind::CloudDocument
+                if self.locator.is_none() =>
+            {
+                Err("invalid_response: saved Office document is missing a locator".to_string())
+            }
+            OfficeDocumentKind::LocalFile => {
+                let locator = self.locator.as_deref().unwrap_or_default();
+                if std::path::Path::new(locator).is_absolute() {
+                    Ok(())
+                } else {
+                    Err("invalid_response: local Office locator is not absolute".to_string())
+                }
+            }
+            OfficeDocumentKind::CloudDocument => {
+                let locator = self.locator.as_deref().unwrap_or_default();
+                if locator.starts_with("https://") || locator.starts_with("http://") {
+                    Ok(())
+                } else {
+                    Err("invalid_response: cloud Office locator is not HTTP(S)".to_string())
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+
+    pub fn public_view(&self) -> OfficeDocumentRefView {
+        OfficeDocumentRefView {
+            provider: self.provider.clone(),
+            application: self.application,
+            kind: self.kind,
+            display_name: self.display_name.clone(),
+            observed_at_ms: self.observed_at_ms,
+            confidence: self.confidence.clone(),
+            resumable: self.locator.is_some() && self.kind != OfficeDocumentKind::Unsaved,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+pub enum OfficeRequest {
+    Ping {
+        request_id: u64,
+    },
+    Resolve {
+        request_id: u64,
+        generation: u64,
+        application: OfficeApplication,
+        root_hwnd: i64,
+        document_hwnd: i64,
+        pid: u32,
+        title: String,
+    },
+    Shutdown {
+        request_id: u64,
+    },
+}
+
+impl OfficeRequest {
+    #[allow(dead_code)]
+    pub fn request_id(&self) -> u64 {
+        match self {
+            Self::Ping { request_id }
+            | Self::Resolve { request_id, .. }
+            | Self::Shutdown { request_id } => *request_id,
+        }
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if let Self::Resolve {
+            generation,
+            root_hwnd,
+            document_hwnd,
+            pid,
+            title,
+            ..
+        } = self
+        {
+            if *generation == 0 {
+                return Err("invalid_request: Office generation must be positive".to_string());
+            }
+            if *root_hwnd == 0 || *document_hwnd == 0 || *pid == 0 {
+                return Err("invalid_request: Office HWND and PID must be positive".to_string());
+            }
+            if title.chars().count() > MAX_OFFICE_TITLE_CHARS {
+                return Err("limit_exceeded: Office window title is too long".to_string());
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum OfficeResponse {
+    Ready {
+        protocol_version: u32,
+        worker_version: String,
+    },
+    Pong {
+        request_id: u64,
+    },
+    Resolved {
+        request_id: u64,
+        generation: u64,
+        document_hwnd: i64,
+        document: Option<OfficeDocumentRef>,
+        elapsed_ms: f64,
+    },
+    Error {
+        request_id: u64,
+        generation: Option<u64>,
+        kind: String,
+        message: String,
+        elapsed_ms: f64,
+    },
+    ShuttingDown {
+        request_id: u64,
+    },
+}
+
+impl OfficeResponse {
+    fn validate(&self) -> Result<(), String> {
+        match self {
+            Self::Ready {
+                protocol_version,
+                worker_version,
+            } => {
+                if *protocol_version != OFFICE_PROTOCOL_VERSION || worker_version.trim().is_empty()
+                {
+                    return Err("invalid_response: invalid Office worker handshake".to_string());
+                }
+            }
+            Self::Resolved {
+                generation,
+                document_hwnd,
+                document,
+                elapsed_ms,
+                ..
+            } => {
+                if *generation == 0
+                    || *document_hwnd == 0
+                    || !elapsed_ms.is_finite()
+                    || *elapsed_ms < 0.0
+                {
+                    return Err("invalid_response: invalid Office resolution envelope".to_string());
+                }
+                if let Some(document) = document {
+                    document.validate()?;
+                }
+            }
+            Self::Error {
+                kind,
+                message,
+                elapsed_ms,
+                ..
+            } => {
+                if kind.trim().is_empty()
+                    || kind.chars().count() > 128
+                    || message.chars().count() > MAX_OFFICE_ERROR_CHARS
+                    || !elapsed_ms.is_finite()
+                    || *elapsed_ms < 0.0
+                {
+                    return Err("invalid_response: invalid Office error envelope".to_string());
+                }
+            }
+            Self::Pong { .. } | Self::ShuttingDown { .. } => {}
+        }
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+pub fn read_request<R: Read>(reader: &mut R) -> Result<OfficeRequest, String> {
+    let bytes = read_frame(reader)?;
+    let request: OfficeRequest = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("protocol: invalid Office request JSON: {error}"))?;
+    request.validate()?;
+    Ok(request)
+}
+
+pub fn write_request<W: Write>(writer: &mut W, request: &OfficeRequest) -> Result<(), String> {
+    request.validate()?;
+    write_json_frame(writer, request)
+}
+
+pub fn read_response<R: Read>(reader: &mut R) -> Result<OfficeResponse, String> {
+    let bytes = read_frame(reader)?;
+    let response: OfficeResponse = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("protocol: invalid Office response JSON: {error}"))?;
+    response.validate()?;
+    Ok(response)
+}
+
+#[allow(dead_code)]
+pub fn write_response<W: Write>(writer: &mut W, response: &OfficeResponse) -> Result<(), String> {
+    response.validate()?;
+    write_json_frame(writer, response)
+}
+
+fn write_json_frame<W: Write, T: Serialize>(writer: &mut W, value: &T) -> Result<(), String> {
+    let bytes = serde_json::to_vec(value)
+        .map_err(|error| format!("protocol: failed to encode Office frame: {error}"))?;
+    if bytes.len() > MAX_OFFICE_FRAME_BYTES {
+        return Err(format!(
+            "limit_exceeded: Office frame is {} bytes; maximum is {}",
+            bytes.len(),
+            MAX_OFFICE_FRAME_BYTES
+        ));
+    }
+    let len = u32::try_from(bytes.len())
+        .map_err(|_| "limit_exceeded: Office frame length does not fit u32".to_string())?;
+    writer
+        .write_all(&len.to_le_bytes())
+        .and_then(|_| writer.write_all(&bytes))
+        .and_then(|_| writer.flush())
+        .map_err(|error| format!("transport: failed to write Office frame: {error}"))
+}
+
+fn read_frame<R: Read>(reader: &mut R) -> Result<Vec<u8>, String> {
+    let mut len_bytes = [0u8; 4];
+    reader
+        .read_exact(&mut len_bytes)
+        .map_err(|error| format!("transport: failed to read Office frame length: {error}"))?;
+    let len = u32::from_le_bytes(len_bytes) as usize;
+    if len == 0 || len > MAX_OFFICE_FRAME_BYTES {
+        return Err(format!(
+            "limit_exceeded: Office frame length {len} is outside 1..={MAX_OFFICE_FRAME_BYTES}"
+        ));
+    }
+    let mut bytes = vec![0u8; len];
+    reader
+        .read_exact(&mut bytes)
+        .map_err(|error| format!("transport: failed to read Office frame body: {error}"))?;
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn process_names_map_to_supported_office_apps() {
+        assert_eq!(
+            OfficeApplication::from_process_name("WINWORD.EXE"),
+            Some(OfficeApplication::Word)
+        );
+        assert_eq!(
+            OfficeApplication::from_process_name("excel"),
+            Some(OfficeApplication::Excel)
+        );
+        assert_eq!(OfficeApplication::from_process_name("outlook.exe"), None);
+    }
+
+    #[test]
+    fn powerpoint_native_window_classes_are_strict_and_prioritized() {
+        let application = OfficeApplication::PowerPoint;
+        assert_eq!(
+            application.native_window_class_priority("paneClassDC"),
+            Some(0)
+        );
+        assert_eq!(
+            application.native_window_class_priority("MDICLASS"),
+            Some(1)
+        );
+        assert_eq!(
+            application.native_window_class_priority("MsoWorkPane"),
+            None
+        );
+    }
+
+    #[test]
+    fn request_round_trip_is_framed_and_validated() {
+        let request = OfficeRequest::Resolve {
+            request_id: 7,
+            generation: 9,
+            application: OfficeApplication::PowerPoint,
+            root_hwnd: 42,
+            document_hwnd: 43,
+            pid: 99,
+            title: "Roadmap - PowerPoint".to_string(),
+        };
+        let mut bytes = Vec::new();
+        write_request(&mut bytes, &request).unwrap();
+        assert_eq!(read_request(&mut Cursor::new(bytes)).unwrap(), request);
+    }
+
+    #[test]
+    fn oversized_frames_are_rejected_before_allocation() {
+        let mut bytes = ((MAX_OFFICE_FRAME_BYTES + 1) as u32).to_le_bytes().to_vec();
+        bytes.extend_from_slice(b"ignored");
+        let error = read_response(&mut Cursor::new(bytes)).unwrap_err();
+        assert!(error.starts_with("limit_exceeded:"));
+    }
+
+    #[test]
+    fn resolve_requests_reject_oversized_window_titles() {
+        let request = OfficeRequest::Resolve {
+            request_id: 7,
+            generation: 9,
+            application: OfficeApplication::Word,
+            root_hwnd: 42,
+            document_hwnd: 43,
+            pid: 99,
+            title: "x".repeat(MAX_OFFICE_TITLE_CHARS + 1),
+        };
+
+        assert!(write_request(&mut Vec::new(), &request)
+            .unwrap_err()
+            .starts_with("limit_exceeded:"));
+    }
+
+    #[test]
+    fn unsaved_documents_cannot_carry_a_locator() {
+        let reference = OfficeDocumentRef {
+            provider: "office_nativeom".to_string(),
+            application: OfficeApplication::Word,
+            kind: OfficeDocumentKind::Unsaved,
+            display_name: "Document1".to_string(),
+            locator: Some(r"C:\\Document1.docx".to_string()),
+            observed_at_ms: 1,
+            confidence: "exact".to_string(),
+        };
+        assert!(reference.validate().is_err());
+    }
+
+    #[test]
+    fn relative_local_locators_are_rejected() {
+        let reference = OfficeDocumentRef {
+            provider: "office_nativeom".to_string(),
+            application: OfficeApplication::Excel,
+            kind: OfficeDocumentKind::LocalFile,
+            display_name: "Book.xlsx".to_string(),
+            locator: Some("Book.xlsx".to_string()),
+            observed_at_ms: 1,
+            confidence: "exact".to_string(),
+        };
+        assert!(reference.validate().is_err());
+    }
+
+    #[test]
+    fn public_document_view_does_not_serialize_the_locator() {
+        let reference = OfficeDocumentRef {
+            provider: "office_nativeom".to_string(),
+            application: OfficeApplication::Word,
+            kind: OfficeDocumentKind::LocalFile,
+            display_name: "Plan.docx".to_string(),
+            locator: Some(r"C:\\private\\Plan.docx".to_string()),
+            observed_at_ms: 1,
+            confidence: "exact".to_string(),
+        };
+
+        let value = serde_json::to_value(reference.public_view()).unwrap();
+        assert_eq!(value["resumable"], true);
+        assert!(value.get("locator").is_none());
+    }
+}

--- a/src-tauri/src/office_runtime.rs
+++ b/src-tauri/src/office_runtime.rs
@@ -1,0 +1,1416 @@
+//! Supervision, latest-only scheduling, caching, and screenshot association for Office.
+
+use crate::office_protocol::{
+    read_response, write_request, OfficeApplication, OfficeDocumentKind, OfficeDocumentRef,
+    OfficeRequest, OfficeResponse, OFFICE_PROTOCOL_VERSION,
+};
+use crate::office_window::{find_native_document_window, validate_office_window_context};
+use crate::resource_utils::find_existing_file_in_resources;
+use crate::storage::{StorageState, STALE_DOCUMENT_REF_GENERATION};
+use std::collections::{HashMap, VecDeque};
+use std::io::{BufReader, BufWriter};
+use std::os::windows::io::AsRawHandle;
+use std::os::windows::process::CommandExt;
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Emitter};
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+const BELOW_NORMAL_PRIORITY_CLASS: u32 = 0x00004000;
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(3);
+const REQUEST_TIMEOUT: Duration = Duration::from_millis(2500);
+const SUCCESS_CACHE_TTL: Duration = Duration::from_secs(60);
+const EMPTY_CACHE_TTL: Duration = Duration::from_secs(15);
+const FAILURE_CACHE_BASE_TTL: Duration = Duration::from_secs(2);
+const FAILURE_CACHE_MAX_TTL: Duration = Duration::from_secs(60);
+const MAX_CACHE_ENTRIES: usize = 64;
+const MAX_PENDING_SCREENSHOTS: usize = 64;
+/// Polling step while draining, matching the in-flight OCR wait in
+/// `monitor.rs::stop_monitor_impl`.
+const QUIESCE_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct OfficeWindowFingerprint {
+    application: OfficeApplication,
+    root_hwnd: i64,
+    document_hwnd: i64,
+    pid: u32,
+    title: String,
+}
+
+/// Opaque token carried from foreground observation to screenshot persistence.
+#[derive(Clone, Debug)]
+pub struct OfficeCaptureContext {
+    fingerprint: OfficeWindowFingerprint,
+    generation: u64,
+}
+
+impl OfficeCaptureContext {
+    pub fn document_hwnd(&self) -> i64 {
+        self.fingerprint.document_hwnd
+    }
+}
+
+#[derive(Clone, Debug)]
+struct QueuedObservation {
+    generation: u64,
+    fingerprint: OfficeWindowFingerprint,
+}
+
+/// A screenshot waiting for the resolution of the window it was taken from.
+///
+/// The database generation is captured when the id is handed over, not when
+/// the write finally happens: an id only identifies a screenshot within the
+/// database it was issued by.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PendingScreenshot {
+    id: i64,
+    db_generation: u64,
+}
+
+#[derive(Clone, Debug)]
+struct PendingAssociation {
+    fingerprint: OfficeWindowFingerprint,
+    resolution: PendingResolution,
+    screenshot: PendingScreenshot,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PendingResolution {
+    Awaiting(u64),
+    DeferredFailure,
+}
+
+/// Admission control for the observation pipeline.
+///
+/// `active` and `resolving` share one mutex so that `quiesce` cannot close the
+/// gate in the window between the consumer reading `active` and announcing that
+/// it started a resolution — that gap would let a resolution, and the write
+/// that follows it, begin after the drain reported success.
+#[derive(Default)]
+struct RuntimeGate {
+    active: bool,
+    resolving: bool,
+}
+
+/// Holds the drain open for one association write.
+///
+/// Created while the observation lock is held, so a write is always counted
+/// before the state that led to it becomes invisible; released when the
+/// blocking task ends, including on panic.
+struct PendingWriteGuard(Arc<AtomicU32>);
+
+impl PendingWriteGuard {
+    fn new(counter: &Arc<AtomicU32>) -> Self {
+        counter.fetch_add(1, Ordering::SeqCst);
+        Self(counter.clone())
+    }
+}
+
+impl Drop for PendingWriteGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// Marks a resolution as running for as long as it runs, unwinding included.
+/// A resolution that ended without clearing the flag would make every later
+/// drain wait out its full timeout.
+struct ResolutionGuard<'a>(&'a Mutex<RuntimeGate>);
+
+impl Drop for ResolutionGuard<'_> {
+    fn drop(&mut self) {
+        self.0
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .resolving = false;
+    }
+}
+
+#[derive(Clone, Debug)]
+enum CachedResolutionOutcome {
+    Document(OfficeDocumentRef),
+    ConfirmedEmpty,
+    TransientFailure,
+}
+
+struct CachedResolution {
+    generation: u64,
+    outcome: CachedResolutionOutcome,
+    refreshed_at: Instant,
+    valid_for: Duration,
+    consecutive_failures: u32,
+}
+
+impl CachedResolution {
+    fn is_fresh(&self) -> bool {
+        self.refreshed_at.elapsed() < self.valid_for
+    }
+}
+
+struct ObservationState {
+    latest_generation: u64,
+    last_observed: Option<OfficeWindowFingerprint>,
+    active_query: Option<QueuedObservation>,
+    cache: HashMap<OfficeWindowFingerprint, CachedResolution>,
+    pending_screenshots: VecDeque<PendingAssociation>,
+}
+
+enum QueueUpdate {
+    None,
+    Invalidate,
+    Resolve(QueuedObservation),
+}
+
+struct OfficeChild {
+    child: Mutex<Child>,
+    stdin: Mutex<BufWriter<ChildStdin>>,
+    stdout: Mutex<BufReader<ChildStdout>>,
+    request_lock: Mutex<()>,
+    _job: OfficeJobHandle,
+}
+
+impl OfficeChild {
+    fn request(&self, request: &OfficeRequest) -> Result<OfficeResponse, String> {
+        let _request_guard = self
+            .request_lock
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        {
+            let mut stdin = self.stdin.lock().unwrap_or_else(|error| error.into_inner());
+            write_request(&mut *stdin, request)?;
+        }
+        let mut stdout = self
+            .stdout
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        read_response(&mut *stdout)
+    }
+
+    fn kill(&self) {
+        let mut child = self.child.lock().unwrap_or_else(|error| error.into_inner());
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+struct PendingOfficeChild(Option<Child>);
+
+impl PendingOfficeChild {
+    fn new(child: Child) -> Self {
+        Self(Some(child))
+    }
+
+    fn child(&self) -> &Child {
+        self.0.as_ref().expect("pending Office child is available")
+    }
+
+    fn child_mut(&mut self) -> &mut Child {
+        self.0.as_mut().expect("pending Office child is available")
+    }
+
+    fn take(&mut self) -> Child {
+        self.0.take().expect("pending Office child is available")
+    }
+}
+
+impl Drop for PendingOfficeChild {
+    fn drop(&mut self) {
+        if let Some(child) = self.0.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+struct OfficeJobHandle(HANDLE);
+
+impl Drop for OfficeJobHandle {
+    fn drop(&mut self) {
+        // SAFETY: the RAII wrapper owns this Job Object handle exactly once.
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+// SAFETY: Job Object handles are thread-safe opaque kernel references; the
+// wrapper enforces single-close ownership.
+unsafe impl Send for OfficeJobHandle {}
+// SAFETY: shared access does not expose mutable Rust memory.
+unsafe impl Sync for OfficeJobHandle {}
+
+struct SupervisorState {
+    process: Option<Arc<OfficeChild>>,
+    worker_version: Option<String>,
+    restart_count: u64,
+    last_error: Option<String>,
+}
+
+struct OfficeResolution {
+    generation: u64,
+    document_hwnd: i64,
+    document: Option<OfficeDocumentRef>,
+}
+
+pub struct OfficeRuntimeState {
+    observations: Mutex<ObservationState>,
+    sender: tokio::sync::watch::Sender<Option<QueuedObservation>>,
+    receiver: Mutex<Option<tokio::sync::watch::Receiver<Option<QueuedObservation>>>>,
+    supervisor: Mutex<SupervisorState>,
+    lifecycle_lock: Mutex<()>,
+    request_gate: tokio::sync::Mutex<()>,
+    next_request_id: AtomicU64,
+    /// Whether observation, resolution and association are currently accepted.
+    /// Lock order: acquired before `observations`, never after.
+    gate: Mutex<RuntimeGate>,
+    /// Association writes handed to the blocking pool but not yet finished.
+    in_flight_writes: Arc<AtomicU32>,
+}
+
+impl Default for OfficeRuntimeState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OfficeRuntimeState {
+    pub fn new() -> Self {
+        let (sender, receiver) = tokio::sync::watch::channel(None);
+        Self {
+            observations: Mutex::new(ObservationState {
+                latest_generation: 0,
+                last_observed: None,
+                active_query: None,
+                cache: HashMap::new(),
+                pending_screenshots: VecDeque::new(),
+            }),
+            sender,
+            receiver: Mutex::new(Some(receiver)),
+            supervisor: Mutex::new(SupervisorState {
+                process: None,
+                worker_version: None,
+                restart_count: 0,
+                last_error: None,
+            }),
+            lifecycle_lock: Mutex::new(()),
+            request_gate: tokio::sync::Mutex::new(()),
+            next_request_id: AtomicU64::new(1),
+            // Observation follows the capture loop: the gate opens when the
+            // monitor starts, not when the runtime is constructed.
+            gate: Mutex::new(RuntimeGate {
+                active: false,
+                resolving: false,
+            }),
+            in_flight_writes: Arc::new(AtomicU32::new(0)),
+        }
+    }
+
+    /// Start the single latest-only observation consumer.
+    pub fn start(self: &Arc<Self>, app: AppHandle, storage: Arc<StorageState>) {
+        let receiver = self
+            .receiver
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take();
+        let Some(mut receiver) = receiver else {
+            return;
+        };
+        let runtime = self.clone();
+        tauri::async_runtime::spawn(async move {
+            while receiver.changed().await.is_ok() {
+                let observation = receiver.borrow_and_update().clone();
+                let Some(observation) = observation else {
+                    continue;
+                };
+                let Some(resolution_guard) = runtime.begin_resolution() else {
+                    continue;
+                };
+                let result = runtime.resolve(&app, &observation).await;
+                runtime.complete_observation(app.clone(), storage.clone(), observation, result);
+                drop(resolution_guard);
+            }
+        });
+    }
+
+    /// Reopen the gate closed by [`OfficeRuntimeState::quiesce`].
+    ///
+    /// Called when the capture loop is (re)started; observation only makes
+    /// sense while screenshots are being taken.
+    pub fn resume(&self) {
+        let mut gate = self.gate.lock().unwrap_or_else(|error| error.into_inner());
+        gate.active = true;
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.gate
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .active
+    }
+
+    /// Stop observing, let in-flight resolutions and writes finish, then
+    /// release the worker process.
+    ///
+    /// Must be awaited before the database is closed or replaced — by
+    /// `stop_monitor_impl`, by backup export/import, and by the
+    /// data-directory switch. Association writes carry screenshot ids that
+    /// only mean something in the database they came from, and the worker has
+    /// no reason to keep talking to Office once capture has stopped.
+    ///
+    /// Returns whether everything drained within `timeout`; on timeout the
+    /// remaining writes are still rejected by the generation check in
+    /// `storage/document_ref.rs`.
+    pub async fn quiesce(&self, timeout: Duration) -> bool {
+        {
+            let mut gate = self.gate.lock().unwrap_or_else(|error| error.into_inner());
+            gate.active = false;
+        }
+        self.sender.send_replace(None);
+
+        let deadline = tokio::time::Instant::now() + timeout;
+        let drained = loop {
+            let resolving = self
+                .gate
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .resolving;
+            let writes = self.in_flight_writes.load(Ordering::SeqCst);
+            if !resolving && writes == 0 {
+                break true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                tracing::warn!(
+                    "[OFFICE:LIFECYCLE] drain timed out (resolving={}, pending writes={})",
+                    resolving,
+                    writes
+                );
+                break false;
+            }
+            tokio::time::sleep(QUIESCE_POLL_INTERVAL).await;
+        };
+
+        // Everything here belongs to the database that is about to go away:
+        // pending ids, and cached resolutions keyed by windows whose next
+        // screenshots will be numbered by a different database.
+        {
+            let mut state = self
+                .observations
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            state.last_observed = None;
+            state.active_query = None;
+            state.cache.clear();
+            state.pending_screenshots.clear();
+        }
+
+        let process = {
+            let mut supervisor = self
+                .supervisor
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            supervisor.worker_version = None;
+            supervisor.process.take()
+        };
+        if let Some(process) = process {
+            tracing::info!("[OFFICE:LIFECYCLE] releasing worker after drain");
+            if let Err(error) = tokio::task::spawn_blocking(move || process.kill()).await {
+                tracing::warn!("[OFFICE:LIFECYCLE] worker shutdown task failed: {}", error);
+            }
+        }
+
+        drained
+    }
+
+    /// Announce a resolution while the gate is open, so a concurrent drain
+    /// waits for it. Returns `None` when the gate has already closed.
+    fn begin_resolution(&self) -> Option<ResolutionGuard<'_>> {
+        let mut gate = self.gate.lock().unwrap_or_else(|error| error.into_inner());
+        if !gate.active {
+            return None;
+        }
+        gate.resolving = true;
+        Some(ResolutionGuard(&self.gate))
+    }
+
+    /// Observe a foreground Office window without issuing COM on the caller thread.
+    pub fn observe_window(
+        &self,
+        application: OfficeApplication,
+        root_hwnd: i64,
+        pid: u32,
+        title: &str,
+    ) -> Option<OfficeCaptureContext> {
+        if !self.is_active() {
+            return None;
+        }
+        let document_hwnd = find_native_document_window(root_hwnd, pid, application)?;
+        let fingerprint = OfficeWindowFingerprint {
+            application,
+            root_hwnd,
+            document_hwnd,
+            pid,
+            title: title.to_string(),
+        };
+
+        let (context, update) = {
+            let mut state = self
+                .observations
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            let mut update = QueueUpdate::None;
+
+            if state.last_observed.as_ref() != Some(&fingerprint) {
+                state.last_observed = Some(fingerprint.clone());
+                if state
+                    .active_query
+                    .as_ref()
+                    .is_some_and(|query| query.fingerprint != fingerprint)
+                {
+                    // The query is stale only for latest-window caching. Any
+                    // screenshot already issued against this generation still
+                    // owns its eventual result and must remain pending.
+                    state.active_query = None;
+                    next_generation(&mut state);
+                    update = QueueUpdate::Invalidate;
+                }
+            }
+
+            if let Some(active) = state
+                .active_query
+                .as_ref()
+                .filter(|query| query.fingerprint == fingerprint)
+            {
+                (
+                    OfficeCaptureContext {
+                        fingerprint,
+                        generation: active.generation,
+                    },
+                    update,
+                )
+            } else if let Some(cached) = state
+                .cache
+                .get(&fingerprint)
+                .filter(|entry| entry.is_fresh())
+            {
+                (
+                    OfficeCaptureContext {
+                        fingerprint,
+                        generation: cached.generation,
+                    },
+                    update,
+                )
+            } else {
+                let generation = next_generation(&mut state);
+                let observation = QueuedObservation {
+                    generation,
+                    fingerprint: fingerprint.clone(),
+                };
+                state.active_query = Some(observation.clone());
+                (
+                    OfficeCaptureContext {
+                        fingerprint,
+                        generation,
+                    },
+                    // A stale in-flight query may have set `update` to
+                    // `Invalidate` above. The new observation must replace it;
+                    // otherwise the watch channel is cleared without ever
+                    // scheduling the newly active Office window.
+                    QueueUpdate::Resolve(observation),
+                )
+            }
+        };
+
+        match update {
+            QueueUpdate::None => {}
+            QueueUpdate::Invalidate => {
+                self.sender.send_replace(None);
+            }
+            QueueUpdate::Resolve(observation) => {
+                self.sender.send_replace(Some(observation));
+            }
+        }
+        Some(context)
+    }
+
+    /// Associate a newly persisted screenshot with the matching cached or pending result.
+    ///
+    /// `db_generation_before_save` is the generation the caller read just
+    /// before the screenshot row was written; see `capture.rs`.
+    pub fn associate_screenshot(
+        &self,
+        app: AppHandle,
+        storage: Arc<StorageState>,
+        screenshot_id: i64,
+        context: OfficeCaptureContext,
+        db_generation_before_save: u64,
+    ) {
+        if screenshot_id <= 0 || !self.is_active() {
+            return;
+        }
+        // The insert sits between the caller's reading and this one. If they
+        // agree, no swap crossed it and the id belongs to the database that is
+        // open now; if they disagree, which database issued the id is unknown
+        // and the association has to be dropped.
+        if storage.db_generation() != db_generation_before_save {
+            tracing::info!(
+                "[OFFICE:STORAGE] dropped association for screenshot {}: storage changed while it was saved",
+                screenshot_id
+            );
+            return;
+        }
+        let pending = PendingScreenshot {
+            id: screenshot_id,
+            db_generation: db_generation_before_save,
+        };
+        let persist = {
+            let mut state = self
+                .observations
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            if let Some(cached) = state
+                .cache
+                .get(&context.fingerprint)
+                .filter(|entry| entry.generation == context.generation && entry.is_fresh())
+            {
+                match &cached.outcome {
+                    CachedResolutionOutcome::Document(document) => Some((
+                        document.clone(),
+                        PendingWriteGuard::new(&self.in_flight_writes),
+                    )),
+                    CachedResolutionOutcome::TransientFailure => {
+                        enqueue_pending_screenshot(
+                            &mut state,
+                            context.fingerprint.clone(),
+                            PendingResolution::DeferredFailure,
+                            pending,
+                        );
+                        None
+                    }
+                    CachedResolutionOutcome::ConfirmedEmpty => None,
+                }
+            } else if state.active_query.as_ref().is_some_and(|query| {
+                query.generation == context.generation && query.fingerprint == context.fingerprint
+            }) {
+                enqueue_pending_screenshot(
+                    &mut state,
+                    context.fingerprint.clone(),
+                    PendingResolution::Awaiting(context.generation),
+                    pending,
+                );
+                None
+            } else {
+                None
+            }
+        };
+
+        if let Some((document, write_guard)) = persist {
+            persist_document_refs(app, storage, vec![pending], document, write_guard);
+        }
+    }
+
+    fn complete_observation(
+        &self,
+        app: AppHandle,
+        storage: Arc<StorageState>,
+        observation: QueuedObservation,
+        result: Result<OfficeResolution, String>,
+    ) {
+        let outcome = match &result {
+            Ok(resolution)
+                if resolution.generation == observation.generation
+                    && resolution.document_hwnd == observation.fingerprint.document_hwnd =>
+            {
+                match &resolution.document {
+                    Some(document) => CachedResolutionOutcome::Document(document.clone()),
+                    None => CachedResolutionOutcome::ConfirmedEmpty,
+                }
+            }
+            _ => CachedResolutionOutcome::TransientFailure,
+        };
+        let mut document_to_persist = None;
+        let mut write_guard = None;
+        let pending_ids = {
+            let mut state = self
+                .observations
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            let is_current = state.active_query.as_ref().is_some_and(|active| {
+                active.generation == observation.generation
+                    && active.fingerprint == observation.fingerprint
+                    && state.latest_generation == observation.generation
+            });
+            let pending = match &outcome {
+                CachedResolutionOutcome::Document(document) => {
+                    let pending = take_pending_screenshots(
+                        &mut state.pending_screenshots,
+                        &observation.fingerprint,
+                        observation.generation,
+                    );
+                    if !pending.is_empty() {
+                        // Counted before the lock is released, so a drain that
+                        // starts right now still waits for this write.
+                        write_guard = Some(PendingWriteGuard::new(&self.in_flight_writes));
+                        document_to_persist = Some(document.clone());
+                    }
+                    pending
+                }
+                CachedResolutionOutcome::ConfirmedEmpty => {
+                    let pending = take_pending_screenshots(
+                        &mut state.pending_screenshots,
+                        &observation.fingerprint,
+                        observation.generation,
+                    );
+                    if !pending.is_empty() {
+                        tracing::debug!(
+                            "[OFFICE:CACHE] discarded {} pending associations after confirming no document",
+                            pending.len()
+                        );
+                    }
+                    pending
+                }
+                CachedResolutionOutcome::TransientFailure => {
+                    defer_pending_screenshots(
+                        &mut state.pending_screenshots,
+                        &observation.fingerprint,
+                        observation.generation,
+                    );
+                    Vec::new()
+                }
+            };
+
+            if !is_current {
+                tracing::debug!(
+                    "[OFFICE:CACHE] ignored stale generation {} for cache; completing {} pending associations",
+                    observation.generation,
+                    pending.len()
+                );
+            } else {
+                state.active_query = None;
+                let previous_failures = state
+                    .cache
+                    .get(&observation.fingerprint)
+                    .map(|cached| cached.consecutive_failures)
+                    .unwrap_or(0);
+                let (outcome, valid_for, consecutive_failures) = match outcome {
+                    CachedResolutionOutcome::Document(document) => (
+                        CachedResolutionOutcome::Document(document),
+                        SUCCESS_CACHE_TTL,
+                        0,
+                    ),
+                    CachedResolutionOutcome::ConfirmedEmpty => {
+                        (CachedResolutionOutcome::ConfirmedEmpty, EMPTY_CACHE_TTL, 0)
+                    }
+                    CachedResolutionOutcome::TransientFailure => {
+                        if result.is_ok() {
+                            tracing::debug!(
+                                "[OFFICE:CACHE] document HWND changed during generation {}",
+                                observation.generation
+                            );
+                        } else if let Err(error) = &result {
+                            tracing::warn!(
+                                "[OFFICE:RESOLVE] generation {} failed: {}",
+                                observation.generation,
+                                error
+                            );
+                        }
+                        let failures = previous_failures.saturating_add(1);
+                        (
+                            CachedResolutionOutcome::TransientFailure,
+                            failure_cache_ttl(failures),
+                            failures,
+                        )
+                    }
+                };
+                insert_cache_entry(
+                    &mut state,
+                    observation.fingerprint,
+                    CachedResolution {
+                        generation: observation.generation,
+                        outcome,
+                        refreshed_at: Instant::now(),
+                        valid_for,
+                        consecutive_failures,
+                    },
+                );
+            }
+            pending
+        };
+
+        if let (Some(document), Some(write_guard)) = (document_to_persist, write_guard) {
+            persist_document_refs(app, storage, pending_ids, document, write_guard);
+        }
+    }
+
+    async fn resolve(
+        self: &Arc<Self>,
+        app: &AppHandle,
+        observation: &QueuedObservation,
+    ) -> Result<OfficeResolution, String> {
+        let _request_guard = self.request_gate.lock().await;
+        let runtime = self.clone();
+        let app_for_start = app.clone();
+        let process = tokio::task::spawn_blocking(move || runtime.ensure_process(&app_for_start))
+            .await
+            .map_err(|error| format!("Office worker startup task failed: {error}"))??;
+
+        let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
+        let request = OfficeRequest::Resolve {
+            request_id,
+            generation: observation.generation,
+            application: observation.fingerprint.application,
+            root_hwnd: observation.fingerprint.root_hwnd,
+            document_hwnd: observation.fingerprint.document_hwnd,
+            pid: observation.fingerprint.pid,
+            title: observation.fingerprint.title.clone(),
+        };
+        let process_for_request = process.clone();
+        let request_task =
+            tokio::task::spawn_blocking(move || process_for_request.request(&request));
+        let response = match tokio::time::timeout(REQUEST_TIMEOUT, request_task).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(error)) => Err(format!("Office request task failed: {error}")),
+            Err(_) => {
+                tracing::error!(
+                    "[OFFICE:WATCHDOG] request {} exceeded {} ms; killing worker",
+                    request_id,
+                    REQUEST_TIMEOUT.as_millis()
+                );
+                process.kill();
+                self.clear_process(&process, "watchdog_timeout");
+                return Err(format!(
+                    "Office watchdog timeout after {} ms",
+                    REQUEST_TIMEOUT.as_millis()
+                ));
+            }
+        };
+
+        match response {
+            Ok(OfficeResponse::Resolved {
+                request_id: response_id,
+                generation,
+                document_hwnd,
+                document,
+                ..
+            }) if response_id == request_id && generation == observation.generation => {
+                if document_hwnd != observation.fingerprint.document_hwnd {
+                    return Err(format!(
+                        "Office worker returned unexpected document HWND {}",
+                        document_hwnd
+                    ));
+                }
+                if !validate_office_window_context(
+                    observation.fingerprint.root_hwnd,
+                    observation.fingerprint.document_hwnd,
+                    observation.fingerprint.pid,
+                    observation.fingerprint.application,
+                    &observation.fingerprint.title,
+                ) {
+                    return Err("Office window context changed after COM resolution".to_string());
+                }
+                if document.as_ref().is_some_and(|reference| {
+                    reference.application != observation.fingerprint.application
+                }) {
+                    return Err(
+                        "Office worker returned a document for the wrong application".to_string(),
+                    );
+                }
+                Ok(OfficeResolution {
+                    generation,
+                    document_hwnd,
+                    document,
+                })
+            }
+            Ok(OfficeResponse::Error {
+                request_id: response_id,
+                generation,
+                kind,
+                message,
+                ..
+            }) if response_id == request_id && generation == Some(observation.generation) => {
+                if kind == "panic" {
+                    process.kill();
+                    self.clear_process(&process, "worker_panic");
+                }
+                Err(format!("Office {kind}: {message}"))
+            }
+            Ok(other) => {
+                let error = format!(
+                    "unexpected Office response for request {request_id}: {}",
+                    response_kind(&other)
+                );
+                process.kill();
+                self.clear_process(&process, "protocol_mismatch");
+                Err(error)
+            }
+            Err(error) => {
+                process.kill();
+                self.clear_process(&process, "transport_failure");
+                Err(error)
+            }
+        }
+    }
+
+    fn ensure_process(&self, app: &AppHandle) -> Result<Arc<OfficeChild>, String> {
+        let _lifecycle_guard = self
+            .lifecycle_lock
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let existing = self
+            .supervisor
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .process
+            .clone();
+        if let Some(process) = existing {
+            let running = process
+                .child
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .try_wait()
+                .map_err(|error| format!("failed to inspect Office worker: {error}"))?
+                .is_none();
+            if running {
+                return Ok(process);
+            }
+            let mut supervisor = self
+                .supervisor
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            if supervisor
+                .process
+                .as_ref()
+                .is_some_and(|current| Arc::ptr_eq(current, &process))
+            {
+                supervisor.process = None;
+                supervisor.restart_count += 1;
+            }
+        }
+        self.start_process(app)
+    }
+
+    fn start_process(&self, app: &AppHandle) -> Result<Arc<OfficeChild>, String> {
+        let executable = resolve_office_executable(app)?;
+        let mut command = Command::new(&executable);
+        command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .creation_flags(CREATE_NO_WINDOW | BELOW_NORMAL_PRIORITY_CLASS);
+        tracing::info!(
+            "[OFFICE:SUPERVISOR] starting worker path={}",
+            executable.display()
+        );
+        let child = command
+            .spawn()
+            .map_err(|error| format!("failed to start Office worker: {error}"))?;
+        let mut pending = PendingOfficeChild::new(child);
+        let job = assign_kill_on_close_job(pending.child())?;
+        let stdin = pending
+            .child_mut()
+            .stdin
+            .take()
+            .ok_or("Office worker stdin unavailable")?;
+        let stdout = pending
+            .child_mut()
+            .stdout
+            .take()
+            .ok_or("Office worker stdout unavailable")?;
+        if let Some(stderr) = pending.child_mut().stderr.take() {
+            std::thread::Builder::new()
+                .name("carbonpaper-office-log".to_string())
+                .spawn(move || {
+                    use std::io::BufRead;
+                    for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+                        tracing::info!("[OFFICE:WORKER] {line}");
+                    }
+                })
+                .map_err(|error| format!("failed to start Office log reader: {error}"))?;
+        }
+
+        let (ready_sender, ready_receiver) = std::sync::mpsc::sync_channel(1);
+        std::thread::Builder::new()
+            .name("carbonpaper-office-handshake".to_string())
+            .spawn(move || {
+                let mut reader = BufReader::new(stdout);
+                let ready = read_response(&mut reader);
+                let _ = ready_sender.send((ready, reader));
+            })
+            .map_err(|error| format!("failed to start Office handshake reader: {error}"))?;
+        let (ready, stdout) = ready_receiver
+            .recv_timeout(STARTUP_TIMEOUT)
+            .map_err(|_| "Office worker startup timed out".to_string())?;
+
+        let child = pending.take();
+        let process = Arc::new(OfficeChild {
+            child: Mutex::new(child),
+            stdin: Mutex::new(BufWriter::new(stdin)),
+            stdout: Mutex::new(stdout),
+            request_lock: Mutex::new(()),
+            _job: job,
+        });
+        match ready {
+            Ok(OfficeResponse::Ready {
+                protocol_version,
+                worker_version,
+            }) if protocol_version == OFFICE_PROTOCOL_VERSION => {
+                let mut supervisor = self
+                    .supervisor
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner());
+                supervisor.process = Some(process.clone());
+                supervisor.worker_version = Some(worker_version);
+                supervisor.last_error = None;
+                tracing::info!("[OFFICE:SUPERVISOR] worker ready");
+                Ok(process)
+            }
+            Ok(other) => {
+                process.kill();
+                Err(format!(
+                    "invalid Office worker handshake: {}",
+                    response_kind(&other)
+                ))
+            }
+            Err(error) => {
+                process.kill();
+                Err(format!("Office worker startup failed: {error}"))
+            }
+        }
+    }
+
+    fn clear_process(&self, process: &Arc<OfficeChild>, reason: &str) {
+        let mut supervisor = self
+            .supervisor
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if supervisor
+            .process
+            .as_ref()
+            .is_some_and(|current| Arc::ptr_eq(current, process))
+        {
+            supervisor.process = None;
+            supervisor.restart_count += 1;
+            supervisor.last_error = Some(reason.to_string());
+        }
+    }
+}
+
+fn response_kind(response: &OfficeResponse) -> &'static str {
+    match response {
+        OfficeResponse::Ready { .. } => "ready",
+        OfficeResponse::Pong { .. } => "pong",
+        OfficeResponse::Resolved { .. } => "resolved",
+        OfficeResponse::Error { .. } => "error",
+        OfficeResponse::ShuttingDown { .. } => "shutting_down",
+    }
+}
+
+fn next_generation(state: &mut ObservationState) -> u64 {
+    state.latest_generation = state.latest_generation.wrapping_add(1).max(1);
+    state.latest_generation
+}
+
+fn failure_cache_ttl(consecutive_failures: u32) -> Duration {
+    let exponent = consecutive_failures.saturating_sub(1).min(5);
+    let multiplier = 1u32 << exponent;
+    FAILURE_CACHE_BASE_TTL
+        .saturating_mul(multiplier)
+        .min(FAILURE_CACHE_MAX_TTL)
+}
+
+fn enqueue_pending_screenshot(
+    state: &mut ObservationState,
+    fingerprint: OfficeWindowFingerprint,
+    resolution: PendingResolution,
+    screenshot: PendingScreenshot,
+) {
+    if state.pending_screenshots.iter().any(|entry| {
+        entry.screenshot.id == screenshot.id
+            && entry.screenshot.db_generation == screenshot.db_generation
+    }) {
+        return;
+    }
+
+    if state.pending_screenshots.len() >= MAX_PENDING_SCREENSHOTS {
+        if let Some(evicted) = state.pending_screenshots.pop_front() {
+            tracing::warn!(
+                "[OFFICE:CACHE] pending association limit reached; evicted screenshot {}",
+                evicted.screenshot.id
+            );
+        }
+    }
+    state.pending_screenshots.push_back(PendingAssociation {
+        fingerprint,
+        resolution,
+        screenshot,
+    });
+}
+
+fn defer_pending_screenshots(
+    queue: &mut VecDeque<PendingAssociation>,
+    fingerprint: &OfficeWindowFingerprint,
+    generation: u64,
+) {
+    for entry in queue {
+        if &entry.fingerprint == fingerprint
+            && entry.resolution == PendingResolution::Awaiting(generation)
+        {
+            entry.resolution = PendingResolution::DeferredFailure;
+        }
+    }
+}
+
+fn take_pending_screenshots(
+    queue: &mut VecDeque<PendingAssociation>,
+    fingerprint: &OfficeWindowFingerprint,
+    generation: u64,
+) -> Vec<PendingScreenshot> {
+    let mut pending = Vec::new();
+    queue.retain(|entry| {
+        let belongs_to_resolution = match entry.resolution {
+            PendingResolution::DeferredFailure => true,
+            PendingResolution::Awaiting(active) => active == generation,
+        };
+        if &entry.fingerprint == fingerprint && belongs_to_resolution {
+            pending.push(entry.screenshot);
+            false
+        } else {
+            true
+        }
+    });
+    pending
+}
+
+fn insert_cache_entry(
+    state: &mut ObservationState,
+    fingerprint: OfficeWindowFingerprint,
+    entry: CachedResolution,
+) {
+    if state.cache.len() >= MAX_CACHE_ENTRIES && !state.cache.contains_key(&fingerprint) {
+        if let Some(oldest) = state
+            .cache
+            .iter()
+            .min_by_key(|(_, cached)| cached.refreshed_at)
+            .map(|(key, _)| key.clone())
+        {
+            state.cache.remove(&oldest);
+        }
+    }
+    state.cache.insert(fingerprint, entry);
+}
+
+fn persist_document_refs(
+    app: AppHandle,
+    storage: Arc<StorageState>,
+    screenshots: Vec<PendingScreenshot>,
+    document: OfficeDocumentRef,
+    write_guard: PendingWriteGuard,
+) {
+    if screenshots.is_empty() {
+        return;
+    }
+    tauri::async_runtime::spawn_blocking(move || {
+        // Released when this task ends, however it ends.
+        let _write_guard = write_guard;
+        for screenshot in screenshots {
+            match storage.save_screenshot_document_ref_for_generation(
+                screenshot.id,
+                &document,
+                screenshot.db_generation,
+            ) {
+                Ok(()) => {
+                    if let Err(error) = app.emit(
+                        "office-document-ref-updated",
+                        serde_json::json!({ "screenshot_id": screenshot.id }),
+                    ) {
+                        tracing::debug!(
+                            "[OFFICE:UI] failed to emit document update for {}: {}",
+                            screenshot.id,
+                            error
+                        );
+                    }
+                }
+                // Not a failure: the database this id belongs to is gone, so
+                // the association has nowhere meaningful to land.
+                Err(error) if error == STALE_DOCUMENT_REF_GENERATION => {
+                    tracing::info!(
+                        "[OFFICE:STORAGE] dropped association for screenshot {} after a storage switch",
+                        screenshot.id
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        "[OFFICE:STORAGE] failed to associate screenshot {}: {}",
+                        screenshot.id,
+                        error
+                    );
+                }
+            }
+        }
+    });
+}
+
+fn resolve_office_executable(app: &AppHandle) -> Result<PathBuf, String> {
+    if let Some(path) = find_existing_file_in_resources(app, "carbonpaper-office.exe") {
+        return Ok(path);
+    }
+    if let Ok(current) = std::env::current_exe() {
+        if let Some(directory) = current.parent() {
+            let sibling = directory.join("carbonpaper-office.exe");
+            if sibling.exists() {
+                return Ok(sibling);
+            }
+        }
+    }
+    let development = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("debug")
+        .join("carbonpaper-office.exe");
+    if development.exists() {
+        return Ok(development);
+    }
+    Err("carbonpaper-office.exe was not found; build or reinstall CarbonPaper".to_string())
+}
+
+fn assign_kill_on_close_job(child: &Child) -> Result<OfficeJobHandle, String> {
+    // SAFETY: structure sizes and handles match the Job Object API contract;
+    // every error path closes the newly created handle.
+    unsafe {
+        let handle = CreateJobObjectW(None, None)
+            .map_err(|error| format!("failed to create Office job object: {error:?}"))?;
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        if let Err(error) = SetInformationJobObject(
+            handle,
+            JobObjectExtendedLimitInformation,
+            &limits as *const _ as *const _,
+            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        ) {
+            let _ = CloseHandle(handle);
+            return Err(format!("failed to configure Office job object: {error:?}"));
+        }
+        let process_handle = HANDLE(child.as_raw_handle() as *mut _);
+        if let Err(error) = AssignProcessToJobObject(handle, process_handle) {
+            let _ = CloseHandle(handle);
+            return Err(format!(
+                "failed to assign Office worker to job object: {error:?}"
+            ));
+        }
+        Ok(OfficeJobHandle(handle))
+    }
+}
+
+fn resume_target(document: &OfficeDocumentRef) -> Result<String, String> {
+    let locator = document
+        .locator
+        .as_deref()
+        .ok_or_else(|| "OFFICE_DOCUMENT_UNSAVED".to_string())?;
+    match document.kind {
+        OfficeDocumentKind::Unsaved => Err("OFFICE_DOCUMENT_UNSAVED".to_string()),
+        OfficeDocumentKind::LocalFile => {
+            if !std::path::Path::new(locator).is_file() {
+                Err("OFFICE_DOCUMENT_MISSING".to_string())
+            } else {
+                Ok(locator.to_string())
+            }
+        }
+        OfficeDocumentKind::CloudDocument => {
+            let scheme = match document.application {
+                OfficeApplication::Word => "ms-word:ofe|u|",
+                OfficeApplication::Excel => "ms-excel:ofe|u|",
+                OfficeApplication::PowerPoint => "ms-powerpoint:ofe|u|",
+            };
+            Ok(format!("{scheme}{locator}"))
+        }
+    }
+}
+
+/// Open the exact saved Office document associated with an authenticated screenshot.
+#[tauri::command]
+pub async fn office_resume_document(
+    window: tauri::Window,
+    credential_state: tauri::State<'_, Arc<crate::credential_manager::CredentialManagerState>>,
+    storage: tauri::State<'_, Arc<StorageState>>,
+    screenshot_id: i64,
+) -> Result<serde_json::Value, String> {
+    if window.label() != "main" && window.label() != "snapshot-preview" {
+        return Err("WINDOW_NOT_AUTHORIZED".to_string());
+    }
+    crate::commands::check_auth_required(&credential_state)?;
+    if screenshot_id <= 0 {
+        return Err("Invalid screenshot id".to_string());
+    }
+    let storage = storage.inner().clone();
+    tokio::task::spawn_blocking(move || {
+        let document = storage
+            .get_screenshot_document_ref(screenshot_id)?
+            .ok_or_else(|| "OFFICE_DOCUMENT_NOT_FOUND".to_string())?;
+        let target = resume_target(&document)?;
+        open::that_detached(&target)
+            .map_err(|error| format!("Failed to resume Office document: {error}"))?;
+        Ok(serde_json::json!({
+            "status": "opened",
+            "application": document.application,
+            "display_name": document.display_name
+        }))
+    })
+    .await
+    .map_err(|error| format!("Office resume task failed: {error}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fingerprint() -> OfficeWindowFingerprint {
+        OfficeWindowFingerprint {
+            application: OfficeApplication::Word,
+            root_hwnd: 11,
+            document_hwnd: 22,
+            pid: 33,
+            title: "Report.docx - Word".to_string(),
+        }
+    }
+
+    #[test]
+    fn resolution_is_refused_until_capture_starts() {
+        let runtime = OfficeRuntimeState::new();
+        assert!(!runtime.is_active(), "the gate opens with the capture loop");
+        assert!(runtime.begin_resolution().is_none());
+
+        runtime.resume();
+        assert!(runtime.is_active());
+        {
+            let _resolving = runtime.begin_resolution().expect("gate is open");
+            assert!(
+                runtime
+                    .gate
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .resolving
+            );
+        }
+        assert!(
+            !runtime
+                .gate
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .resolving,
+            "the flag must clear even when the resolution unwinds"
+        );
+    }
+
+    #[tokio::test]
+    async fn draining_waits_for_an_association_write() {
+        let runtime = OfficeRuntimeState::new();
+        runtime.resume();
+
+        let write = PendingWriteGuard::new(&runtime.in_flight_writes);
+        assert!(
+            !runtime.quiesce(Duration::from_millis(250)).await,
+            "a write still in flight must hold the drain open"
+        );
+
+        drop(write);
+        assert!(runtime.quiesce(Duration::from_millis(250)).await);
+    }
+
+    #[tokio::test]
+    async fn draining_discards_state_tied_to_the_old_database() {
+        let runtime = OfficeRuntimeState::new();
+        runtime.resume();
+        {
+            let mut state = runtime
+                .observations
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            state.last_observed = Some(fingerprint());
+            state.active_query = Some(QueuedObservation {
+                generation: 1,
+                fingerprint: fingerprint(),
+            });
+            state.pending_screenshots.push_back(PendingAssociation {
+                fingerprint: fingerprint(),
+                resolution: PendingResolution::Awaiting(1),
+                screenshot: PendingScreenshot {
+                    id: 42,
+                    db_generation: 7,
+                },
+            });
+            state.cache.insert(
+                fingerprint(),
+                CachedResolution {
+                    generation: 1,
+                    outcome: CachedResolutionOutcome::ConfirmedEmpty,
+                    refreshed_at: Instant::now(),
+                    valid_for: SUCCESS_CACHE_TTL,
+                    consecutive_failures: 0,
+                },
+            );
+        }
+
+        assert!(runtime.quiesce(Duration::from_millis(250)).await);
+        assert!(!runtime.is_active());
+
+        let state = runtime
+            .observations
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        assert!(state.pending_screenshots.is_empty());
+        assert!(state.cache.is_empty());
+        assert!(state.active_query.is_none());
+        assert!(state.last_observed.is_none());
+    }
+
+    #[test]
+    fn cloud_resume_uses_the_office_protocol_handler() {
+        let document = OfficeDocumentRef {
+            provider: "office_nativeom".to_string(),
+            application: OfficeApplication::PowerPoint,
+            kind: OfficeDocumentKind::CloudDocument,
+            display_name: "Roadmap.pptx".to_string(),
+            locator: Some("https://tenant.example/Roadmap.pptx".to_string()),
+            observed_at_ms: 1,
+            confidence: "exact".to_string(),
+        };
+        assert_eq!(
+            resume_target(&document).unwrap(),
+            "ms-powerpoint:ofe|u|https://tenant.example/Roadmap.pptx"
+        );
+    }
+
+    #[test]
+    fn unsaved_documents_cannot_be_resumed() {
+        let document = OfficeDocumentRef {
+            provider: "office_nativeom".to_string(),
+            application: OfficeApplication::Word,
+            kind: OfficeDocumentKind::Unsaved,
+            display_name: "Document1".to_string(),
+            locator: None,
+            observed_at_ms: 1,
+            confidence: "exact".to_string(),
+        };
+        assert_eq!(
+            resume_target(&document).unwrap_err(),
+            "OFFICE_DOCUMENT_UNSAVED"
+        );
+    }
+
+    #[test]
+    fn office_failure_backoff_is_bounded() {
+        assert_eq!(failure_cache_ttl(1), Duration::from_secs(2));
+        assert_eq!(failure_cache_ttl(2), Duration::from_secs(4));
+        assert_eq!(failure_cache_ttl(5), Duration::from_secs(32));
+        assert_eq!(failure_cache_ttl(6), Duration::from_secs(60));
+        assert_eq!(failure_cache_ttl(u32::MAX), Duration::from_secs(60));
+    }
+}

--- a/src-tauri/src/office_window.rs
+++ b/src-tauri/src/office_window.rs
@@ -1,0 +1,173 @@
+//! Cheap Win32 fingerprinting for Office document view windows.
+//!
+//! This module deliberately performs no COM work. It is shared by the capture
+//! process and the isolated Office worker so both sides agree on the native view
+//! HWND that identifies a document surface.
+
+use crate::office_protocol::{OfficeApplication, MAX_OFFICE_TITLE_CHARS};
+use windows::Win32::Foundation::{BOOL, HWND, LPARAM};
+use windows::Win32::UI::WindowsAndMessaging::{
+    EnumChildWindows, GetAncestor, GetClassNameW, GetWindowTextW, GetWindowThreadProcessId,
+    IsWindow, IsWindowVisible, GA_ROOT,
+};
+
+struct EnumerationContext {
+    application: OfficeApplication,
+    pid: u32,
+    first_match: isize,
+    first_priority: usize,
+    visible_match: isize,
+    visible_priority: usize,
+}
+
+/// Return the Office native document-view HWND below `root_hwnd`.
+pub fn find_native_document_window(
+    root_hwnd: i64,
+    pid: u32,
+    application: OfficeApplication,
+) -> Option<i64> {
+    let root_raw = isize::try_from(root_hwnd).ok()?;
+    let root = HWND(root_raw as *mut _);
+    if root.0.is_null() || pid == 0 {
+        return None;
+    }
+
+    // SAFETY: `root` comes from foreground-window discovery. The callback only
+    // borrows the stack context for the duration of the synchronous enumeration.
+    unsafe {
+        if !IsWindow(root).as_bool() || window_pid(root) != pid {
+            return None;
+        }
+        let mut context = EnumerationContext {
+            application,
+            pid,
+            first_match: 0,
+            first_priority: usize::MAX,
+            visible_match: 0,
+            visible_priority: usize::MAX,
+        };
+        let _ = EnumChildWindows(
+            root,
+            Some(enumerate_document_window),
+            LPARAM((&mut context as *mut EnumerationContext) as isize),
+        );
+        let result = if context.visible_match != 0 {
+            context.visible_match
+        } else {
+            context.first_match
+        };
+        (result != 0).then_some(result as i64)
+    }
+}
+
+/// Validate an HWND supplied by the capture process before using it for COM.
+pub fn validate_native_document_window(
+    root_hwnd: i64,
+    document_hwnd: i64,
+    pid: u32,
+    application: OfficeApplication,
+) -> bool {
+    let Ok(root_raw) = isize::try_from(root_hwnd) else {
+        return false;
+    };
+    let Ok(document_raw) = isize::try_from(document_hwnd) else {
+        return false;
+    };
+    let root = HWND(root_raw as *mut _);
+    let document = HWND(document_raw as *mut _);
+
+    // SAFETY: both handles are treated as untrusted and checked with IsWindow
+    // before querying process, ancestry, visibility, or class metadata.
+    unsafe {
+        IsWindow(root).as_bool()
+            && IsWindow(document).as_bool()
+            && window_pid(root) == pid
+            && window_pid(document) == pid
+            && GetAncestor(document, GA_ROOT) == root
+            && application
+                .native_window_class_priority(&window_class(document))
+                .is_some()
+    }
+}
+
+/// Validate the complete foreground context captured by the parent process.
+///
+/// HWND values and PIDs are necessary but not sufficient: a reused top-level
+/// window can keep the same handle while Office changes its document title.
+/// Reading the title again on both sides of the COM call lets the worker fail
+/// closed when the foreground document changed during resolution.
+pub fn validate_office_window_context(
+    root_hwnd: i64,
+    document_hwnd: i64,
+    pid: u32,
+    application: OfficeApplication,
+    expected_title: &str,
+) -> bool {
+    if expected_title.chars().count() > MAX_OFFICE_TITLE_CHARS {
+        return false;
+    }
+    if !validate_native_document_window(root_hwnd, document_hwnd, pid, application) {
+        return false;
+    }
+
+    let Ok(root_raw) = isize::try_from(root_hwnd) else {
+        return false;
+    };
+    let root = HWND(root_raw as *mut _);
+
+    // SAFETY: `root` was validated above and the buffer is a documented,
+    // writable UTF-16 destination for GetWindowTextW.
+    unsafe { window_title(root) == expected_title }
+}
+
+unsafe extern "system" fn enumerate_document_window(hwnd: HWND, lparam: LPARAM) -> BOOL {
+    // SAFETY: `lparam` is the live `EnumerationContext` pointer passed to the
+    // synchronous EnumChildWindows call above.
+    let context = unsafe { &mut *(lparam.0 as *mut EnumerationContext) };
+    if unsafe { window_pid(hwnd) } != context.pid {
+        return true.into();
+    }
+    let class_name = unsafe { window_class(hwnd) };
+    let Some(priority) = context
+        .application
+        .native_window_class_priority(&class_name)
+    else {
+        return true.into();
+    };
+
+    if priority < context.first_priority {
+        context.first_match = hwnd.0 as isize;
+        context.first_priority = priority;
+    }
+    if unsafe { IsWindowVisible(hwnd).as_bool() } && priority < context.visible_priority {
+        context.visible_match = hwnd.0 as isize;
+        context.visible_priority = priority;
+    }
+    true.into()
+}
+
+unsafe fn window_pid(hwnd: HWND) -> u32 {
+    let mut pid = 0;
+    unsafe { GetWindowThreadProcessId(hwnd, Some(&mut pid)) };
+    pid
+}
+
+unsafe fn window_class(hwnd: HWND) -> String {
+    let mut buffer = [0u16; 256];
+    let len = unsafe { GetClassNameW(hwnd, &mut buffer) };
+    if len > 0 {
+        String::from_utf16_lossy(&buffer[..len as usize])
+    } else {
+        String::new()
+    }
+}
+
+unsafe fn window_title(hwnd: HWND) -> String {
+    let mut buffer = [0u16; 512];
+    let len = unsafe { GetWindowTextW(hwnd, &mut buffer) };
+    if len > 0 {
+        String::from_utf16_lossy(&buffer[..len as usize])
+    } else {
+        String::new()
+    }
+}

--- a/src-tauri/src/storage/document_ref.rs
+++ b/src-tauri/src/storage/document_ref.rs
@@ -1,0 +1,157 @@
+//! Independently encrypted Office document references associated with screenshots.
+
+use crate::credential_manager::CngKeySession;
+use crate::office_protocol::OfficeDocumentRef;
+use rusqlite::{params, OptionalExtension};
+
+use super::StorageState;
+
+/// Returned when the database was swapped between the moment a document
+/// reference was collected and the moment it would have been written. Callers
+/// treat this as a deliberate discard rather than a storage failure.
+pub const STALE_DOCUMENT_REF_GENERATION: &str = "storage_changed_before_document_ref_write";
+
+impl StorageState {
+    /// Upsert a document reference without reading or decrypting the screenshot row.
+    ///
+    /// `expected_generation` is the [`StorageState::db_generation`] observed
+    /// when `screenshot_id` was collected. Office resolution runs on its own
+    /// worker and can finish after a backup restore or a data-directory switch
+    /// has replaced the database; ids are only unique within one generation, so
+    /// without this check a late write could attach the reference to a
+    /// completely unrelated screenshot that reuses the id — and the upsert
+    /// would overwrite whatever correct reference that row already had.
+    pub fn save_screenshot_document_ref_for_generation(
+        &self,
+        screenshot_id: i64,
+        reference: &OfficeDocumentRef,
+        expected_generation: u64,
+    ) -> Result<(), String> {
+        if screenshot_id <= 0 {
+            return Err("Invalid screenshot id for Office document reference".to_string());
+        }
+        // Cheap pre-check: skip key wrapping and encryption for a write that is
+        // already known to be stale. The authoritative check happens below,
+        // under the connection lock.
+        if self.db_generation() != expected_generation {
+            return Err(STALE_DOCUMENT_REF_GENERATION.to_string());
+        }
+        reference.validate()?;
+        let plaintext = serde_json::to_vec(reference)
+            .map_err(|error| format!("Failed to serialize Office document reference: {error}"))?;
+        let (ref_enc, content_key_encrypted) = self.encrypt_payload_with_row_key(&plaintext)?;
+
+        let guard = self.get_connection_named("save_screenshot_document_ref")?;
+        // Holding the connection lock, a concurrent `shutdown`/`initialize`
+        // cannot bump the generation between this check and the statement.
+        if self.db_generation() != expected_generation {
+            return Err(STALE_DOCUMENT_REF_GENERATION.to_string());
+        }
+        let conn = guard.as_ref().unwrap();
+        conn.execute(
+            "INSERT INTO screenshot_document_refs (
+                screenshot_id, ref_enc, content_key_encrypted, updated_at
+             ) VALUES (?1, ?2, ?3, CURRENT_TIMESTAMP)
+             ON CONFLICT(screenshot_id) DO UPDATE SET
+                ref_enc = excluded.ref_enc,
+                content_key_encrypted = excluded.content_key_encrypted,
+                updated_at = CURRENT_TIMESTAMP",
+            params![screenshot_id, ref_enc, content_key_encrypted],
+        )
+        .map_err(|error| format!("Failed to save Office document reference: {error}"))?;
+        Ok(())
+    }
+
+    /// Read and validate the Office reference after the caller has authenticated.
+    pub fn get_screenshot_document_ref(
+        &self,
+        screenshot_id: i64,
+    ) -> Result<Option<OfficeDocumentRef>, String> {
+        if screenshot_id <= 0 {
+            return Ok(None);
+        }
+        let encrypted = {
+            let guard = self.get_connection_named("get_screenshot_document_ref")?;
+            let conn = guard.as_ref().unwrap();
+            conn.query_row(
+                "SELECT ref_enc, content_key_encrypted
+                   FROM screenshot_document_refs
+                  WHERE screenshot_id = ?1",
+                params![screenshot_id],
+                |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?)),
+            )
+            .optional()
+            .map_err(|error| format!("Failed to read Office document reference: {error}"))?
+        };
+        let Some((ref_enc, content_key_encrypted)) = encrypted else {
+            return Ok(None);
+        };
+
+        let session = CngKeySession::open_silent()
+            .map_err(|error| format!("Failed to open Office document key session: {error}"))?;
+        let plaintext =
+            Self::decrypt_payload_with_unwrap(&ref_enc, &content_key_encrypted, &|ciphertext| {
+                session.unwrap_row_key(ciphertext)
+            })
+            .map_err(|error| format!("Failed to decrypt Office document reference: {error}"))?;
+        let reference: OfficeDocumentRef = serde_json::from_slice(&plaintext)
+            .map_err(|error| format!("Failed to decode Office document reference: {error}"))?;
+        reference.validate()?;
+        Ok(Some(reference))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credential_manager::CredentialManagerState;
+    use crate::office_protocol::{OfficeApplication, OfficeDocumentKind};
+    use rusqlite::Connection;
+    use std::sync::Arc;
+
+    fn test_storage() -> (tempfile::TempDir, StorageState) {
+        let temp = tempfile::tempdir().expect("temp storage directory");
+        let credential = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        let storage = StorageState::new(temp.path().to_path_buf(), credential);
+        let connection = Connection::open_in_memory().expect("in-memory database");
+        storage.init_tables(&connection).expect("initialize schema");
+        *storage.db.lock().unwrap_or_else(|error| error.into_inner()) = Some(connection);
+        (temp, storage)
+    }
+
+    fn document() -> OfficeDocumentRef {
+        OfficeDocumentRef {
+            provider: "office_nativeom".to_string(),
+            application: OfficeApplication::Word,
+            kind: OfficeDocumentKind::LocalFile,
+            display_name: "Report.docx".to_string(),
+            locator: Some("D:\\docs\\Report.docx".to_string()),
+            observed_at_ms: 1,
+            confidence: "exact".to_string(),
+        }
+    }
+
+    #[test]
+    fn closing_the_database_starts_a_new_generation() {
+        let (_temp, storage) = test_storage();
+        let generation = storage.db_generation();
+        storage.shutdown().expect("close storage");
+        assert_ne!(
+            storage.db_generation(),
+            generation,
+            "ids collected before the close must not look current afterwards"
+        );
+    }
+
+    #[test]
+    fn a_reference_collected_against_a_previous_database_is_refused() {
+        let (_temp, storage) = test_storage();
+        let generation = storage.db_generation();
+        storage.shutdown().expect("close storage");
+
+        let error = storage
+            .save_screenshot_document_ref_for_generation(7, &document(), generation)
+            .expect_err("a write from the previous database must not be attempted");
+        assert_eq!(error, STALE_DOCUMENT_REF_GENERATION);
+    }
+}

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -7,6 +7,7 @@
 
 mod derived_index;
 mod derived_migration;
+mod document_ref;
 mod encryption;
 mod image_io;
 mod link_scoring;
@@ -28,6 +29,7 @@ pub(crate) mod wire_time;
 pub use derived_index::*;
 #[allow(unused_imports)]
 pub use derived_migration::*;
+pub use document_ref::STALE_DOCUMENT_REF_GENERATION;
 #[allow(unused_imports)]
 pub use image_io::{read_encrypted_image_as_base64, read_image_as_base64};
 pub(crate) use policy::disk_totals_for_path;
@@ -128,6 +130,14 @@ pub struct StorageState {
     /// order itself holds no plaintext and expires on its own; see
     /// `search.rs::CachedSearchOrder`.
     search_order_cache: Mutex<Option<search::CachedSearchOrder>>,
+    /// Incremented on every close and every open of the backing database file,
+    /// always while the `db` mutex is held. A background writer that captured
+    /// this value before being scheduled can tell whether it is still facing
+    /// the same database; row ids are only meaningful within one generation,
+    /// so a write that crosses a backup restore or a data-directory switch
+    /// would otherwise land on an unrelated screenshot that happens to share
+    /// the id. See `document_ref.rs::save_screenshot_document_ref_for_generation`.
+    db_generation: AtomicU64,
 }
 
 struct NamedConnectionGuard<'a> {
@@ -198,6 +208,7 @@ impl StorageState {
             clip_cache_load_lock: Mutex::new(()),
             semantic_cache_reset_generation: AtomicU64::new(0),
             search_order_cache: Mutex::new(None),
+            db_generation: AtomicU64::new(0),
         }
     }
 
@@ -361,5 +372,24 @@ impl StorageState {
     /// Returns whether the current credential session is unlocked/valid.
     pub fn is_session_valid(&self) -> bool {
         self.credential_state.is_session_valid()
+    }
+
+    /// The identity of the currently open database file.
+    ///
+    /// Capture this before handing work to a background task, then pass it back
+    /// to the write call. The value changes whenever the database is closed or
+    /// reopened, which is exactly when previously collected row ids stop being
+    /// meaningful.
+    pub fn db_generation(&self) -> u64 {
+        self.db_generation.load(Ordering::Acquire)
+    }
+
+    /// Records that the backing database file is being swapped.
+    ///
+    /// Callers must already hold the `db` mutex, so that a writer which passed
+    /// the generation check under that same lock cannot be overtaken by a swap
+    /// before its statement runs.
+    pub(super) fn bump_db_generation(&self) {
+        self.db_generation.fetch_add(1, Ordering::Release);
     }
 }

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -21,6 +21,10 @@ impl StorageState {
         // Belt-and-braces against a stale resident matrix from a previous
         // connection; `shutdown` already clears it on the normal path.
         self.reset_semantic_vector_cache();
+        // `shutdown` parks the lazy indexer; without this the thread would stay
+        // parked for the rest of the process after any backup or data-directory
+        // switch, and its backlog would never be worked off again.
+        self.lazy_indexer_shutdown.store(false, Ordering::SeqCst);
 
         // Create directories
         let data_dir = self
@@ -72,7 +76,13 @@ impl StorageState {
         Self::set_auto_vacuum_incremental(&conn)?;
         let tables_dur = t3.elapsed();
 
-        *self.db.lock().unwrap_or_else(|e| e.into_inner()) = Some(conn);
+        {
+            let mut db_guard = self.db.lock().unwrap_or_else(|e| e.into_inner());
+            // Under the same lock the write path checks, so a task holding the
+            // previous generation can never slip a statement into this file.
+            self.bump_db_generation();
+            *db_guard = Some(conn);
+        }
 
         // Initialize approximate OCR row count using MAX(id) — O(log N) via primary key index.
         // AUTOINCREMENT ids only increase, so MAX(id) >= actual row count; acceptable for IDF.
@@ -111,6 +121,10 @@ impl StorageState {
         // connection comes next can silently score against the old file.
         self.reset_semantic_vector_cache();
         let mut db_guard = self.db.lock().map_err(|e| format!("lock error: {}", e))?;
+        // Every id collected against this connection stops being meaningful the
+        // moment it closes, whether the next `initialize` reopens the same file
+        // or a restored backup.
+        self.bump_db_generation();
         if db_guard.is_some() {
             *db_guard = None;
         }
@@ -185,6 +199,16 @@ impl StorageState {
                 postprocess_attempts INTEGER NOT NULL DEFAULT 0,
                 postprocess_next_retry_at TIMESTAMP,
                 attempted_at TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (screenshot_id) REFERENCES screenshots(id) ON DELETE CASCADE
+            );
+
+            -- Document references use their own row key so delayed native
+            -- discovery never has to unwrap or rewrite screenshot metadata.
+            CREATE TABLE IF NOT EXISTS screenshot_document_refs (
+                screenshot_id INTEGER PRIMARY KEY,
+                ref_enc BLOB NOT NULL,
+                content_key_encrypted BLOB NOT NULL,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY (screenshot_id) REFERENCES screenshots(id) ON DELETE CASCADE
             );
@@ -979,6 +1003,20 @@ impl StorageState {
         )
         .map_err(|e| format!("Failed to create OCR lifecycle indexes: {}", e))?;
 
+        Self::create_table_if_missing(
+            conn,
+            "screenshot_document_refs",
+            r#"
+            CREATE TABLE IF NOT EXISTS screenshot_document_refs (
+                screenshot_id INTEGER PRIMARY KEY,
+                ref_enc BLOB NOT NULL,
+                content_key_encrypted BLOB NOT NULL,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (screenshot_id) REFERENCES screenshots(id) ON DELETE CASCADE
+            )
+            "#,
+        )?;
+
         // Task clustering tables
         Self::create_table_if_missing(
             conn,
@@ -1558,6 +1596,7 @@ mod tests {
             "index",
             "idx_derived_migration_runs_updated"
         ));
+        assert!(object_exists(&conn, "table", "screenshot_document_refs"));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.8.4",
   "identifier": "com.eyling.carbonpaper",
   "build": {
-    "beforeDevCommand": "npm run build:nmh && npm run dev",
+    "beforeDevCommand": "npm run build:nmh && npm run build:office && npm run dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "npm run build && npm run test:release-assets",
     "frontendDist": "../dist"

--- a/src/components/DetailCard.jsx
+++ b/src/components/DetailCard.jsx
@@ -7,6 +7,7 @@ import { openUrl } from '@tauri-apps/plugin-opener';
 import { CATEGORY_LIST, CATEGORY_COLORS } from '../lib/categories';
 import { buildActivityContext, getHostname } from '../lib/activity_context';
 import ActivityContextDrawer from './ActivityContextDrawer';
+import OfficeDocumentEntry from './OfficeDocumentEntry';
 
 export default function DetailCard({ selectedEvent, selectedDetails, onCategoryChange, onSelectRelated, onOpenFloatingPreview }) {
   const { t } = useTranslation();
@@ -50,6 +51,8 @@ export default function DetailCard({ selectedEvent, selectedDetails, onCategoryC
   }, [selectedDetails?.record?.visible_links]);
 
   const pageUrl = selectedDetails?.record?.page_url;
+  const documentRef = selectedDetails?.document_ref || null;
+  const screenshotId = selectedDetails?.record?.id || selectedEvent?.id;
   const activityContext = useMemo(() => buildActivityContext({
     selectedEvent,
     selectedRecord: selectedDetails?.record,
@@ -415,6 +418,20 @@ export default function DetailCard({ selectedEvent, selectedDetails, onCategoryC
                     </div>
                   </div>
                 ))}
+              </div>
+            </div>
+          )}
+
+          {documentRef && (
+            <div>
+              <label className="text-xs text-ide-muted uppercase font-bold">
+                {t('documentSource.title')}
+              </label>
+              <div className="mt-1">
+                <OfficeDocumentEntry
+                  documentRef={documentRef}
+                  screenshotId={screenshotId}
+                />
               </div>
             </div>
           )}

--- a/src/components/OfficeDocumentEntry.jsx
+++ b/src/components/OfficeDocumentEntry.jsx
@@ -1,0 +1,102 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ExternalLink, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { resumeOfficeDocument } from '../lib/monitor_api';
+import {
+  getOfficeDocumentApplicationKey,
+  getOfficeDocumentIcon,
+  getOfficeDocumentKindKey,
+} from '../lib/document_ref';
+
+/**
+ * A contextual, clickable representation of the Office document associated
+ * with a screenshot.  The encrypted locator never reaches this component;
+ * the authenticated resume command resolves it on the backend.
+ */
+export default function OfficeDocumentEntry({
+  documentRef,
+  screenshotId,
+  compact = false,
+  className = '',
+}) {
+  const { t } = useTranslation();
+  const [isOpening, setIsOpening] = useState(false);
+  const [error, setError] = useState(null);
+
+  const documentKey = `${screenshotId || ''}:${documentRef?.display_name || ''}:${documentRef?.application || ''}:${documentRef?.kind || ''}:${documentRef?.resumable ? '1' : '0'}`;
+  useEffect(() => {
+    setIsOpening(false);
+    setError(null);
+  }, [documentKey]);
+
+  const applicationKey = getOfficeDocumentApplicationKey(documentRef?.application);
+  const kindKey = getOfficeDocumentKindKey(documentRef?.kind);
+  const Icon = getOfficeDocumentIcon(documentRef?.application);
+  const displayName = documentRef?.display_name || t('documentSource.unknownFile');
+  const applicationLabel = t(`documentSource.applications.${applicationKey}`);
+  const kindLabel = t(`documentSource.kinds.${kindKey}`);
+  const canResume = Boolean(documentRef?.resumable && Number(screenshotId) > 0);
+
+  const title = useMemo(() => {
+    if (canResume) return t('documentSource.openTitle', { name: displayName });
+    if (kindKey === 'unsaved') return t('documentSource.unsavedTitle');
+    return t('documentSource.unavailableTitle');
+  }, [canResume, displayName, kindKey, t]);
+
+  const handleOpen = useCallback(async () => {
+    if (!canResume || isOpening) return;
+    setIsOpening(true);
+    setError(null);
+    try {
+      await resumeOfficeDocument(Number(screenshotId));
+    } catch (nextError) {
+      console.error('Failed to open associated Office document', nextError);
+      setError(t('documentSource.openFailed', {
+        error: nextError?.message || String(nextError),
+      }));
+    } finally {
+      setIsOpening(false);
+    }
+  }, [canResume, isOpening, screenshotId, t]);
+
+  if (!documentRef) return null;
+
+  const rowClassName = compact
+    ? 'flex w-full items-center gap-2 rounded border border-ide-border bg-ide-bg px-2 py-1.5 text-left text-xs transition-colors'
+    : 'flex w-full items-start gap-2 rounded p-2 text-left text-xs transition-colors';
+  const stateClassName = canResume
+    ? 'cursor-pointer hover:bg-ide-hover'
+    : 'cursor-not-allowed opacity-60';
+
+  return (
+    <div className={`min-w-0 ${className}`}>
+      <button
+        type="button"
+        onClick={handleOpen}
+        disabled={!canResume || isOpening}
+        className={`${rowClassName} ${stateClassName} group disabled:pointer-events-auto`}
+        title={title}
+      >
+        <Icon className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${canResume ? 'text-ide-accent' : 'text-ide-muted'}`} />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate font-medium text-ide-text" title={displayName}>
+            {displayName}
+          </span>
+          <span className="mt-0.5 block truncate text-[10px] text-ide-muted">
+            {applicationLabel} · {kindLabel}
+          </span>
+        </span>
+        {isOpening ? (
+          <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-ide-accent" />
+        ) : (
+          <ExternalLink className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${canResume ? 'text-ide-muted group-hover:text-ide-accent' : 'text-ide-muted'}`} />
+        )}
+      </button>
+      {error && (
+        <div role="alert" className="mt-1 break-words text-[11px] text-red-400">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/OfficeDocumentEntry.test.jsx
+++ b/src/components/OfficeDocumentEntry.test.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, options) => (options?.name ? `${key}:${options.name}` : key),
+  }),
+}));
+
+vi.mock('../lib/monitor_api', () => ({
+  resumeOfficeDocument: vi.fn(async () => ({ status: 'opened' })),
+}));
+
+import { resumeOfficeDocument } from '../lib/monitor_api';
+import OfficeDocumentEntry from './OfficeDocumentEntry';
+
+describe('OfficeDocumentEntry', () => {
+  beforeEach(() => {
+    resumeOfficeDocument.mockClear();
+  });
+
+  it('shows the application and opens a resumable document', async () => {
+    render(
+      <OfficeDocumentEntry
+        screenshotId={42}
+        documentRef={{
+          application: 'excel',
+          kind: 'cloud_document',
+          display_name: 'Budget.xlsx',
+          resumable: true,
+        }}
+      />,
+    );
+
+    const openButton = screen.getByRole('button');
+    expect(openButton).toHaveTextContent('documentSource.applications.excel');
+    expect(openButton).toHaveTextContent('documentSource.kinds.cloud');
+    fireEvent.click(openButton);
+
+    await waitFor(() => {
+      expect(resumeOfficeDocument).toHaveBeenCalledWith(42);
+    });
+  });
+
+  it('keeps an unsaved document visible but disabled', () => {
+    render(
+      <OfficeDocumentEntry
+        screenshotId={42}
+        documentRef={{
+          application: 'word',
+          kind: 'unsaved',
+          display_name: 'Document1',
+          resumable: false,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Document1')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});

--- a/src/components/PreviewActionBar.jsx
+++ b/src/components/PreviewActionBar.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useCallback, useMemo } from 'react';
-import { Trash2, ExternalLink, MoreHorizontal, ChevronUp, Clock, Maximize2 } from 'lucide-react';
-import { extractUrlsFromOcr } from '../lib/ocr_url_detector';
+import React, { useState, useCallback } from 'react';
+import { Trash2, MoreHorizontal, ChevronUp, Clock, Maximize2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { getSnapshotSourceOptions } from '../lib/snapshot_sources';
+import SnapshotSourceAction from './SnapshotSourceAction';
 
 export default function PreviewActionBar({
   selectedEvent,
@@ -18,12 +19,14 @@ export default function PreviewActionBar({
   const [isDeleting, setIsDeleting] = useState(false);
 
   const pageUrl = selectedDetails?.record?.page_url || null;
-  const extractedUrls = useMemo(() => {
-    if (pageUrl) return [pageUrl]; // Prioritize page URL if available
-    return extractUrlsFromOcr(selectedDetails?.ocr_results || []).slice(0, 5); // Limit to top 5 URLs
-  }, [selectedDetails?.ocr_results]);
-
-  const hasUrls = extractedUrls.length > 0;
+  const documentRef = selectedDetails?.document_ref || null;
+  const screenshotId = selectedDetails?.record?.id || selectedEvent?.id;
+  const sourceOptions = getSnapshotSourceOptions({
+    documentRef,
+    screenshotId,
+    pageUrl,
+    ocrResults: selectedDetails?.ocr_results,
+  });
 
   const handleDeleteRecord = useCallback(async () => {
     if (!selectedEvent?.id) return;
@@ -47,12 +50,6 @@ export default function PreviewActionBar({
     }
   }, [selectedEvent?.timestamp, onDeleteNearbyRecords]);
 
-  const handleOpenFirstUrl = useCallback(() => {
-    if (extractedUrls.length > 0) {
-      onOpenUrl?.(extractedUrls[0]);
-    }
-  }, [extractedUrls, onOpenUrl]);
-
   if (!selectedEvent) return null;
 
   return (
@@ -64,7 +61,7 @@ export default function PreviewActionBar({
         />
       )}
       <div
-        className={`absolute bottom-0 left-1/2 -translate-x-1/2 z-30 flex items-end justify-center transition-all duration-300 w-[540px] ${
+        className={`absolute bottom-0 left-1/2 -translate-x-1/2 z-30 flex w-[760px] max-w-[calc(100vw-1rem)] items-end justify-center transition-all duration-300 ${
           showDeleteMenu
             ? 'h-24 pb-6'
             : 'h-12 pb-2 hover:h-24 hover:pb-6 group/actionbar'
@@ -138,24 +135,22 @@ export default function PreviewActionBar({
             )}
           </div>
 
-          <div className="w-px h-5 bg-ide-border/50" />
+          {sourceOptions.length > 0 && (
+            <>
+              <div className="w-px h-5 bg-ide-border/50" />
+              <SnapshotSourceAction
+                documentRef={documentRef}
+                screenshotId={screenshotId}
+                pageUrl={pageUrl}
+                ocrResults={selectedDetails?.ocr_results}
+                onOpenUrl={onOpenUrl}
+                compact
+              />
+              <div className="w-px h-5 bg-ide-border/50" />
+            </>
+          )}
 
-          {/* Callback Button (Beta) */}
-          <button
-            onClick={handleOpenFirstUrl}
-            disabled={!hasUrls}
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs transition-colors ${hasUrls
-                ? 'hover:bg-ide-hover text-ide-text'
-                : 'text-ide-muted cursor-not-allowed opacity-50'
-              }`}
-            title={hasUrls ? t('previewAction.openUrlTitle', { url: extractedUrls[0] }) : t('previewAction.noUrlDetected')}
-          >
-            <ExternalLink className="w-3.5 h-3.5" />
-            <span>Callback</span>
-            <span className="px-1 py-0.5 bg-amber-500/20 text-amber-400 text-[10px] rounded">beta</span>
-          </button>
-
-          <div className="w-px h-5 bg-ide-border/50" />
+          {sourceOptions.length === 0 && <div className="w-px h-5 bg-ide-border/50" />}
 
           <button
             onClick={onOpenFloatingPreview}

--- a/src/components/SnapshotPreviewDock.jsx
+++ b/src/components/SnapshotPreviewDock.jsx
@@ -5,8 +5,11 @@ import {
   Maximize2, Minimize2, Monitor, Tag, X,
 } from 'lucide-react';
 import { openUrl } from '@tauri-apps/plugin-opener';
+import { listen } from '@tauri-apps/api/event';
 import { InspectorImage } from './InspectorImage';
 import { CategoryBadge } from './ThumbnailCard';
+import OfficeDocumentEntry from './OfficeDocumentEntry';
+import SnapshotSourceAction from './SnapshotSourceAction';
 import { extractUrlsFromOcr } from '../lib/ocr_url_detector';
 import { parseCreatedAt } from '../lib/search_grouping';
 import { fetchImage, getScreenshotDetails } from '../lib/monitor_api';
@@ -176,6 +179,8 @@ export default function SnapshotPreviewDock({
   const isLoading = loadingKey === resolvedActiveKey && (!activeImage || !activeDetails);
   const record = activeDetails?.record || {};
   const ocrResults = activeDetails?.ocr_results || [];
+  const documentRef = activeDetails?.document_ref || null;
+  const screenshotId = getTargetId(activeTab);
 
   const ocrText = useMemo(() => (
     ocrResults.map((result) => result.text).filter(Boolean).join('\n')
@@ -389,6 +394,26 @@ export default function SnapshotPreviewDock({
   }, [activeKey]);
 
   useEffect(() => {
+    if (!screenshotId || !resolvedActiveKey) return undefined;
+    let disposed = false;
+    let unlisten;
+    listen('office-document-ref-updated', async (event) => {
+      if (event.payload?.screenshot_id !== screenshotId) return;
+      const details = await getScreenshotDetails(screenshotId, getTargetPath(activeTab));
+      if (!disposed && details && !details.error) {
+        storeLimited(setDetailsCache, detailsOrderRef, resolvedActiveKey, details, DETAILS_CACHE_LIMIT);
+      }
+    }).then((dispose) => {
+      if (disposed) dispose();
+      else unlisten = dispose;
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [activeTab, resolvedActiveKey, screenshotId]);
+
+  useEffect(() => {
     setOcrPanelHeight((prev) => clampOcrHeight(prev));
   }, [clampOcrHeight]);
 
@@ -476,7 +501,6 @@ export default function SnapshotPreviewDock({
     || activeTab.metadata?.screenshot_created_at
     || activeTab.created_at
     || activeTab.metadata?.created_at;
-  const screenshotId = getTargetId(activeTab);
   const score = activeTab.rerank_score;
   const assignedAt = activeTab.assigned_at;
   const sourceLabel = getLocalizedSourceLabel(activeTab, t);
@@ -683,6 +707,14 @@ export default function SnapshotPreviewDock({
               </button>
             )}
 
+            <SnapshotSourceAction
+              documentRef={documentRef}
+              screenshotId={screenshotId}
+              pageUrl={record.page_url}
+              ocrResults={ocrResults}
+              onOpenUrl={handleOpenUrl}
+            />
+
             <div className="min-w-0">
               <div className="truncate text-sm font-semibold text-ide-text" title={displayTitle}>
                 {displayTitle}
@@ -738,6 +770,19 @@ export default function SnapshotPreviewDock({
                     <span className="truncate">{url}</span>
                   </button>
                 ))}
+              </div>
+            )}
+
+            {documentRef && (
+              <div className="space-y-1">
+                <div className="text-[10px] font-semibold uppercase text-ide-muted">
+                  {t('documentSource.title')}
+                </div>
+                <OfficeDocumentEntry
+                  documentRef={documentRef}
+                  screenshotId={screenshotId}
+                  compact
+                />
               </div>
             )}
           </div>

--- a/src/components/SnapshotSourceAction.jsx
+++ b/src/components/SnapshotSourceAction.jsx
@@ -1,0 +1,185 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ExternalLink, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { resumeOfficeDocument } from '../lib/monitor_api';
+import { getSnapshotSourceOptions } from '../lib/snapshot_sources';
+import {
+  getOfficeDocumentApplicationKey,
+  getOfficeDocumentIcon,
+  getOfficeDocumentKindKey,
+} from '../lib/document_ref';
+
+function getUrlLabel(url) {
+  try {
+    return new URL(url).hostname || url;
+  } catch {
+    return url;
+  }
+}
+
+function SourceOptionIcon({ source }) {
+  if (source.kind === 'office') {
+    const Icon = getOfficeDocumentIcon(source.documentRef?.application);
+    return <Icon className="h-3.5 w-3.5 shrink-0 text-ide-accent" />;
+  }
+  return <ExternalLink className="h-3.5 w-3.5 shrink-0 text-ide-accent" />;
+}
+
+function SourceOptionText({ source, t }) {
+  if (source.kind === 'office') {
+    const applicationKey = getOfficeDocumentApplicationKey(source.documentRef?.application);
+    const kindKey = getOfficeDocumentKindKey(source.documentRef?.kind);
+    return (
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-left text-xs text-ide-text" title={source.documentRef?.display_name}>
+          {source.documentRef?.display_name || t('documentSource.unknownFile')}
+        </span>
+        <span className="mt-0.5 block truncate text-left text-[10px] text-ide-muted">
+          {t(`documentSource.applications.${applicationKey}`)} · {t(`documentSource.kinds.${kindKey}`)}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span className="min-w-0 flex-1">
+      <span className="block truncate text-left text-xs text-ide-text" title={source.url}>
+        {getUrlLabel(source.url)}
+      </span>
+      <span className="mt-0.5 block truncate text-left text-[10px] text-ide-muted" title={source.url}>
+        {source.url}
+      </span>
+    </span>
+  );
+}
+
+/**
+ * One source action for the preview surfaces.  With one source it opens
+ * directly; with multiple sources it presents a small chooser instead of
+ * silently opening the first OCR URL.
+ */
+export default function SnapshotSourceAction({
+  documentRef,
+  screenshotId,
+  pageUrl,
+  ocrResults,
+  onOpenUrl,
+  compact = false,
+  className = '',
+}) {
+  const { t } = useTranslation();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [isOpening, setIsOpening] = useState(false);
+  const [error, setError] = useState(null);
+
+  const sources = useMemo(() => getSnapshotSourceOptions({
+    documentRef,
+    screenshotId,
+    pageUrl,
+    ocrResults,
+  }), [documentRef, ocrResults, pageUrl, screenshotId]);
+  const sourceSignature = sources.map((source) => source.id).join('|');
+
+  useEffect(() => {
+    setMenuOpen(false);
+    setError(null);
+  }, [sourceSignature, screenshotId]);
+
+  const openSource = useCallback(async (source) => {
+    if (!source || isOpening) return;
+    setMenuOpen(false);
+    setIsOpening(true);
+    setError(null);
+    try {
+      if (source.kind === 'office') {
+        if (Number(screenshotId) <= 0) throw new Error('Invalid screenshot id');
+        await resumeOfficeDocument(Number(screenshotId));
+      } else if (onOpenUrl) {
+        await onOpenUrl(source.url);
+      } else {
+        throw new Error('URL opener is unavailable');
+      }
+    } catch (nextError) {
+      console.error('Failed to open associated snapshot source', nextError);
+      setError(t('snapshotSource.openFailed', {
+        error: nextError?.message || String(nextError),
+      }));
+    } finally {
+      setIsOpening(false);
+    }
+  }, [isOpening, onOpenUrl, screenshotId, t]);
+
+  const handleButtonClick = useCallback(() => {
+    if (isOpening) return;
+    if (sources.length === 1) {
+      openSource(sources[0]);
+    } else {
+      setMenuOpen((previous) => !previous);
+      setError(null);
+    }
+  }, [isOpening, openSource, sources]);
+
+  if (sources.length === 0) return null;
+
+  const buttonClassName = compact
+    ? 'flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs text-ide-text transition-colors hover:bg-ide-hover disabled:cursor-wait disabled:opacity-60'
+    : 'flex w-full items-center justify-center gap-2 rounded-md border border-ide-accent bg-ide-accent/10 px-3 py-2 text-xs font-medium text-ide-accent transition-colors hover:bg-ide-accent/20 disabled:cursor-wait disabled:opacity-60';
+  const errorClassName = compact
+    ? 'absolute bottom-full left-1/2 z-50 mb-2 w-max max-w-[min(32rem,calc(100vw-2rem))] -translate-x-1/2 break-words rounded-md border border-red-500/40 bg-ide-panel px-3 py-2 text-xs text-red-400 shadow-xl'
+    : 'mt-1 break-words text-[11px] text-red-400';
+
+  return (
+    <div className={`relative ${className}`}>
+      {menuOpen && (
+        <div
+          className="fixed inset-0 z-20"
+          onClick={() => setMenuOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      {error && (
+        <div role="alert" className={errorClassName}>
+          {error}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={handleButtonClick}
+        disabled={isOpening}
+        className={buttonClassName}
+        title={sources.length > 1 ? t('snapshotSource.chooseTitle') : t('snapshotSource.openTitle')}
+        aria-haspopup={sources.length > 1 ? 'menu' : undefined}
+        aria-expanded={sources.length > 1 ? menuOpen : undefined}
+      >
+        {isOpening ? (
+          <Loader2 className={compact ? 'h-3.5 w-3.5 animate-spin' : 'h-4 w-4 animate-spin'} />
+        ) : (
+          <ExternalLink className={compact ? 'h-3.5 w-3.5' : 'h-3.5 w-3.5'} />
+        )}
+        <span>{isOpening ? t('snapshotSource.opening') : t('snapshotSource.open')}</span>
+      </button>
+
+      {menuOpen && (
+        <div
+          role="menu"
+          className={`absolute bottom-full z-40 mb-2 min-w-64 max-w-[min(24rem,calc(100vw-2rem))] overflow-hidden rounded-lg border border-ide-border bg-ide-panel p-1 shadow-xl ${compact ? 'right-0' : 'left-0 right-0'}`}
+        >
+          {sources.map((source) => (
+            <button
+              key={source.id}
+              type="button"
+              role="menuitem"
+              onClick={() => openSource(source)}
+              className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left transition-colors hover:bg-ide-hover"
+            >
+              <SourceOptionIcon source={source} />
+              <SourceOptionText source={source} t={t} />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SnapshotSourceAction.test.jsx
+++ b/src/components/SnapshotSourceAction.test.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, options) => (options?.name ? `${key}:${options.name}` : key),
+  }),
+}));
+
+vi.mock('../lib/monitor_api', () => ({
+  resumeOfficeDocument: vi.fn(async () => ({ status: 'opened' })),
+}));
+
+import { resumeOfficeDocument } from '../lib/monitor_api';
+import SnapshotSourceAction from './SnapshotSourceAction';
+
+const documentRef = {
+  application: 'word',
+  kind: 'local_file',
+  display_name: 'Report.docx',
+  resumable: true,
+};
+
+describe('SnapshotSourceAction', () => {
+  beforeEach(() => {
+    resumeOfficeDocument.mockClear();
+  });
+
+  it('opens the associated Office document directly when it is the only source', async () => {
+    render(<SnapshotSourceAction documentRef={documentRef} screenshotId={42} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'snapshotSource.open' }));
+
+    await waitFor(() => {
+      expect(resumeOfficeDocument).toHaveBeenCalledWith(42);
+    });
+  });
+
+  it('asks the user to choose when a document and page are both available', async () => {
+    const onOpenUrl = vi.fn(async () => undefined);
+    render(
+      <SnapshotSourceAction
+        documentRef={documentRef}
+        screenshotId={42}
+        pageUrl="https://example.com/work"
+        onOpenUrl={onOpenUrl}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'snapshotSource.open' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Report\.docx/ }));
+
+    await waitFor(() => {
+      expect(resumeOfficeDocument).toHaveBeenCalledWith(42);
+      expect(onOpenUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  it('opens a page source when no document is available', async () => {
+    const onOpenUrl = vi.fn(async () => undefined);
+    render(
+      <SnapshotSourceAction
+        screenshotId={42}
+        pageUrl="https://example.com/work"
+        onOpenUrl={onOpenUrl}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'snapshotSource.open' }));
+
+    await waitFor(() => {
+      expect(onOpenUrl).toHaveBeenCalledWith('https://example.com/work');
+    });
+  });
+});

--- a/src/hooks/useSelectedSnapshot.js
+++ b/src/hooks/useSelectedSnapshot.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { listen } from '@tauri-apps/api/event';
 import { fetchImage, getScreenshotDetails } from '../lib/monitor_api';
 
 /**
@@ -114,6 +115,28 @@ export function useSelectedSnapshot() {
 
     return () => {
       cancelled = true;
+    };
+  }, [selectedEvent]);
+
+  useEffect(() => {
+    if (!selectedEvent) return undefined;
+    const targetId = selectedEvent.id === -1 ? null : selectedEvent.id;
+    if (!targetId) return undefined;
+    let disposed = false;
+    let unlisten;
+    listen('office-document-ref-updated', async (event) => {
+      if (event.payload?.screenshot_id !== targetId) return;
+      const details = await getScreenshotDetails(targetId, selectedEvent.path || selectedEvent.image_path);
+      if (!disposed && details && !details.error) {
+        setSelectedDetails(details);
+      }
+    }).then((dispose) => {
+      if (disposed) dispose();
+      else unlisten = dispose;
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
     };
   }, [selectedEvent]);
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -917,14 +917,39 @@
     "moreDeleteOptions": "More delete options",
     "deleteThisRecord": "Delete this record",
     "deleteNearby5min": "Delete records within 5 minutes",
-    "openUrlTitle": "Open URL: {{url}}",
-    "noUrlDetected": "No URL detected",
     "more": "More",
     "showOcr": "Show OCR content",
     "openFloatingPreview": "View in separate window",
     "openMainPreview": "View in main window/preview",
     "float": "Separate Preview",
     "alpha": "alpha"
+  },
+  "snapshotSource": {
+    "open": "Open related content",
+    "opening": "Opening...",
+    "openTitle": "Open the page or file associated with this snapshot",
+    "chooseTitle": "Choose related content to open",
+    "openFailed": "Could not open related content: {{error}}"
+  },
+  "documentSource": {
+    "title": "Edited file",
+    "unknownFile": "Office document",
+    "openTitle": "Open {{name}}",
+    "unsavedTitle": "This file had not been saved and cannot be resumed",
+    "unavailableTitle": "This file cannot be resumed",
+    "openFailed": "Could not open the file: {{error}}",
+    "applications": {
+      "word": "Word",
+      "excel": "Excel",
+      "powerPoint": "PowerPoint",
+      "office": "Office"
+    },
+    "kinds": {
+      "local": "Local file",
+      "cloud": "Cloud document",
+      "unsaved": "Not saved",
+      "office": "Office document"
+    }
   },
   "snapshotPreview": {
     "windowTitle": "Snapshot Preview",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -952,14 +952,39 @@
     "moreDeleteOptions": "更多删除选项",
     "deleteThisRecord": "删除此记录",
     "deleteNearby5min": "删除附近5分钟内的记录",
-    "openUrlTitle": "打开 URL: {{url}}",
-    "noUrlDetected": "未检测到 URL",
     "more": "更多",
     "showOcr": "显示OCR内容",
     "openFloatingPreview": "在独立窗口中查看",
     "openMainPreview": "在主窗口/预览中查看",
     "float": "独立预览",
     "alpha": "alpha"
+  },
+  "snapshotSource": {
+    "open": "打开关联内容",
+    "opening": "正在打开……",
+    "openTitle": "打开此快照对应的页面或文件",
+    "chooseTitle": "选择要打开的关联内容",
+    "openFailed": "无法打开关联内容：{{error}}"
+  },
+  "documentSource": {
+    "title": "编辑中的文件",
+    "unknownFile": "Office 文档",
+    "openTitle": "打开 {{name}}",
+    "unsavedTitle": "此文件当时尚未保存，无法恢复",
+    "unavailableTitle": "此文件当前无法恢复",
+    "openFailed": "无法打开文件：{{error}}",
+    "applications": {
+      "word": "Word",
+      "excel": "Excel",
+      "powerPoint": "PowerPoint",
+      "office": "Office"
+    },
+    "kinds": {
+      "local": "本地文件",
+      "cloud": "云端文档",
+      "unsaved": "未保存",
+      "office": "Office 文档"
+    }
   },
   "snapshotPreview": {
     "windowTitle": "快照预览",

--- a/src/lib/document_ref.js
+++ b/src/lib/document_ref.js
@@ -1,0 +1,46 @@
+import { FileSpreadsheet, FileText, Presentation } from 'lucide-react';
+
+/**
+ * The backend exposes the Office application as a stable enum.  Keep the
+ * presentation mapping here instead of guessing from display_name, which is
+ * absent for some unsaved documents and can be localized by Office.
+ */
+export function getOfficeDocumentIcon(application) {
+  switch (application) {
+    case 'excel':
+      return FileSpreadsheet;
+    case 'power_point':
+    case 'powerpoint':
+      return Presentation;
+    case 'word':
+    default:
+      return FileText;
+  }
+}
+
+export function getOfficeDocumentApplicationKey(application) {
+  switch (application) {
+    case 'excel':
+      return 'excel';
+    case 'power_point':
+    case 'powerpoint':
+      return 'powerPoint';
+    case 'word':
+      return 'word';
+    default:
+      return 'office';
+  }
+}
+
+export function getOfficeDocumentKindKey(kind) {
+  switch (kind) {
+    case 'local_file':
+      return 'local';
+    case 'cloud_document':
+      return 'cloud';
+    case 'unsaved':
+      return 'unsaved';
+    default:
+      return 'office';
+  }
+}

--- a/src/lib/document_ref.test.js
+++ b/src/lib/document_ref.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getOfficeDocumentApplicationKey,
+  getOfficeDocumentIcon,
+  getOfficeDocumentKindKey,
+} from './document_ref';
+
+describe('document_ref presentation helpers', () => {
+  it('maps Office applications to stable labels and icons', () => {
+    expect(getOfficeDocumentApplicationKey('word')).toBe('word');
+    expect(getOfficeDocumentApplicationKey('excel')).toBe('excel');
+    expect(getOfficeDocumentApplicationKey('power_point')).toBe('powerPoint');
+    expect(getOfficeDocumentIcon('word')).toBeTruthy();
+    expect(getOfficeDocumentIcon('excel')).toBeTruthy();
+    expect(getOfficeDocumentIcon('power_point')).toBeTruthy();
+    expect(getOfficeDocumentIcon('unknown')).toBeTruthy();
+  });
+
+  it('maps saved and unsaved document kinds', () => {
+    expect(getOfficeDocumentKindKey('local_file')).toBe('local');
+    expect(getOfficeDocumentKindKey('cloud_document')).toBe('cloud');
+    expect(getOfficeDocumentKindKey('unsaved')).toBe('unsaved');
+    expect(getOfficeDocumentKindKey('unknown')).toBe('office');
+  });
+});

--- a/src/lib/monitor_api.api.test.js
+++ b/src/lib/monitor_api.api.test.js
@@ -18,6 +18,7 @@ import {
   searchScreenshots,
   listProcesses,
   getScreenshotDetails,
+  resumeOfficeDocument,
   updateMonitorFilters,
 } from './monitor_api';
 
@@ -112,6 +113,14 @@ describe('monitor_api command wrappers', () => {
     invoke.mockRejectedValue(new Error('boom'));
 
     await expect(getScreenshotDetails(1)).resolves.toEqual({ error: 'Error: boom' });
+    expectWithAuth(1);
+  });
+
+  it('resumes an Office document through the authenticated command', async () => {
+    invoke.mockResolvedValue({ status: 'opened' });
+
+    await expect(resumeOfficeDocument(42)).resolves.toEqual({ status: 'opened' });
+    expect(invoke).toHaveBeenCalledWith('office_resume_document', { screenshotId: 42 });
     expectWithAuth(1);
   });
 

--- a/src/lib/monitor_api.js
+++ b/src/lib/monitor_api.js
@@ -478,6 +478,11 @@ export const getScreenshotDetails = async (id, path = null) => {
     }
 };
 
+export const resumeOfficeDocument = async (screenshotId) => {
+    if (!screenshotId) throw new Error('A screenshot id is required');
+    return withAuth(() => invoke('office_resume_document', { screenshotId }));
+};
+
 export const updateMonitorFilters = async (filters) => {
     return withAuth(async () => {
         try {

--- a/src/lib/snapshot_sources.js
+++ b/src/lib/snapshot_sources.js
@@ -1,0 +1,32 @@
+import { extractUrlsFromOcr } from './ocr_url_detector';
+
+/**
+ * Build the actionable sources associated with a snapshot.  Office locators
+ * remain backend-only; the public document reference is enough for display
+ * and for deciding whether the authenticated resume command is available.
+ */
+export function getSnapshotSourceOptions({ documentRef, screenshotId, pageUrl, ocrResults }) {
+  const urls = pageUrl
+    ? [pageUrl]
+    : extractUrlsFromOcr(ocrResults || []).slice(0, 5);
+  const options = [];
+
+  if (documentRef?.resumable && Number(screenshotId) > 0) {
+    options.push({
+      id: 'office-document',
+      kind: 'office',
+      documentRef,
+    });
+  }
+
+  urls.forEach((url, index) => {
+    if (!url) return;
+    options.push({
+      id: `url-${index}-${url}`,
+      kind: 'url',
+      url,
+    });
+  });
+
+  return options;
+}

--- a/src/lib/snapshot_sources.test.js
+++ b/src/lib/snapshot_sources.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { getSnapshotSourceOptions } from './snapshot_sources';
+
+const documentRef = {
+  application: 'word',
+  kind: 'local_file',
+  display_name: 'Report.docx',
+  resumable: true,
+};
+
+describe('snapshot_sources', () => {
+  it('returns the resumable document as the only direct source', () => {
+    const sources = getSnapshotSourceOptions({
+      documentRef,
+      screenshotId: 42,
+    });
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0]).toMatchObject({ kind: 'office', documentRef });
+  });
+
+  it('offers both the document and page when both are available', () => {
+    const sources = getSnapshotSourceOptions({
+      documentRef,
+      screenshotId: 42,
+      pageUrl: 'https://example.com/work',
+    });
+
+    expect(sources.map((source) => source.kind)).toEqual(['office', 'url']);
+    expect(sources[1].url).toBe('https://example.com/work');
+  });
+
+  it('uses OCR URLs when no page URL is available', () => {
+    const sources = getSnapshotSourceOptions({
+      screenshotId: 42,
+      ocrResults: [
+        { text: 'https://one.example/a and www.two.example/b' },
+      ],
+    });
+
+    expect(sources.map((source) => source.url)).toEqual([
+      'https://one.example/a',
+      'https://www.two.example/b',
+    ]);
+  });
+
+  it('does not expose an unsaved document as an actionable source', () => {
+    const sources = getSnapshotSourceOptions({
+      documentRef: { ...documentRef, resumable: false, kind: 'unsaved' },
+      screenshotId: 42,
+    });
+
+    expect(sources).toEqual([]);
+  });
+
+  it('does not offer a document without a valid screenshot id', () => {
+    expect(getSnapshotSourceOptions({
+      documentRef,
+      screenshotId: -1,
+    })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Office document context to captured snapshots and lets users reopen associated Word, Excel, and PowerPoint documents from preview surfaces.

## Implementation

- Captures document metadata through an isolated carbonpaper-office worker using a framed JSON stdin/stdout protocol and Windows NativeOM window handles.
- Persists versioned document references with local, cloud, and unsaved classification, exposes sanitized public metadata, and resumes saved documents through an authenticated Tauri command.
- Adds source selection in the React preview UI, live refresh through office-document-ref-updated, and release/portable packaging for the worker.

## Technical principle

Office automation remains isolated from the main Tauri process. Bounded request/response frames carry only the required data, while stable document locators support recovery and the UI receives public metadata rather than COM details.