### PR TITLE
fix: ensure background scheduler drains manual index tasks completely

### DIFF
--- a/src-tauri/src/background_scheduler.rs
+++ b/src-tauri/src/background_scheduler.rs
@@ -186,6 +186,7 @@ impl ScheduledSliceResult {
 pub struct BackgroundSchedulerStatus {
     pub enabled: bool,
     pub running_task: Option<String>,
+    pub running_manual: bool,
     pub tasks: Vec<BackgroundTaskState>,
     pub queue_depths: serde_json::Value,
     pub blocked_reason: Option<String>,
@@ -199,6 +200,7 @@ struct SchedulerRuntime {
     wake: Notify,
     task: Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
     running_task: Mutex<Option<String>>,
+    running_manual: AtomicBool,
     blocked_reason: Mutex<Option<String>>,
     service_seq: AtomicU64,
     worker_restart_count: AtomicU64,
@@ -216,6 +218,7 @@ impl Default for SchedulerRuntime {
             wake: Notify::new(),
             task: Mutex::new(None),
             running_task: Mutex::new(None),
+            running_manual: AtomicBool::new(false),
             blocked_reason: Mutex::new(None),
             service_seq: AtomicU64::new(0),
             worker_restart_count: AtomicU64::new(0),
@@ -395,6 +398,7 @@ impl BackgroundSchedulerState {
         BackgroundSchedulerStatus {
             enabled,
             running_task,
+            running_manual: self.runtime.running_manual.load(Ordering::Relaxed),
             tasks,
             queue_depths: depths,
             blocked_reason,
@@ -838,7 +842,9 @@ async fn scheduler_loop(app: AppHandle, runtime: Arc<SchedulerRuntime>) {
             .running_task
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = Some(kind.as_str().to_string());
+        runtime.running_manual.store(manual, Ordering::SeqCst);
         let result = execute_slice(&app, kind, manual, &runtime).await;
+        runtime.running_manual.store(false, Ordering::SeqCst);
         *runtime
             .running_task
             .lock()

--- a/src-tauri/src/background_scheduler.rs
+++ b/src-tauri/src/background_scheduler.rs
@@ -191,6 +191,8 @@ pub struct BackgroundSchedulerStatus {
     pub queue_depths: serde_json::Value,
     pub blocked_reason: Option<String>,
     pub next_retry_at_ms: Option<i64>,
+    /// Earliest retry timestamp among manually requested tasks.
+    pub manual_retry_at_ms: Option<i64>,
     pub worker_restart_count: u64,
     pub monitor_restart_degraded: bool,
 }
@@ -372,6 +374,11 @@ impl BackgroundSchedulerState {
             .filter(|task| task.status == "retry_wait")
             .map(|task| task.next_attempt_at_ms)
             .min();
+        let manual_retry_at_ms = tasks
+            .iter()
+            .filter(|task| task.manual_pending && task.status == "retry_wait")
+            .map(|task| task.next_attempt_at_ms)
+            .min();
         let running_task = self
             .runtime
             .running_task
@@ -403,6 +410,7 @@ impl BackgroundSchedulerState {
             queue_depths: depths,
             blocked_reason,
             next_retry_at_ms,
+            manual_retry_at_ms,
             worker_restart_count: self.runtime.worker_restart_count.load(Ordering::Relaxed),
             monitor_restart_degraded: self
                 .runtime
@@ -490,11 +498,11 @@ fn queue_depths(storage: Option<tauri::State<'_, Arc<StorageState>>>) -> serde_j
     };
     let semantic = storage
         .derived_index_backlog(DerivedIndexKind::SemanticText, 5)
-        .map(|backlog| backlog.claimable)
+        .map(|backlog| backlog.ready)
         .unwrap_or(0);
     let clip = storage
         .derived_index_backlog(DerivedIndexKind::ClipImage, 5)
-        .map(|backlog| backlog.claimable)
+        .map(|backlog| backlog.ready)
         .unwrap_or(0);
     let smart = storage.count_smart_cluster_pending().unwrap_or(0).max(0) as u64;
     serde_json::json!({
@@ -553,11 +561,11 @@ async fn refresh_backlog(app: &AppHandle) {
     let counts = tokio::task::spawn_blocking(move || {
         let semantic = count_storage
             .derived_index_backlog(DerivedIndexKind::SemanticText, 5)
-            .map(|backlog| backlog.claimable)
+            .map(|backlog| backlog.ready)
             .unwrap_or(0);
         let clip = count_storage
             .derived_index_backlog(DerivedIndexKind::ClipImage, 5)
-            .map(|backlog| backlog.claimable)
+            .map(|backlog| backlog.ready)
             .unwrap_or(0);
         let smart = count_storage
             .count_smart_cluster_pending()
@@ -936,10 +944,21 @@ async fn scheduler_loop(app: AppHandle, runtime: Arc<SchedulerRuntime>) {
                 let smart_cluster_policy = (kind == BackgroundTaskKind::SmartCluster).then(|| {
                     crate::smart_cluster_scoring::scheduled_failure_policy(&error, failures)
                 });
-                if smart_cluster_policy.is_some_and(|policy| policy.terminal) {
-                    let failure_code = smart_cluster_policy
-                        .map(|policy| policy.code)
-                        .unwrap_or("task_failed");
+                let deterministic_index_failure = matches!(
+                    kind,
+                    BackgroundTaskKind::SemanticIndex | BackgroundTaskKind::ClipIndex
+                )
+                    && crate::semantic_runtime::is_deterministic_worker_failure(&error);
+                if deterministic_index_failure
+                    || smart_cluster_policy.is_some_and(|policy| policy.terminal)
+                {
+                    let failure_code = smart_cluster_policy.map(|policy| policy.code).unwrap_or(
+                        if deterministic_index_failure {
+                            "index_worker_failure"
+                        } else {
+                            "task_failed"
+                        },
+                    );
                     let terminal_failed = storage
                         .mark_background_task_terminal_failure(kind.as_str(), failures, &error)
                         .unwrap_or(false);

--- a/src-tauri/src/clip_index.rs
+++ b/src-tauri/src/clip_index.rs
@@ -327,6 +327,17 @@ pub async fn run_scheduled_slice(
 ) -> Result<ScheduledSliceResult, String> {
     let run = app.state::<Arc<ClipIndexRunState>>().inner().clone();
     let _active = manual.then(|| run.begin());
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+    if manual {
+        // See the MiniLM counterpart: a click that arrived during an earlier
+        // slice must still clear failures produced after that click.
+        let reset_storage = storage.clone();
+        tokio::task::spawn_blocking(move || {
+            reset_storage.reset_derived_index_retries(DerivedIndexKind::ClipImage)
+        })
+        .await
+        .map_err(|error| format!("clip retry reset task failed: {error}"))??;
+    }
     let outcome = run_pass(app, scheduled_pass_mode(manual)).await?;
     if let Some(reason) = outcome.refused.or(outcome.stopped_because) {
         return Ok(ScheduledSliceResult::skipped(reason));
@@ -334,11 +345,10 @@ pub async fn run_scheduled_slice(
     if let Err(error) = crate::clip_ann::maybe_rebuild(app, false).await {
         tracing::warn!("[CLIP:ANN] scheduled rebuild failed: {error}");
     }
-    let storage = app.state::<Arc<StorageState>>().inner().clone();
     let backlog = tokio::task::spawn_blocking(move || {
         storage
             .derived_index_backlog(DerivedIndexKind::ClipImage, MAX_ATTEMPTS)
-            .map(|backlog| backlog.claimable)
+            .map(|backlog| backlog.ready)
     })
     .await
     .map_err(|error| format!("clip backlog task failed: {error}"))??;
@@ -606,7 +616,8 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
                     .unwrap_or(RepairScope::Suspended);
                 reconcile_missing(storage.clone(), scope).await?;
             }
-            drain_queue(app, storage, mode, locked).await
+            let mut fast_retry_used = false;
+            drain_queue(app, storage, mode, locked, &mut fast_retry_used).await
         }
         PassMode::Manual => {
             reap_orphans(storage.clone()).await?;
@@ -634,7 +645,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
             let total = tokio::task::spawn_blocking(move || {
                 counting
                     .derived_index_backlog(DerivedIndexKind::ClipImage, MAX_ATTEMPTS)
-                    .map(|backlog| backlog.claimable)
+                    .map(|backlog| backlog.ready)
                     .unwrap_or(0)
             })
             .await
@@ -690,10 +701,11 @@ async fn drain_until_done(
 ) -> Result<PassOutcome, String> {
     debug_assert!(mode.is_manual());
     let mut total = PassOutcome::default();
+    let mut fast_retry_used = false;
     loop {
         // Manual runs hold an authenticated session by construction:
         // `clip_index_run_now` checks it before anything else.
-        let outcome = drain_queue(app, storage.clone(), mode, false).await?;
+        let outcome = drain_queue(app, storage.clone(), mode, false, &mut fast_retry_used).await?;
         total.indexed += outcome.indexed;
         total.failed += outcome.failed;
         match outcome.stopped_because {
@@ -718,10 +730,16 @@ async fn drain_until_done(
 
 /// One claimed job: its ledger identity, the image to encode, and the lease
 /// that authorizes the commit.
+#[derive(Clone)]
 struct ClaimedJob {
     spec: DerivedIndexJobSpec,
     image_hash: String,
     lease_token: String,
+}
+
+struct EncodeChunkFailure {
+    error: String,
+    claimed: Vec<ClaimedJob>,
 }
 
 async fn drain_queue(
@@ -729,6 +747,7 @@ async fn drain_queue(
     storage: Arc<StorageState>,
     mode: PassMode,
     locked: bool,
+    fast_retry_used: &mut bool,
 ) -> Result<PassOutcome, String> {
     let claimed = claim_batch(storage.clone(), locked).await?;
     if claimed.is_empty() {
@@ -769,7 +788,23 @@ async fn drain_queue(
 
         let chunk: Vec<ClaimedJob> = pending.drain(..ENCODE_CHUNK.min(pending.len())).collect();
         let chunk_len = chunk.len() as u64;
-        match encode_chunk(app, &semantic, storage.clone(), chunk).await {
+        let encoded_result = match encode_chunk(app, &semantic, storage.clone(), chunk).await {
+            Err(failure)
+                if mode.is_manual()
+                    && !*fast_retry_used
+                    && crate::semantic_runtime::is_transient_worker_failure(&failure.error) =>
+            {
+                *fast_retry_used = true;
+                tracing::warn!(
+                    "[CLIP:INDEX] manual encode failed; restarting worker for one immediate retry: {}",
+                    failure.error
+                );
+                semantic.restart_for_manual_retry();
+                encode_chunk(app, &semantic, storage.clone(), failure.claimed).await
+            }
+            other => other,
+        };
+        match encoded_result {
             Ok(encoded) => {
                 outcome.indexed += encoded as u64;
                 if mode.is_manual() {
@@ -791,7 +826,7 @@ async fn drain_queue(
                     break;
                 }
             }
-            Err(error) => {
+            Err(chunk_failure) => {
                 outcome.failed += chunk_len;
                 if mode.is_manual() {
                     run.report_chunk(app, chunk_len, 0);
@@ -808,7 +843,9 @@ async fn drain_queue(
                     )
                     .await;
                 }
-                failure = Some(error);
+                settle_failed_claims(storage.clone(), chunk_failure.claimed, &chunk_failure.error)
+                    .await;
+                failure = Some(chunk_failure.error);
                 break;
             }
         }
@@ -834,18 +871,23 @@ async fn drain_queue(
 ///
 /// An image that cannot be read or decoded is discarded rather than retried:
 /// the bytes on disk are stable, so the next attempt fails identically. An
-/// encode failure is a worker problem and does charge the retry budget.
+/// encode failure is returned with its lease so the caller can distinguish a
+/// worker-wide retry from a deterministic per-image failure.
 async fn encode_chunk(
     app: &AppHandle,
     semantic: &Arc<SemanticRuntimeState>,
     storage: Arc<StorageState>,
     claimed: Vec<ClaimedJob>,
-) -> Result<usize, String> {
+) -> Result<usize, EncodeChunkFailure> {
     let read_storage = storage.clone();
     let hashes: Vec<String> = claimed.iter().map(|job| job.image_hash.clone()).collect();
+    let retry_claimed = claimed.clone();
     let decoded = tokio::task::spawn_blocking(move || load_images(&read_storage, &hashes))
         .await
-        .map_err(|error| format!("image read task failed: {error}"))?;
+        .map_err(|error| EncodeChunkFailure {
+            error: format!("image read task failed: {error}"),
+            claimed: retry_claimed,
+        })?;
 
     // Partition before submitting: an unreadable image must not cost the
     // readable ones in the same chunk their attempt.
@@ -903,20 +945,30 @@ async fn encode_chunk(
         Ok(result) if result.vectors.len() == jobs.len() => result.vectors,
         Ok(result) => {
             let error = format!(
-                "semantic worker returned {} vectors for {} images",
+                "protocol: semantic worker returned {} vectors for {} images",
                 result.vectors.len(),
                 jobs.len()
             );
-            fail_claims(storage, jobs, "embed_mismatch", &error).await;
-            return Err(error);
+            return Err(EncodeChunkFailure {
+                error,
+                claimed: jobs,
+            });
         }
         Err(error) => {
-            fail_claims(storage, jobs, "embed_failed", &error).await;
-            return Err(format!("embed failed: {error}"));
+            return Err(EncodeChunkFailure {
+                error: format!("embed failed: {error}"),
+                claimed: jobs,
+            });
         }
     };
 
-    commit_batch(storage, jobs, vectors).await
+    let retry_jobs = jobs.clone();
+    commit_batch(storage, jobs, vectors)
+        .await
+        .map_err(|error| EncodeChunkFailure {
+            error,
+            claimed: retry_jobs,
+        })
 }
 
 /// One screenshot decoded into the packed RGB the CLIP preprocessor expects.
@@ -1163,6 +1215,20 @@ async fn fail_claims(
     .await;
 }
 
+async fn settle_failed_claims(storage: Arc<StorageState>, claimed: Vec<ClaimedJob>, error: &str) {
+    if crate::semantic_runtime::is_deterministic_worker_failure(error) {
+        fail_claims(storage, claimed, "embed_failed", error).await;
+    } else {
+        release_claims(
+            storage,
+            claimed,
+            "worker_retry",
+            "semantic worker failure; scheduler will retry the batch",
+        )
+        .await;
+    }
+}
+
 /// Drop CLIP rows with no live screenshot behind them.
 ///
 /// A safety net rather than a live path — see the module header. It also cleans
@@ -1248,18 +1314,21 @@ pub async fn clip_index_run_now(
 ) -> Result<ClipIndexRunSummary, String> {
     crate::commands::check_auth_required(&credential)?;
     let _ = run;
-    if let Some(scheduler) =
-        app.try_state::<Arc<crate::background_scheduler::BackgroundSchedulerState>>()
-    {
-        scheduler.enqueue(
-            &app,
-            crate::background_scheduler::BackgroundTaskKind::ClipIndex,
-            true,
-        )?;
-    } else {
-        return Err("Background scheduler is unavailable".to_string());
-    }
+    let scheduler = app
+        .try_state::<Arc<crate::background_scheduler::BackgroundSchedulerState>>()
+        .ok_or_else(|| "Background scheduler is unavailable".to_string())?;
     let storage = app.state::<Arc<StorageState>>().inner().clone();
+    let _ = tokio::task::spawn_blocking({
+        let storage = storage.clone();
+        move || storage.reset_derived_index_retries(DerivedIndexKind::ClipImage)
+    })
+    .await
+    .map_err(|error| format!("clip retry reset task failed: {error}"))??;
+    scheduler.enqueue(
+        &app,
+        crate::background_scheduler::BackgroundTaskKind::ClipIndex,
+        true,
+    )?;
     let backlog = tokio::task::spawn_blocking(move || {
         storage
             .derived_index_backlog(DerivedIndexKind::ClipImage, MAX_ATTEMPTS)

--- a/src-tauri/src/clip_index.rs
+++ b/src-tauri/src/clip_index.rs
@@ -349,7 +349,7 @@ pub async fn run_scheduled_slice(
 
 fn scheduled_pass_mode(manual: bool) -> PassMode {
     if manual {
-        PassMode::ScheduledManual
+        PassMode::Manual
     } else {
         PassMode::Idle
     }
@@ -358,23 +358,21 @@ fn scheduled_pass_mode(manual: bool) -> PassMode {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum PassMode {
     Idle,
+    /// A complete manual drain, admitted by the unified scheduler. The command
+    /// enqueues and returns, so by the time this runs nobody is awaiting it:
+    /// an encode failure propagates out of the pass rather than being folded
+    /// into a run summary, which leaves the retry to the scheduler's durable
+    /// backoff. See the failure match at the end of [`drain_queue`].
     Manual,
-    /// A complete manual drain whose admission and failure retry are owned by
-    /// the unified scheduler.
-    ScheduledManual,
 }
 
 impl PassMode {
     fn is_manual(self) -> bool {
-        matches!(self, Self::Manual | Self::ScheduledManual)
+        self == Self::Manual
     }
 
     fn yields_after_chunk(self) -> bool {
         self == Self::Idle
-    }
-
-    fn reports_failure_in_summary(self) -> bool {
-        self == Self::Manual
     }
 }
 
@@ -571,7 +569,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
         {
             return Ok(PassOutcome::refused(FOREGROUND_QUERY_STOP));
         }
-    } else if let Some(reason) = stand_aside_for_foreground(app, mode).await {
+    } else if let Some(reason) = stand_aside_for_foreground(app).await {
         return Ok(PassOutcome::refused(reason));
     }
 
@@ -585,7 +583,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
     // batch `waiting_for_auth` on every tick.
     let locked = match mode {
         PassMode::Idle => !storage.is_background_authorized(),
-        PassMode::Manual | PassMode::ScheduledManual => !storage.is_silent_read_authorized(),
+        PassMode::Manual => !storage.is_silent_read_authorized(),
     };
     if locked && !has_prepared_captures() {
         return Ok(PassOutcome::refused(if mode == PassMode::Idle {
@@ -610,7 +608,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
             }
             drain_queue(app, storage, mode, locked).await
         }
-        PassMode::Manual | PassMode::ScheduledManual => {
+        PassMode::Manual => {
             reap_orphans(storage.clone()).await?;
             let scope_storage = storage.clone();
             let scope = tokio::task::spawn_blocking(move || repair_scope(&scope_storage))
@@ -653,8 +651,10 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
 /// starts again at the next, so it bounds a run that cannot make progress
 /// rather than a run that has been politely yielding for a long time — see
 /// [`MANUAL_FOREGROUND_WAIT_BUDGET`].
-async fn stand_aside_for_foreground(app: &AppHandle, mode: PassMode) -> Option<&'static str> {
-    debug_assert!(mode.is_manual());
+///
+/// Only a manual pass calls this: an idle pass yields to the foreground by
+/// ending rather than by waiting.
+async fn stand_aside_for_foreground(app: &AppHandle) -> Option<&'static str> {
     let semantic = app.state::<Arc<SemanticRuntimeState>>().inner().clone();
     let mut waited = Duration::ZERO;
     loop {
@@ -703,7 +703,7 @@ async fn drain_until_done(
             // A foreground query took the worker: wait for it and claim again,
             // rather than ending a run somebody started.
             Some(FOREGROUND_QUERY_STOP) => {
-                if let Some(reason) = stand_aside_for_foreground(app, mode).await {
+                if let Some(reason) = stand_aside_for_foreground(app).await {
                     total.stopped_because = Some(reason);
                     return Ok(total);
                 }
@@ -818,11 +818,13 @@ async fn drain_queue(
         tracing::info!("[CLIP:INDEX] indexed {} image(s)", indexed);
     }
     match failure {
-        Some(error) if mode.reports_failure_in_summary() => {
-            outcome.stopped_because = Some("encode_failed");
-            tracing::warn!("[CLIP:INDEX] manual run stopped: {error}");
-            Ok(outcome)
-        }
+        // The failure propagates rather than being folded into the summary:
+        // the command that asked for this run enqueued it and returned, so
+        // nothing is awaiting a report and only the scheduler's durable retry
+        // and backoff can act on it. Reporting it as a pass that stopped early
+        // would have the scheduler defer by a single tick and re-enter without
+        // counting the attempt, which is a tight loop against a worker that is
+        // already down.
         Some(error) => Err(error),
         None => Ok(outcome),
     }
@@ -1639,10 +1641,9 @@ mod tests {
         // The scheduler decides when this starts. It must not turn the user's
         // complete drain into one image followed by ordinary idle work.
         let mode = scheduled_pass_mode(true);
-        assert_eq!(mode, PassMode::ScheduledManual);
+        assert_eq!(mode, PassMode::Manual);
         assert!(mode.is_manual());
         assert!(!mode.yields_after_chunk());
-        assert!(!mode.reports_failure_in_summary());
         assert_eq!(scheduled_pass_mode(false), PassMode::Idle);
     }
 

--- a/src-tauri/src/clip_index.rs
+++ b/src-tauri/src/clip_index.rs
@@ -318,7 +318,8 @@ fn indexable_hashes(
     Ok(indexable)
 }
 
-/// Execute one automatic CLIP index/repair slice. The unified scheduler owns
+/// Execute one automatic CLIP index/repair slice, or a complete manual drain
+/// after the unified scheduler admits the user's request. The scheduler owns
 /// admission and the semantic-worker guard.
 pub async fn run_scheduled_slice(
     app: &AppHandle,
@@ -326,15 +327,7 @@ pub async fn run_scheduled_slice(
 ) -> Result<ScheduledSliceResult, String> {
     let run = app.state::<Arc<ClipIndexRunState>>().inner().clone();
     let _active = manual.then(|| run.begin());
-    let outcome = run_pass(
-        app,
-        if manual {
-            PassMode::ScheduledManual
-        } else {
-            PassMode::Idle
-        },
-    )
-    .await?;
+    let outcome = run_pass(app, scheduled_pass_mode(manual)).await?;
     if let Some(reason) = outcome.refused.or(outcome.stopped_because) {
         return Ok(ScheduledSliceResult::skipped(reason));
     }
@@ -354,16 +347,34 @@ pub async fn run_scheduled_slice(
     ))
 }
 
+fn scheduled_pass_mode(manual: bool) -> PassMode {
+    if manual {
+        PassMode::ScheduledManual
+    } else {
+        PassMode::Idle
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum PassMode {
     Idle,
     Manual,
+    /// A complete manual drain whose admission and failure retry are owned by
+    /// the unified scheduler.
     ScheduledManual,
 }
 
 impl PassMode {
     fn is_manual(self) -> bool {
         matches!(self, Self::Manual | Self::ScheduledManual)
+    }
+
+    fn yields_after_chunk(self) -> bool {
+        self == Self::Idle
+    }
+
+    fn reports_failure_in_summary(self) -> bool {
+        self == Self::Manual
     }
 }
 
@@ -560,7 +571,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
         {
             return Ok(PassOutcome::refused(FOREGROUND_QUERY_STOP));
         }
-    } else if let Some(reason) = stand_aside_for_foreground(app).await {
+    } else if let Some(reason) = stand_aside_for_foreground(app, mode).await {
         return Ok(PassOutcome::refused(reason));
     }
 
@@ -599,16 +610,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
             }
             drain_queue(app, storage, mode, locked).await
         }
-        PassMode::ScheduledManual => {
-            reap_orphans(storage.clone()).await?;
-            let scope_storage = storage.clone();
-            let scope = tokio::task::spawn_blocking(move || repair_scope(&scope_storage))
-                .await
-                .unwrap_or(RepairScope::Suspended);
-            reconcile_missing(storage.clone(), scope).await?;
-            drain_queue(app, storage, mode, false).await
-        }
-        PassMode::Manual => {
+        PassMode::Manual | PassMode::ScheduledManual => {
             reap_orphans(storage.clone()).await?;
             let scope_storage = storage.clone();
             let scope = tokio::task::spawn_blocking(move || repair_scope(&scope_storage))
@@ -640,7 +642,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
             .await
             .unwrap_or(0);
             run.total.store(total, Ordering::SeqCst);
-            drain_until_done(app, storage).await
+            drain_until_done(app, storage, mode).await
         }
     }
 }
@@ -651,7 +653,8 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
 /// starts again at the next, so it bounds a run that cannot make progress
 /// rather than a run that has been politely yielding for a long time — see
 /// [`MANUAL_FOREGROUND_WAIT_BUDGET`].
-async fn stand_aside_for_foreground(app: &AppHandle) -> Option<&'static str> {
+async fn stand_aside_for_foreground(app: &AppHandle, mode: PassMode) -> Option<&'static str> {
+    debug_assert!(mode.is_manual());
     let semantic = app.state::<Arc<SemanticRuntimeState>>().inner().clone();
     let mut waited = Duration::ZERO;
     loop {
@@ -683,12 +686,14 @@ async fn stand_aside_for_foreground(app: &AppHandle) -> Option<&'static str> {
 async fn drain_until_done(
     app: &AppHandle,
     storage: Arc<StorageState>,
+    mode: PassMode,
 ) -> Result<PassOutcome, String> {
+    debug_assert!(mode.is_manual());
     let mut total = PassOutcome::default();
     loop {
         // Manual runs hold an authenticated session by construction:
         // `clip_index_run_now` checks it before anything else.
-        let outcome = drain_queue(app, storage.clone(), PassMode::Manual, false).await?;
+        let outcome = drain_queue(app, storage.clone(), mode, false).await?;
         total.indexed += outcome.indexed;
         total.failed += outcome.failed;
         match outcome.stopped_because {
@@ -698,7 +703,7 @@ async fn drain_until_done(
             // A foreground query took the worker: wait for it and claim again,
             // rather than ending a run somebody started.
             Some(FOREGROUND_QUERY_STOP) => {
-                if let Some(reason) = stand_aside_for_foreground(app).await {
+                if let Some(reason) = stand_aside_for_foreground(app, mode).await {
                     total.stopped_because = Some(reason);
                     return Ok(total);
                 }
@@ -771,7 +776,7 @@ async fn drain_queue(
                     run.report_chunk(app, chunk_len, encoded as u64);
                 }
                 indexed += encoded;
-                if !matches!(mode, PassMode::Manual) && !pending.is_empty() {
+                if mode.yields_after_chunk() && !pending.is_empty() {
                     // A scheduled request owns one bounded image batch. Give
                     // the remaining claimed jobs back without consuming retry
                     // budget so the unified scheduler can rotate to the next
@@ -813,7 +818,7 @@ async fn drain_queue(
         tracing::info!("[CLIP:INDEX] indexed {} image(s)", indexed);
     }
     match failure {
-        Some(error) if mode.is_manual() => {
+        Some(error) if mode.reports_failure_in_summary() => {
             outcome.stopped_because = Some("encode_failed");
             tracing::warn!("[CLIP:INDEX] manual run stopped: {error}");
             Ok(outcome)
@@ -1627,6 +1632,18 @@ mod tests {
         // chunk size *is* the worst case a search arriving mid-pass inherits.
         assert_eq!(ENCODE_CHUNK, 1);
         assert!(DRAIN_BATCH >= ENCODE_CHUNK);
+    }
+
+    #[test]
+    fn a_scheduled_manual_request_uses_the_complete_drain_mode() {
+        // The scheduler decides when this starts. It must not turn the user's
+        // complete drain into one image followed by ordinary idle work.
+        let mode = scheduled_pass_mode(true);
+        assert_eq!(mode, PassMode::ScheduledManual);
+        assert!(mode.is_manual());
+        assert!(!mode.yields_after_chunk());
+        assert!(!mode.reports_failure_in_summary());
+        assert_eq!(scheduled_pass_mode(false), PassMode::Idle);
     }
 
     #[test]

--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -174,11 +174,13 @@ mod tests {
             clip_image_rows: 9,
             semantic_index_backlog: DerivedIndexBacklog {
                 claimable: 2,
+                ready: 1,
                 exhausted: 1,
                 oldest_claimable_age_secs: Some(30),
             },
             clip_index_backlog: DerivedIndexBacklog {
                 claimable: 4,
+                ready: 2,
                 exhausted: 3,
                 oldest_claimable_age_secs: Some(60),
             },

--- a/src-tauri/src/minilm_index.rs
+++ b/src-tauri/src/minilm_index.rs
@@ -305,7 +305,8 @@ pub fn enqueue_captured_screenshot(
     Ok(())
 }
 
-/// Execute exactly one automatic MiniLM maintenance/encode slice. Scheduling,
+/// Execute one automatic MiniLM maintenance/encode slice, or a complete manual
+/// drain after the unified scheduler admits the user's request. Scheduling,
 /// authorization, and serialization are owned by `background_scheduler`.
 pub async fn run_scheduled_slice(
     app: &AppHandle,
@@ -313,15 +314,7 @@ pub async fn run_scheduled_slice(
 ) -> Result<ScheduledSliceResult, String> {
     let run = app.state::<Arc<SemanticIndexRunState>>().inner().clone();
     let _active = manual.then(|| run.begin());
-    let outcome = run_pass(
-        app,
-        if manual {
-            PassMode::ScheduledManual
-        } else {
-            PassMode::Idle
-        },
-    )
-    .await?;
+    let outcome = run_pass(app, scheduled_pass_mode(manual)).await?;
     if let Some(reason) = outcome.refused.or(outcome.stopped_because) {
         return Ok(ScheduledSliceResult::skipped(reason));
     }
@@ -357,26 +350,44 @@ pub async fn run_scheduled_slice(
     Ok(ScheduledSliceResult::complete(backlog > 0))
 }
 
+fn scheduled_pass_mode(manual: bool) -> PassMode {
+    if manual {
+        PassMode::ScheduledManual
+    } else {
+        PassMode::Idle
+    }
+}
+
 /// What is allowed to stop a pass.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum PassMode {
     /// Background work: runs only inside an idle window and stands down the
     /// moment the user comes back.
     Idle,
-    /// The user asked for this run, so the idle gate does not apply. Every
-    /// other guard still does — maintenance mode, the locked session, the
-    /// ledger's retry budget — and the run stops on the user's word or on the
-    /// runaway deadline.
+    /// The user asked for this run and the scheduler admitted it, so the idle
+    /// gate does not apply and the queue drains without yielding to another
+    /// background task. Every other guard still does — maintenance mode, the
+    /// locked session, the ledger's retry budget — and the run stops on the
+    /// user's word or on the runaway deadline.
     Manual,
-    /// A user request dispatched by the unified scheduler. It ignores the
-    /// idle gate like `Manual`, but returns after one drain so other queued
-    /// tasks get a scheduling boundary.
+    /// The same complete drain after admission by the unified scheduler. This
+    /// stays distinct from `Manual` only so worker failures return to the
+    /// scheduler's durable retry/backoff policy instead of becoming a command
+    /// summary for a caller that is no longer awaiting the run.
     ScheduledManual,
 }
 
 impl PassMode {
     fn is_manual(self) -> bool {
         matches!(self, Self::Manual | Self::ScheduledManual)
+    }
+
+    fn yields_after_chunk(self) -> bool {
+        self == Self::Idle
+    }
+
+    fn reports_failure_in_summary(self) -> bool {
+        self == Self::Manual
     }
 }
 
@@ -552,7 +563,8 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
         {
             return Ok(PassOutcome::refused(FOREGROUND_QUERY_STOP));
         }
-    } else if let Some(reason) = stand_aside_for_foreground(app, deadline, &mut waited).await {
+    } else if let Some(reason) = stand_aside_for_foreground(app, mode, deadline, &mut waited).await
+    {
         // Nothing was attempted, so this is a refusal rather than a stop: the
         // summary says "skipped, and here is which guard", which is the true
         // account of a click that never reached the worker.
@@ -576,8 +588,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
 
     match mode {
         PassMode::Idle => drain_queue(app, storage, mode).await,
-        PassMode::ScheduledManual => drain_queue(app, storage, mode).await,
-        PassMode::Manual => {
+        PassMode::Manual | PassMode::ScheduledManual => {
             // The queue depth the user is about to watch drain, read once and
             // after the repair pass that can add to it. Re-reading it per chunk
             // would take the process-wide database mutex several times a second
@@ -593,7 +604,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
             .await
             .unwrap_or(0);
             run.total.store(total, Ordering::SeqCst);
-            drain_until_done(app, storage, deadline, waited).await
+            drain_until_done(app, storage, deadline, waited, mode).await
         }
     }
 }
@@ -613,9 +624,11 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
 /// resumes leaves the ledger exactly as it found it.
 async fn stand_aside_for_foreground(
     app: &AppHandle,
+    mode: PassMode,
     deadline: Instant,
     waited: &mut Duration,
 ) -> Option<&'static str> {
+    debug_assert!(mode.is_manual());
     let semantic = app.state::<Arc<SemanticRuntimeState>>().inner().clone();
     if !semantic.foreground_waiting() {
         return None;
@@ -671,18 +684,20 @@ async fn drain_until_done(
     storage: Arc<StorageState>,
     deadline: Instant,
     mut waited: Duration,
+    mode: PassMode,
 ) -> Result<PassOutcome, String> {
+    debug_assert!(mode.is_manual());
     let run = app.state::<Arc<SemanticIndexRunState>>().inner().clone();
     let mut total = PassOutcome::default();
     loop {
         // Before claiming anything, not after: a batch claimed and then held
         // through a pause is a batch nobody else can encode, and the leases
         // would be released uncharged one chunk later anyway.
-        if let Some(reason) = stand_aside_for_foreground(app, deadline, &mut waited).await {
+        if let Some(reason) = stand_aside_for_foreground(app, mode, deadline, &mut waited).await {
             total.stopped_because = Some(reason);
             break;
         }
-        let pass = drain_queue(app, storage.clone(), PassMode::Manual).await?;
+        let pass = drain_queue(app, storage.clone(), mode).await?;
         let drained = pass.indexed + pass.failed;
         total.indexed += pass.indexed;
         total.failed += pass.failed;
@@ -934,7 +949,7 @@ async fn drain_queue(
                     run.report_chunk(app, chunk_len, encoded.len() as u64);
                 }
                 indexed.append(&mut encoded);
-                if mode != PassMode::Manual && !pending.is_empty() {
+                if mode.yields_after_chunk() && !pending.is_empty() {
                     // One scheduler slice is one worker request and commit.
                     // Return the rest of this broader database claim without
                     // charging attempts so the task can re-enter at the FIFO
@@ -980,7 +995,7 @@ async fn drain_queue(
         // A manual run reports the failure through its summary instead of
         // propagating it, so the user sees "3 indexed, 4 failed" rather than an
         // error dialog that hides the work that did land.
-        Some(error) if mode.is_manual() => {
+        Some(error) if mode.reports_failure_in_summary() => {
             outcome.stopped_because = Some("encode_failed");
             tracing::warn!("[SEMANTIC:INDEX] manual run stopped: {error}");
             Ok(outcome)
@@ -1612,6 +1627,19 @@ mod tests {
         // rewriting the same store, which consent cannot make safe.
         assert_eq!(PassMode::Manual, PassMode::Manual);
         assert_ne!(PassMode::Idle, PassMode::Manual);
+    }
+
+    #[test]
+    fn a_scheduled_manual_request_uses_the_complete_drain_mode() {
+        // The scheduler owns admission, not the meaning of the user's action.
+        // Once admitted, a manual request must keep the worker until the queue
+        // is empty (or a real manual stop condition fires).
+        let mode = scheduled_pass_mode(true);
+        assert_eq!(mode, PassMode::ScheduledManual);
+        assert!(mode.is_manual());
+        assert!(!mode.yields_after_chunk());
+        assert!(!mode.reports_failure_in_summary());
+        assert_eq!(scheduled_pass_mode(false), PassMode::Idle);
     }
 
     #[test]

--- a/src-tauri/src/minilm_index.rs
+++ b/src-tauri/src/minilm_index.rs
@@ -314,15 +314,27 @@ pub async fn run_scheduled_slice(
 ) -> Result<ScheduledSliceResult, String> {
     let run = app.state::<Arc<SemanticIndexRunState>>().inner().clone();
     let _active = manual.then(|| run.begin());
+    let storage = app.state::<Arc<StorageState>>().inner().clone();
+    if manual {
+        // Reset at admission as well as at button-click time. A second click
+        // can arrive while an earlier slice is still running; that slice may
+        // fail after the click's reset, and the pending request must still be
+        // a fresh retry when it starts.
+        let reset_storage = storage.clone();
+        tokio::task::spawn_blocking(move || {
+            reset_storage.reset_derived_index_retries(DerivedIndexKind::SemanticText)
+        })
+        .await
+        .map_err(|error| format!("semantic retry reset task failed: {error}"))??;
+    }
     let outcome = run_pass(app, scheduled_pass_mode(manual)).await?;
     if let Some(reason) = outcome.refused.or(outcome.stopped_because) {
         return Ok(ScheduledSliceResult::skipped(reason));
     }
-    let storage = app.state::<Arc<StorageState>>().inner().clone();
     let backlog = tokio::task::spawn_blocking(move || {
         storage
             .derived_index_backlog(DerivedIndexKind::SemanticText, MAX_ATTEMPTS)
-            .map(|backlog| backlog.claimable)
+            .map(|backlog| backlog.ready)
     })
     .await
     .map_err(|error| format!("semantic backlog task failed: {error}"))??;
@@ -582,7 +594,10 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
     reconcile_missing(storage.clone()).await?;
 
     match mode {
-        PassMode::Idle => drain_queue(app, storage, mode).await,
+        PassMode::Idle => {
+            let mut fast_retry_used = false;
+            drain_queue(app, storage, mode, &mut fast_retry_used).await
+        }
         PassMode::Manual => {
             // The queue depth the user is about to watch drain, read once and
             // after the repair pass that can add to it. Re-reading it per chunk
@@ -593,7 +608,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
             let total = tokio::task::spawn_blocking(move || {
                 counting
                     .derived_index_backlog(DerivedIndexKind::SemanticText, MAX_ATTEMPTS)
-                    .map(|backlog| backlog.claimable)
+                    .map(|backlog| backlog.ready)
                     .unwrap_or(0)
             })
             .await
@@ -685,6 +700,7 @@ async fn drain_until_done(
     debug_assert!(mode.is_manual());
     let run = app.state::<Arc<SemanticIndexRunState>>().inner().clone();
     let mut total = PassOutcome::default();
+    let mut fast_retry_used = false;
     loop {
         // Before claiming anything, not after: a batch claimed and then held
         // through a pause is a batch nobody else can encode, and the leases
@@ -693,7 +709,7 @@ async fn drain_until_done(
             total.stopped_because = Some(reason);
             break;
         }
-        let pass = drain_queue(app, storage.clone(), mode).await?;
+        let pass = drain_queue(app, storage.clone(), mode, &mut fast_retry_used).await?;
         let drained = pass.indexed + pass.failed;
         total.indexed += pass.indexed;
         total.failed += pass.failed;
@@ -852,11 +868,17 @@ async fn reconcile_missing(storage: Arc<StorageState>) -> Result<(), String> {
 
 /// One claimed job: its ledger identity, its model input, the metadata the
 /// mirror will need, and the lease that authorizes the commit.
+#[derive(Clone)]
 struct ClaimedJob {
     spec: DerivedIndexJobSpec,
     text: String,
     summary: BackgroundScreenshotSummary,
     lease_token: String,
+}
+
+struct EncodeChunkFailure {
+    error: String,
+    claimed: Vec<ClaimedJob>,
 }
 
 /// One screenshot that became query-visible in this pass, in the shape the
@@ -872,6 +894,7 @@ async fn drain_queue(
     app: &AppHandle,
     storage: Arc<StorageState>,
     mode: PassMode,
+    fast_retry_used: &mut bool,
 ) -> Result<PassOutcome, String> {
     let claimed = claim_batch(storage.clone()).await?;
     if claimed.is_empty() {
@@ -935,7 +958,23 @@ async fn drain_queue(
         }
         let chunk: Vec<ClaimedJob> = pending.drain(..ENCODE_CHUNK.min(pending.len())).collect();
         let chunk_len = chunk.len() as u64;
-        match encode_chunk(app, &semantic, storage.clone(), chunk).await {
+        let encoded_result = match encode_chunk(app, &semantic, storage.clone(), chunk).await {
+            Err(failure)
+                if mode.is_manual()
+                    && !*fast_retry_used
+                    && crate::semantic_runtime::is_transient_worker_failure(&failure.error) =>
+            {
+                *fast_retry_used = true;
+                tracing::warn!(
+                    "[SEMANTIC:INDEX] manual encode failed; restarting worker for one immediate retry: {}",
+                    failure.error
+                );
+                semantic.restart_for_manual_retry();
+                encode_chunk(app, &semantic, storage.clone(), failure.claimed).await
+            }
+            other => other,
+        };
+        match encoded_result {
             Ok(mut encoded) => {
                 outcome.indexed += encoded.len() as u64;
                 // The whole chunk left the queue; not all of it necessarily
@@ -960,7 +999,7 @@ async fn drain_queue(
                     break;
                 }
             }
-            Err(error) => {
+            Err(chunk_failure) => {
                 outcome.failed += chunk_len;
                 if mode.is_manual() {
                     run.report_chunk(app, chunk_len, 0);
@@ -977,7 +1016,9 @@ async fn drain_queue(
                     )
                     .await;
                 }
-                failure = Some(error);
+                settle_failed_claims(storage.clone(), chunk_failure.claimed, &chunk_failure.error)
+                    .await;
+                failure = Some(chunk_failure.error);
                 break;
             }
         }
@@ -1000,14 +1041,15 @@ async fn drain_queue(
     }
 }
 
-/// Encode and commit one chunk. The chunk's leases are consumed either way:
-/// success commits them, failure charges the retry budget with a backoff.
+/// Encode and commit one chunk. The chunk's leases are returned to the caller
+/// on worker failure so it can choose between the manual fast retry and the
+/// scheduler's durable backoff policy.
 async fn encode_chunk(
     app: &AppHandle,
     semantic: &Arc<SemanticRuntimeState>,
     storage: Arc<StorageState>,
     claimed: Vec<ClaimedJob>,
-) -> Result<Vec<IndexedSubject>, String> {
+) -> Result<Vec<IndexedSubject>, EncodeChunkFailure> {
     let texts: Vec<String> = claimed.iter().map(|job| job.text.clone()).collect();
     let embedded = semantic
         .embed_text(
@@ -1025,20 +1067,27 @@ async fn encode_chunk(
         Ok(result) if result.vectors.len() == claimed.len() => result.vectors,
         Ok(result) => {
             let error = format!(
-                "semantic worker returned {} vectors for {} inputs",
+                "protocol: semantic worker returned {} vectors for {} inputs",
                 result.vectors.len(),
                 claimed.len()
             );
-            fail_claims(storage, claimed, "embed_mismatch", &error).await;
-            return Err(error);
+            return Err(EncodeChunkFailure { error, claimed });
         }
         Err(error) => {
-            fail_claims(storage, claimed, "embed_failed", &error).await;
-            return Err(format!("embed failed: {error}"));
+            return Err(EncodeChunkFailure {
+                error: format!("embed failed: {error}"),
+                claimed,
+            });
         }
     };
 
-    commit_batch(storage, claimed, vectors).await
+    let retry_claimed = claimed.clone();
+    commit_batch(storage, claimed, vectors)
+        .await
+        .map_err(|error| EncodeChunkFailure {
+            error,
+            claimed: retry_claimed,
+        })
 }
 
 /// Claim up to one batch, rebuilding each job's source text from SQLite.
@@ -1221,6 +1270,23 @@ async fn fail_claims(
     .await;
 }
 
+/// Worker-wide failures belong to the scheduler, not to each screenshot. A
+/// deterministic contract/model failure remains on the per-subject ledger so
+/// it can be diagnosed and rebuilt explicitly.
+async fn settle_failed_claims(storage: Arc<StorageState>, claimed: Vec<ClaimedJob>, error: &str) {
+    if crate::semantic_runtime::is_deterministic_worker_failure(error) {
+        fail_claims(storage, claimed, "embed_failed", error).await;
+    } else {
+        release_claims(
+            storage,
+            claimed,
+            "worker_retry",
+            "semantic worker failure; scheduler will retry the batch",
+        )
+        .await;
+    }
+}
+
 /// Mirror newly indexed vectors into Python's Chroma hot layer.
 ///
 /// The M2.4 dual-write with its direction reversed. Milestone 4 task clustering
@@ -1323,18 +1389,23 @@ pub async fn semantic_index_run_now(
     crate::commands::check_main_window(&window)?;
     crate::commands::check_auth_required(&credential_state)?;
 
-    if let Some(scheduler) =
-        app.try_state::<Arc<crate::background_scheduler::BackgroundSchedulerState>>()
-    {
-        scheduler.enqueue(
-            &app,
-            crate::background_scheduler::BackgroundTaskKind::SemanticIndex,
-            true,
-        )?;
-    } else {
-        return Err("Background scheduler is unavailable".to_string());
-    }
+    let scheduler = app
+        .try_state::<Arc<crate::background_scheduler::BackgroundSchedulerState>>()
+        .ok_or_else(|| "Background scheduler is unavailable".to_string())?;
     let storage = app.state::<Arc<StorageState>>().inner().clone();
+    // The explicit button is also the recovery action for rows that exhausted
+    // or are still waiting on their per-subject retry timestamp.
+    let _ = tokio::task::spawn_blocking({
+        let storage = storage.clone();
+        move || storage.reset_derived_index_retries(DerivedIndexKind::SemanticText)
+    })
+    .await
+    .map_err(|error| format!("semantic retry reset task failed: {error}"))??;
+    scheduler.enqueue(
+        &app,
+        crate::background_scheduler::BackgroundTaskKind::SemanticIndex,
+        true,
+    )?;
     let backlog = tokio::task::spawn_blocking(move || {
         storage
             .derived_index_backlog(DerivedIndexKind::SemanticText, MAX_ATTEMPTS)

--- a/src-tauri/src/minilm_index.rs
+++ b/src-tauri/src/minilm_index.rs
@@ -352,7 +352,7 @@ pub async fn run_scheduled_slice(
 
 fn scheduled_pass_mode(manual: bool) -> PassMode {
     if manual {
-        PassMode::ScheduledManual
+        PassMode::Manual
     } else {
         PassMode::Idle
     }
@@ -364,30 +364,26 @@ enum PassMode {
     /// Background work: runs only inside an idle window and stands down the
     /// moment the user comes back.
     Idle,
-    /// The user asked for this run and the scheduler admitted it, so the idle
-    /// gate does not apply and the queue drains without yielding to another
-    /// background task. Every other guard still does — maintenance mode, the
-    /// locked session, the ledger's retry budget — and the run stops on the
-    /// user's word or on the runaway deadline.
+    /// The user asked for this run, so the idle gate does not apply and the
+    /// queue drains without yielding to another background task. Every other
+    /// guard still does — maintenance mode, the locked session, the ledger's
+    /// retry budget — and the run stops on the user's word or on the runaway
+    /// deadline.
+    ///
+    /// The unified scheduler owns admission: the command enqueues and returns,
+    /// so by the time this runs nobody is awaiting it. That is why an encode
+    /// failure propagates out of the pass instead of being folded into a run
+    /// summary — see the failure match at the end of [`drain_queue`].
     Manual,
-    /// The same complete drain after admission by the unified scheduler. This
-    /// stays distinct from `Manual` only so worker failures return to the
-    /// scheduler's durable retry/backoff policy instead of becoming a command
-    /// summary for a caller that is no longer awaiting the run.
-    ScheduledManual,
 }
 
 impl PassMode {
     fn is_manual(self) -> bool {
-        matches!(self, Self::Manual | Self::ScheduledManual)
+        self == Self::Manual
     }
 
     fn yields_after_chunk(self) -> bool {
         self == Self::Idle
-    }
-
-    fn reports_failure_in_summary(self) -> bool {
-        self == Self::Manual
     }
 }
 
@@ -563,8 +559,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
         {
             return Ok(PassOutcome::refused(FOREGROUND_QUERY_STOP));
         }
-    } else if let Some(reason) = stand_aside_for_foreground(app, mode, deadline, &mut waited).await
-    {
+    } else if let Some(reason) = stand_aside_for_foreground(app, deadline, &mut waited).await {
         // Nothing was attempted, so this is a refusal rather than a stop: the
         // summary says "skipped, and here is which guard", which is the true
         // account of a click that never reached the worker.
@@ -588,7 +583,7 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
 
     match mode {
         PassMode::Idle => drain_queue(app, storage, mode).await,
-        PassMode::Manual | PassMode::ScheduledManual => {
+        PassMode::Manual => {
             // The queue depth the user is about to watch drain, read once and
             // after the repair pass that can add to it. Re-reading it per chunk
             // would take the process-wide database mutex several times a second
@@ -622,13 +617,14 @@ async fn run_pass(app: &AppHandle, mode: PassMode) -> Result<PassOutcome, String
 /// sitting when one of them fires. Nothing is claimed while this waits: the
 /// drain released its leases uncharged on its way out, so a run that never
 /// resumes leaves the ledger exactly as it found it.
+///
+/// Only a manual pass calls this: an idle pass yields to the foreground by
+/// ending rather than by waiting.
 async fn stand_aside_for_foreground(
     app: &AppHandle,
-    mode: PassMode,
     deadline: Instant,
     waited: &mut Duration,
 ) -> Option<&'static str> {
-    debug_assert!(mode.is_manual());
     let semantic = app.state::<Arc<SemanticRuntimeState>>().inner().clone();
     if !semantic.foreground_waiting() {
         return None;
@@ -693,7 +689,7 @@ async fn drain_until_done(
         // Before claiming anything, not after: a batch claimed and then held
         // through a pause is a batch nobody else can encode, and the leases
         // would be released uncharged one chunk later anyway.
-        if let Some(reason) = stand_aside_for_foreground(app, mode, deadline, &mut waited).await {
+        if let Some(reason) = stand_aside_for_foreground(app, deadline, &mut waited).await {
             total.stopped_because = Some(reason);
             break;
         }
@@ -992,14 +988,13 @@ async fn drain_queue(
         mirror_to_chroma(app, &indexed).await;
     }
     match failure {
-        // A manual run reports the failure through its summary instead of
-        // propagating it, so the user sees "3 indexed, 4 failed" rather than an
-        // error dialog that hides the work that did land.
-        Some(error) if mode.reports_failure_in_summary() => {
-            outcome.stopped_because = Some("encode_failed");
-            tracing::warn!("[SEMANTIC:INDEX] manual run stopped: {error}");
-            Ok(outcome)
-        }
+        // The failure propagates rather than being folded into the summary:
+        // the command that asked for this run enqueued it and returned, so
+        // nothing is awaiting a report and only the scheduler's durable retry
+        // and backoff can act on it. Reporting it as a pass that stopped early
+        // would have the scheduler defer by a single tick and re-enter without
+        // counting the attempt, which is a tight loop against a worker that is
+        // already down.
         Some(error) => Err(error),
         None => Ok(outcome),
     }
@@ -1620,25 +1615,14 @@ mod tests {
     }
 
     #[test]
-    fn maintenance_binds_a_manual_run_but_idleness_does_not() {
-        // The two guards a manual run must treat differently. The idle gate
-        // exists to protect the foreground, and the user pressing the button is
-        // the foreground; maintenance mode exists because the migration is
-        // rewriting the same store, which consent cannot make safe.
-        assert_eq!(PassMode::Manual, PassMode::Manual);
-        assert_ne!(PassMode::Idle, PassMode::Manual);
-    }
-
-    #[test]
     fn a_scheduled_manual_request_uses_the_complete_drain_mode() {
         // The scheduler owns admission, not the meaning of the user's action.
         // Once admitted, a manual request must keep the worker until the queue
         // is empty (or a real manual stop condition fires).
         let mode = scheduled_pass_mode(true);
-        assert_eq!(mode, PassMode::ScheduledManual);
+        assert_eq!(mode, PassMode::Manual);
         assert!(mode.is_manual());
         assert!(!mode.yields_after_chunk());
-        assert!(!mode.reports_failure_in_summary());
         assert_eq!(scheduled_pass_mode(false), PassMode::Idle);
     }
 

--- a/src-tauri/src/semantic_runtime.rs
+++ b/src-tauri/src/semantic_runtime.rs
@@ -956,6 +956,15 @@ impl SemanticRuntimeState {
         }
     }
 
+    /// Restart the shared semantic worker before a user-initiated retry.
+    ///
+    /// A model-load or transport hiccup is often recoverable once the child
+    /// process is recreated. The caller owns the retry budget; this method only
+    /// resets the worker and records the restart for diagnostics.
+    pub(crate) fn restart_for_manual_retry(&self) {
+        self.restart_process("manual_index_retry");
+    }
+
     fn clear_process(&self, kind: &str, message: &str) {
         let _guard = self
             .lifecycle_lock
@@ -1212,6 +1221,43 @@ fn should_fallback_from_directml(error: &str) -> bool {
         split_error(error).0,
         "provider_unavailable" | "inference" | "timeout" | "worker_stopped" | "transport"
     )
+}
+
+/// Failures which usually describe a broken worker/provider rather than a bad
+/// screenshot. These are retried by the scheduler as a whole, so individual
+/// rows must not be put into their long per-item backoff.
+pub(crate) fn is_transient_worker_failure(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    let lower = lower
+        .strip_prefix("embed failed: ")
+        .unwrap_or(lower.as_str());
+    [
+        "timeout:",
+        "transport:",
+        "worker_stopped:",
+        "provider_unavailable:",
+        "inference:",
+    ]
+    .iter()
+    .any(|prefix| lower.starts_with(prefix))
+}
+
+/// Failures which will not be fixed by restarting the worker. The scheduler
+/// opens its circuit immediately and waits for an explicit user action.
+pub(crate) fn is_deterministic_worker_failure(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    let lower = lower
+        .strip_prefix("embed failed: ")
+        .unwrap_or(lower.as_str());
+    [
+        "invalid_request:",
+        "limit_exceeded:",
+        "model_missing:",
+        "model_mismatch:",
+        "protocol:",
+    ]
+    .iter()
+    .any(|prefix| lower.starts_with(prefix))
 }
 
 /// `invalid_request` and `limit_exceeded` on this path can only come from local
@@ -1607,6 +1653,34 @@ mod tests {
             split_error("ML timeout must be within 1..=600000 ms: 600001").0,
             "protocol"
         );
+    }
+
+    #[test]
+    fn index_failure_classification_requires_a_known_error_prefix() {
+        for error in [
+            "timeout: semantic worker timed out",
+            "embed failed: transport: pipe closed",
+            "worker_stopped: process exited",
+            "embed failed: inference: provider failed",
+        ] {
+            assert!(is_transient_worker_failure(error), "{error}");
+            assert!(!is_deterministic_worker_failure(error), "{error}");
+        }
+        for error in [
+            "protocol: vector count mismatch",
+            "embed failed: model_missing: model is unavailable",
+            "invalid_request: empty batch",
+        ] {
+            assert!(is_deterministic_worker_failure(error), "{error}");
+            assert!(!is_transient_worker_failure(error), "{error}");
+        }
+        for error in [
+            "commit failed: protocol: database busy",
+            "worker reported inference: but did not provide a kind",
+        ] {
+            assert!(!is_transient_worker_failure(error), "{error}");
+            assert!(!is_deterministic_worker_failure(error), "{error}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/storage/derived_index.rs
+++ b/src-tauri/src/storage/derived_index.rs
@@ -154,7 +154,13 @@ pub enum EnsureDerivedIndexJobResult {
 /// subjects stay missing from search until someone intervenes.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DerivedIndexBacklog {
+    /// Rows that are still outstanding, including rows whose per-subject retry
+    /// timestamp has not elapsed yet. This is the user-visible backlog.
     pub claimable: u64,
+    /// Rows a worker can claim at this instant. The scheduler uses this value;
+    /// using `claimable` there would repeatedly admit a task whose rows are all
+    /// still in their own backoff window.
+    pub ready: u64,
     pub exhausted: u64,
     /// Age of the oldest claimable row by ledger update time. `None` when the
     /// queue is empty.
@@ -553,6 +559,26 @@ impl StorageState {
                 increment_attempts: true,
             },
         )
+    }
+
+    /// Make delayed/failed rows eligible for an explicit user retry and reset
+    /// their per-subject budget. A manual action is a new recovery decision,
+    /// not another automatic attempt against the old failure window.
+    pub fn reset_derived_index_retries(&self, index_kind: DerivedIndexKind) -> Result<u64, String> {
+        let guard = self.get_connection_named("reset_derived_index_retries")?;
+        let conn = guard.as_ref().ok_or("Database not initialized")?;
+        let changed = conn
+            .execute(
+                "UPDATE derived_index_jobs
+                 SET status = 'pending', attempts = 0,
+                     error_code = NULL, error = NULL,
+                     next_retry_at = NULL, lease_token = NULL,
+                     updated_at = CURRENT_TIMESTAMP
+                 WHERE index_kind = ?1 AND status = 'failed'",
+                [index_kind.as_str()],
+            )
+            .map_err(|error| format!("Failed to reset derived index retries: {error}"))?;
+        u64::try_from(changed).map_err(|_| "Invalid reset derived index row count".to_string())
     }
 
     pub fn mark_derived_index_job_discarded(
@@ -1140,6 +1166,11 @@ impl StorageState {
                 r#"
                 SELECT
                     COALESCE(SUM(CASE WHEN {CLAIMABLE_JOB_PREDICATE} THEN 1 ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN (
+                        (status IN ('pending', 'waiting_for_auth')
+                         OR (status = 'failed' AND attempts < ?2))
+                        AND (next_retry_at IS NULL OR next_retry_at <= CURRENT_TIMESTAMP)
+                    ) THEN 1 ELSE 0 END), 0),
                     COALESCE(SUM(CASE WHEN status = 'failed' AND attempts >= ?2
                                       THEN 1 ELSE 0 END), 0),
                     CAST((julianday('now') - julianday(
@@ -1153,8 +1184,9 @@ impl StorageState {
             |row| {
                 Ok(DerivedIndexBacklog {
                     claimable: row.get::<_, i64>(0)?.max(0) as u64,
-                    exhausted: row.get::<_, i64>(1)?.max(0) as u64,
-                    oldest_claimable_age_secs: row.get::<_, Option<i64>>(2)?,
+                    ready: row.get::<_, i64>(1)?.max(0) as u64,
+                    exhausted: row.get::<_, i64>(2)?.max(0) as u64,
+                    oldest_claimable_age_secs: row.get::<_, Option<i64>>(3)?,
                 })
             },
         )
@@ -4359,6 +4391,7 @@ mod tests {
         // failures have spent it, and a spent budget is what `exhausted` counts.
         // The leased job is neither: someone is holding it right now.
         assert_eq!(backlog.claimable, 1);
+        assert_eq!(backlog.ready, 1);
         assert_eq!(backlog.exhausted, 2);
         assert!(backlog.oldest_claimable_age_secs.is_some());
 
@@ -4369,6 +4402,7 @@ mod tests {
             .derived_index_backlog(DerivedIndexKind::SemanticText, 5)
             .unwrap();
         assert_eq!(generous.claimable, 3);
+        assert_eq!(generous.ready, 2);
         assert_eq!(generous.exhausted, 0);
 
         // A different index kind must not leak into either number.
@@ -4376,6 +4410,47 @@ mod tests {
             .derived_index_backlog(DerivedIndexKind::ClipImage, 5)
             .unwrap();
         assert_eq!(clip, DerivedIndexBacklog::default());
+    }
+
+    #[test]
+    fn explicit_retry_reset_clears_failed_derived_job_state() {
+        let (_temp, storage) = test_storage();
+        let failed = job(DerivedIndexKind::SemanticText, "56");
+        ensure_active_subject(&storage, &failed);
+        storage.ensure_derived_index_job(&failed).unwrap();
+        let lease = storage.mark_derived_index_job_processing(&failed).unwrap();
+        storage
+            .mark_derived_index_job_failed(
+                &failed,
+                &lease,
+                "embed_failed",
+                "temporary worker failure",
+                Some("9999-12-31 23:59:59"),
+            )
+            .unwrap();
+
+        assert_eq!(
+            storage
+                .reset_derived_index_retries(DerivedIndexKind::SemanticText)
+                .unwrap(),
+            1
+        );
+        let reset = storage
+            .get_derived_index_job(DerivedIndexKind::SemanticText, "56")
+            .unwrap()
+            .unwrap();
+        assert_eq!(reset.status, DerivedIndexJobStatus::Pending);
+        assert_eq!(reset.attempts, 0);
+        assert_eq!(reset.error_code, None);
+        assert_eq!(reset.error, None);
+        assert_eq!(reset.next_retry_at, None);
+        assert_eq!(
+            storage
+                .claimable_derived_index_jobs(DerivedIndexKind::SemanticText, 5, 10)
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     #[test]

--- a/src/components/settings/AdvancedSection.jsx
+++ b/src/components/settings/AdvancedSection.jsx
@@ -45,8 +45,12 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
     semanticStatus,
     semanticStatusLoading,
     semanticIndexRunning,
+    semanticIndexPhase,
+    semanticIndexRetryAt,
     semanticIndexRun,
     clipIndexRunning,
+    clipIndexPhase,
+    clipIndexRetryAt,
     clipIndexRun,
     clipIndexStopping,
     clipIndexProgress,
@@ -144,6 +148,8 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
         onRunIndexNow={handleRunSemanticIndexNow}
         onStopIndexNow={handleStopSemanticIndex}
         indexRunning={semanticIndexRunning}
+        indexPhase={semanticIndexPhase}
+        indexRetryAt={semanticIndexRetryAt}
         indexStopping={semanticIndexStopping}
         indexProgress={semanticIndexProgress}
         indexRun={semanticIndexRun}
@@ -158,6 +164,8 @@ export default function AdvancedSection({ monitorStatus, onRestartMonitor }) {
         onRetryAnn={handleRetryClipAnn}
         annRetrying={clipAnnRetrying}
         indexRunning={clipIndexRunning}
+        indexPhase={clipIndexPhase}
+        indexRetryAt={clipIndexRetryAt}
         indexStopping={clipIndexStopping}
         indexProgress={clipIndexProgress}
         indexRun={clipIndexRun}

--- a/src/components/settings/advanced/InferenceCards.jsx
+++ b/src/components/settings/advanced/InferenceCards.jsx
@@ -5,6 +5,20 @@ import SettingsHelpTooltip from '../SettingsHelpTooltip';
 import { SettingsSwitch } from '../SettingsControls';
 import { formatEstimate } from '../../ClipBackfillDialog';
 
+function effectiveIndexPhase(indexPhase, indexRunning) {
+  // Keep the boolean prop as a compatibility fallback for callers/tests that
+  // predate the explicit scheduler phase. New callers should provide the
+  // phase so `retry_wait` cannot be mistaken for an active run.
+  return indexPhase || (indexRunning ? 'running' : 'idle');
+}
+
+function formatIndexRetryAt(value) {
+  if (value == null || value === '') return null;
+  const numeric = typeof value === 'number' ? value : Number(value);
+  const date = new Date(Number.isFinite(numeric) ? numeric : value);
+  return Number.isNaN(date.getTime()) ? null : date.toLocaleString();
+}
+
 function ChangedNotice({
   children,
   monitorStatus,
@@ -284,6 +298,8 @@ export function SemanticBackendCard({
   onRunIndexNow,
   onStopIndexNow,
   indexRunning,
+  indexPhase,
+  indexRetryAt,
   indexStopping,
   indexProgress,
   indexRun,
@@ -306,9 +322,21 @@ export function SemanticBackendCard({
   const progressRatio = progressTotal > 0
     ? Math.min(1, progressProcessed / progressTotal)
     : null;
+  const phase = effectiveIndexPhase(indexPhase, indexRunning);
+  const retryAt = formatIndexRetryAt(indexRetryAt);
+  const active = phase === 'running';
+  const stoppable = active || phase === 'queued';
 
   let runMessage = null;
-  if (indexRunning) {
+  if (phase === 'retry_wait') {
+    runMessage = retryAt
+      ? t('settings.advanced.semantic_backend.run_retry_wait', { retryAt })
+      : t('settings.advanced.semantic_backend.run_retry_wait_no_time');
+  } else if (phase === 'failed') {
+    runMessage = t('settings.advanced.semantic_backend.run_failed');
+  } else if (phase === 'queued') {
+    runMessage = t('settings.advanced.semantic_backend.run_queued');
+  } else if (active) {
     if (indexStopping) {
       runMessage = t('settings.advanced.semantic_backend.run_stopping');
     } else if (indexProgress) {
@@ -322,7 +350,7 @@ export function SemanticBackendCard({
       // loading a 118 MB model, which is the longest silent stretch of a run.
       runMessage = t('settings.advanced.semantic_backend.run_preparing');
     }
-  } else if (indexRun) {
+  } else if (indexRun && (!indexRun.queued || phase === 'queued' || indexPhase == null)) {
     runMessage = indexRun.queued
       ? t('settings.advanced.semantic_backend.run_queued', '已加入后台整理队列')
       : indexRun.started
@@ -403,7 +431,7 @@ export function SemanticBackendCard({
               <p className="text-[11px] text-ide-muted leading-snug">
                 {runMessage || t('settings.advanced.semantic_backend.run_now_hint')}
               </p>
-              {indexRunning && progressRatio !== null && (
+              {active && progressRatio !== null && (
                 <div className="w-full bg-ide-panel border border-ide-border rounded-full h-1.5 overflow-hidden">
                   <div
                     className="bg-ide-accent h-full transition-all duration-300 ease-out"
@@ -412,7 +440,7 @@ export function SemanticBackendCard({
                 </div>
               )}
             </div>
-            {indexRunning ? (
+            {stoppable ? (
               <button
                 onClick={onStopIndexNow}
                 disabled={indexStopping}
@@ -427,7 +455,9 @@ export function SemanticBackendCard({
                 onClick={onRunIndexNow}
                 className="shrink-0 px-2.5 py-1.5 text-xs text-ide-text bg-ide-panel border border-ide-border rounded-lg hover:bg-ide-hover transition-colors"
               >
-                {t('settings.advanced.semantic_backend.run_now')}
+                {phase === 'retry_wait' || phase === 'failed'
+                  ? t('settings.advanced.semantic_backend.run_retry')
+                  : t('settings.advanced.semantic_backend.run_now')}
               </button>
             )}
           </div>
@@ -445,6 +475,8 @@ export function ClipBackendCard({
   onRunIndexNow,
   onStopIndexNow,
   indexRunning,
+  indexPhase,
+  indexRetryAt,
   indexStopping,
   indexProgress,
   indexRun,
@@ -476,9 +508,21 @@ export function ClipBackendCard({
   const progressRatio = progressTotal > 0
     ? Math.min(1, progressProcessed / progressTotal)
     : null;
+  const phase = effectiveIndexPhase(indexPhase, indexRunning);
+  const retryAt = formatIndexRetryAt(indexRetryAt);
+  const active = phase === 'running';
+  const stoppable = active || phase === 'queued';
 
   let runMessage = null;
-  if (indexRunning) {
+  if (phase === 'retry_wait') {
+    runMessage = retryAt
+      ? t('settings.advanced.clip_backend.run_retry_wait', { retryAt })
+      : t('settings.advanced.clip_backend.run_retry_wait_no_time');
+  } else if (phase === 'failed') {
+    runMessage = t('settings.advanced.clip_backend.run_failed');
+  } else if (phase === 'queued') {
+    runMessage = t('settings.advanced.clip_backend.run_queued');
+  } else if (active) {
     if (indexStopping) {
       runMessage = t('settings.advanced.clip_backend.run_stopping');
     } else if (indexProgress) {
@@ -492,7 +536,7 @@ export function ClipBackendCard({
       // 177 MB model, which is the longest silent stretch of a run.
       runMessage = t('settings.advanced.clip_backend.run_preparing');
     }
-  } else if (indexRun) {
+  } else if (indexRun && (!indexRun.queued || phase === 'queued' || indexPhase == null)) {
     runMessage = indexRun.queued
       ? t('settings.advanced.clip_backend.run_queued', '已加入后台整理队列')
       : indexRun.started
@@ -650,7 +694,7 @@ export function ClipBackendCard({
               <p className="text-[11px] text-ide-muted leading-snug">
                 {runMessage || t('settings.advanced.clip_backend.run_now_hint')}
               </p>
-              {indexRunning && progressRatio !== null && (
+              {active && progressRatio !== null && (
                 <div className="w-full bg-ide-panel border border-ide-border rounded-full h-1.5 overflow-hidden">
                   <div
                     className="bg-ide-accent h-full transition-all duration-300 ease-out"
@@ -659,7 +703,7 @@ export function ClipBackendCard({
                 </div>
               )}
             </div>
-            {indexRunning ? (
+            {stoppable ? (
               <button
                 onClick={onStopIndexNow}
                 disabled={indexStopping}
@@ -674,7 +718,9 @@ export function ClipBackendCard({
                 onClick={onRunIndexNow}
                 className="shrink-0 px-2.5 py-1.5 text-xs text-ide-text bg-ide-panel border border-ide-border rounded-lg hover:bg-ide-hover transition-colors"
               >
-                {t('settings.advanced.clip_backend.run_now')}
+                {phase === 'retry_wait' || phase === 'failed'
+                  ? t('settings.advanced.clip_backend.run_retry')
+                  : t('settings.advanced.clip_backend.run_now')}
               </button>
             )}
           </div>

--- a/src/components/settings/advanced/InferenceCards.test.jsx
+++ b/src/components/settings/advanced/InferenceCards.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { BackgroundSchedulerCard, ClipBackendCard } from './InferenceCards';
+import { BackgroundSchedulerCard, ClipBackendCard, SemanticBackendCard } from './InferenceCards';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -77,5 +77,80 @@ describe('BackgroundSchedulerCard status', () => {
     );
 
     expect(screen.getByText(expectedKey)).toBeInTheDocument();
+  });
+});
+
+describe('manual index phases', () => {
+  const baseStatus = {
+    backend: { index_backlog: 3, index_stalled: 0, indexed_vectors: 4, failure_count: 1 },
+  };
+
+  it('does not present retry_wait as a running job', () => {
+    const onRun = vi.fn();
+    const onStop = vi.fn();
+    render(
+      <SemanticBackendCard
+        status={baseStatus}
+        statusLoading={false}
+        onRefresh={vi.fn()}
+        onRunIndexNow={onRun}
+        onStopIndexNow={onStop}
+        indexRunning={false}
+        indexPhase="retry_wait"
+        indexRetryAt={Date.UTC(2026, 7, 26, 12, 0, 0)}
+        indexStopping={false}
+        indexProgress={null}
+        indexRun={null}
+      />,
+    );
+
+    expect(screen.getByText('settings.advanced.semantic_backend.run_retry_wait')).toBeInTheDocument();
+    expect(screen.queryByText('settings.advanced.semantic_backend.run_stop')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('settings.advanced.semantic_backend.run_retry'));
+    expect(onRun).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
+  });
+
+  it('keeps queued work stoppable', () => {
+    const onStop = vi.fn();
+    render(
+      <SemanticBackendCard
+        status={baseStatus}
+        statusLoading={false}
+        onRefresh={vi.fn()}
+        onRunIndexNow={vi.fn()}
+        onStopIndexNow={onStop}
+        indexRunning={true}
+        indexPhase="queued"
+        indexRetryAt={null}
+        indexStopping={false}
+        indexProgress={null}
+        indexRun={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('settings.advanced.semantic_backend.run_stop'));
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not keep showing a stale queued summary after the scheduler finishes', () => {
+    render(
+      <SemanticBackendCard
+        status={baseStatus}
+        statusLoading={false}
+        onRefresh={vi.fn()}
+        onRunIndexNow={vi.fn()}
+        onStopIndexNow={vi.fn()}
+        indexRunning={false}
+        indexPhase="idle"
+        indexRetryAt={null}
+        indexStopping={false}
+        indexProgress={null}
+        indexRun={{ queued: true }}
+      />,
+    );
+
+    expect(screen.queryByText('settings.advanced.semantic_backend.run_queued')).not.toBeInTheDocument();
+    expect(screen.getByText('settings.advanced.semantic_backend.run_now_hint')).toBeInTheDocument();
   });
 });

--- a/src/components/settings/useAdvancedSectionController.js
+++ b/src/components/settings/useAdvancedSectionController.js
@@ -118,6 +118,22 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
       ]);
       setBackgroundProcessingEnabled(Boolean(enabled));
       setBackgroundSchedulerStatus(status);
+      if (status) {
+        const task = (kind) => status.tasks?.find((item) => item.task_kind === kind);
+        const manuallyRunning = (kind) => status.running_manual && status.running_task === kind;
+        if (!ownsRun.current) {
+          const active = Boolean(task('semantic_index')?.manual_pending)
+            || manuallyRunning('semantic_index');
+          setSemanticIndexRunning(active);
+          if (!active) setSemanticIndexStopping(false);
+        }
+        if (!ownsClipRun.current) {
+          const active = Boolean(task('clip_index')?.manual_pending)
+            || manuallyRunning('clip_index');
+          setClipIndexRunning(active);
+          if (!active) setClipIndexStopping(false);
+        }
+      }
     } catch (err) {
       console.warn('Failed to read background scheduler status:', err);
     }
@@ -326,6 +342,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
    * like it had done nothing and needed pressing dozens of times.
    */
   const handleRunSemanticIndexNow = async () => {
+    let queued = false;
     ownsRun.current = true;
     setSemanticIndexRunning(true);
     setSemanticIndexStopping(false);
@@ -335,6 +352,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
       const summary = await invoke('semantic_index_run_now');
       setSemanticIndexRun(summary);
       if (summary?.queued) {
+        queued = true;
         ownsRun.current = false;
         await refreshBackgroundSchedulerStatus();
         return summary;
@@ -350,7 +368,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
       // `refreshSemanticStatus` above — which ran while this hook still owned
       // the run — is not the one that decides them.
       ownsRun.current = false;
-      setSemanticIndexRunning(false);
+      if (!queued) setSemanticIndexRunning(false);
       setSemanticIndexStopping(false);
       setSemanticIndexProgress(null);
     }
@@ -379,6 +397,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
    * request just like the MiniLM one.
    */
   const handleRunClipIndexNow = async () => {
+    let queued = false;
     ownsClipRun.current = true;
     setClipIndexRunning(true);
     setClipIndexStopping(false);
@@ -388,6 +407,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
       const summary = await invoke('clip_index_run_now');
       setClipIndexRun(summary);
       if (summary?.queued) {
+        queued = true;
         ownsClipRun.current = false;
         await refreshBackgroundSchedulerStatus();
         return summary;
@@ -400,7 +420,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
       return null;
     } finally {
       ownsClipRun.current = false;
-      setClipIndexRunning(false);
+      if (!queued) setClipIndexRunning(false);
       setClipIndexStopping(false);
       setClipIndexProgress(null);
     }

--- a/src/components/settings/useAdvancedSectionController.js
+++ b/src/components/settings/useAdvancedSectionController.js
@@ -23,11 +23,15 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
   const [semanticStatus, setSemanticStatus] = useState(null);
   const [semanticStatusLoading, setSemanticStatusLoading] = useState(false);
   const [semanticIndexRunning, setSemanticIndexRunning] = useState(false);
+  const [semanticIndexPhase, setSemanticIndexPhase] = useState('idle');
+  const [semanticIndexRetryAt, setSemanticIndexRetryAt] = useState(null);
   const [semanticIndexRun, setSemanticIndexRun] = useState(null);
   // The CLIP image index has its own run and progress event. The two passes can
   // run independently, so one status line for both would report whichever
   // finished last.
   const [clipIndexRunning, setClipIndexRunning] = useState(false);
+  const [clipIndexPhase, setClipIndexPhase] = useState('idle');
+  const [clipIndexRetryAt, setClipIndexRetryAt] = useState(null);
   const [clipIndexRun, setClipIndexRun] = useState(null);
   const [clipIndexStopping, setClipIndexStopping] = useState(false);
   const [clipIndexProgress, setClipIndexProgress] = useState(null);
@@ -44,6 +48,12 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
   const [backgroundSchedulerStatus, setBackgroundSchedulerStatus] = useState(null);
   const [backgroundProcessingSaving, setBackgroundProcessingSaving] = useState(false);
   const mlOcrStatusRequestRef = useRef(null);
+
+  // These refs prevent a status poll from overwriting state while the current
+  // settings panel still owns the command promise. Once the command hands the
+  // work to the scheduler, polling becomes the source of truth again.
+  const ownsRun = useRef(false);
+  const ownsClipRun = useRef(false);
 
   const saveConfig = async (newConfig) => {
     const previousConfig = config;
@@ -110,6 +120,24 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     loadConfig();
   }, []);
 
+  const schedulerIndexPhase = (status, kind) => {
+    const tasks = Array.isArray(status?.tasks) ? status.tasks : null;
+    const running = Boolean(status?.running_manual && status.running_task === kind);
+    const row = tasks?.find((item) => item.task_kind === kind);
+    // A transient IPC/database read can return no row (the backend currently
+    // falls back to an empty task list when that read fails). Do not turn a
+    // known queued/retry state into idle on that incomplete snapshot; the
+    // durable row will reconcile on the next poll.
+    if (!row && !running) return null;
+    if (running) return { phase: 'running', retryAt: null };
+    if (row?.manual_pending && row.status === 'retry_wait') {
+      return { phase: 'retry_wait', retryAt: row.next_attempt_at_ms || null };
+    }
+    if (row?.manual_pending) return { phase: 'queued', retryAt: null };
+    if (row?.status === 'failed') return { phase: 'failed', retryAt: null };
+    return { phase: 'idle', retryAt: null };
+  };
+
   const refreshBackgroundSchedulerStatus = async () => {
     try {
       const [enabled, status] = await Promise.all([
@@ -119,20 +147,42 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
       setBackgroundProcessingEnabled(Boolean(enabled));
       setBackgroundSchedulerStatus(status);
       if (status) {
-        const task = (kind) => status.tasks?.find((item) => item.task_kind === kind);
-        const manuallyRunning = (kind) => status.running_manual && status.running_task === kind;
-        if (!ownsRun.current) {
-          const active = Boolean(task('semantic_index')?.manual_pending)
-            || manuallyRunning('semantic_index');
-          setSemanticIndexRunning(active);
-          if (!active) setSemanticIndexStopping(false);
-        }
-        if (!ownsClipRun.current) {
-          const active = Boolean(task('clip_index')?.manual_pending)
-            || manuallyRunning('clip_index');
-          setClipIndexRunning(active);
-          if (!active) setClipIndexStopping(false);
-        }
+        const applyIndexState = ({
+          kind,
+          ownerRef,
+          setPhase,
+          setRetryAt,
+          setRunning,
+          setStopping,
+        }) => {
+          if (ownerRef.current) return;
+          const resolved = schedulerIndexPhase(status, kind);
+          if (!resolved) return;
+          const { phase, retryAt } = resolved;
+          setPhase(phase);
+          setRetryAt(retryAt);
+          // Keep the old boolean for callers that use it as a compact
+          // "active/queued" indicator. `retry_wait` and `failed` are
+          // deliberately not active: they are waiting states, not runs.
+          setRunning(phase === 'running' || phase === 'queued');
+          if (phase !== 'running' && phase !== 'queued') setStopping(false);
+        };
+        applyIndexState({
+          kind: 'semantic_index',
+          ownerRef: ownsRun,
+          setPhase: setSemanticIndexPhase,
+          setRetryAt: setSemanticIndexRetryAt,
+          setRunning: setSemanticIndexRunning,
+          setStopping: setSemanticIndexStopping,
+        });
+        applyIndexState({
+          kind: 'clip_index',
+          ownerRef: ownsClipRun,
+          setPhase: setClipIndexPhase,
+          setRetryAt: setClipIndexRetryAt,
+          setRunning: setClipIndexRunning,
+          setStopping: setClipIndexStopping,
+        });
       }
     } catch (err) {
       console.warn('Failed to read background scheduler status:', err);
@@ -223,33 +273,23 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     refreshRustOcrModelStatus();
   }, []);
 
-  /**
-   * Read the backend diagnostic, and with it whether a manual indexing run is
-   * going.
-   *
-   * A run started from this hook is tracked by its own promise. A run this
-   * hook did not start — the settings dialog was closed or switched away from
-   * mid-run, which unmounts it — has no promise to await, so the backend flag
-   * is what tells the reopened dialog that its button should say "stop". The
-   * two must not fight over the same state, hence the per-index ownership refs.
-   */
-  const ownsRun = useRef(false);
-  const ownsClipRun = useRef(false);
-
   const readSemanticStatus = async ({ quiet = false, refreshDiagnostics = false } = {}) => {
     if (!quiet) setSemanticStatusLoading(true);
     try {
       const status = await invoke('get_ml_semantic_status', { refreshDiagnostics });
       setSemanticStatus(status);
-      if (!ownsRun.current) {
-        const active = Boolean(status?.backend?.index_run_active);
-        setSemanticIndexRunning(active);
-        if (!active) setSemanticIndexStopping(false);
+      // The diagnostic endpoint can see a run that was started before this
+      // panel mounted. It is a useful positive signal, but an inactive value
+      // must not clear `retry_wait`/`queued`: those phases come from the
+      // durable scheduler and are intentionally independent of the worker's
+      // short-lived active flag.
+      if (!ownsRun.current && status?.backend?.index_run_active) {
+        setSemanticIndexPhase('running');
+        setSemanticIndexRunning(true);
       }
-      if (!ownsClipRun.current) {
-        const active = Boolean(status?.clip_backend?.index_run_active);
-        setClipIndexRunning(active);
-        if (!active) setClipIndexStopping(false);
+      if (!ownsClipRun.current && status?.clip_backend?.index_run_active) {
+        setClipIndexPhase('running');
+        setClipIndexRunning(true);
       }
     } catch (err) {
       console.warn('Failed to read semantic backend status:', err);
@@ -265,6 +305,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     const [status] = await Promise.all([
       readSemanticStatus({ refreshDiagnostics: true }),
       refreshClipBackfill(true),
+      refreshBackgroundSchedulerStatus(),
     ]);
     return status;
   };
@@ -275,17 +316,17 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
 
   /**
    * Notice the end of either run this dialog does not own. Two seconds is far
-   * shorter than the time it takes to wonder why a button is still disabled,
-   * and the read itself is one ledger query. Not started for an owned run:
-   * that one already refreshes when its command returns.
+   * shorter than the time it takes to wonder why a button is still disabled.
+   * The scheduler poll is the authority for clearing the phase; this read is
+   * retained as a compatibility fallback for runs that predate its row.
    */
   useEffect(() => {
-    const watchingSemantic = semanticIndexRunning && !ownsRun.current;
-    const watchingClip = clipIndexRunning && !ownsClipRun.current;
+    const watchingSemantic = semanticIndexPhase === 'running' && !ownsRun.current;
+    const watchingClip = clipIndexPhase === 'running' && !ownsClipRun.current;
     if (!watchingSemantic && !watchingClip) return undefined;
     const timer = window.setInterval(() => readSemanticStatus({ quiet: true }), 2000);
     return () => window.clearInterval(timer);
-  }, [semanticIndexRunning, clipIndexRunning]);
+  }, [semanticIndexPhase, clipIndexPhase]);
 
   /**
    * Progress of a running manual pass, one event per encoded chunk of four.
@@ -345,6 +386,8 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     let queued = false;
     ownsRun.current = true;
     setSemanticIndexRunning(true);
+    setSemanticIndexPhase('running');
+    setSemanticIndexRetryAt(null);
     setSemanticIndexStopping(false);
     setSemanticIndexRun(null);
     setSemanticIndexProgress(null);
@@ -354,6 +397,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
       if (summary?.queued) {
         queued = true;
         ownsRun.current = false;
+        setSemanticIndexPhase('queued');
         await refreshBackgroundSchedulerStatus();
         return summary;
       }
@@ -368,7 +412,10 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
       // `refreshSemanticStatus` above — which ran while this hook still owned
       // the run — is not the one that decides them.
       ownsRun.current = false;
-      if (!queued) setSemanticIndexRunning(false);
+      if (!queued) {
+        setSemanticIndexRunning(false);
+        setSemanticIndexPhase('idle');
+      }
       setSemanticIndexStopping(false);
       setSemanticIndexProgress(null);
     }
@@ -400,6 +447,8 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     let queued = false;
     ownsClipRun.current = true;
     setClipIndexRunning(true);
+    setClipIndexPhase('running');
+    setClipIndexRetryAt(null);
     setClipIndexStopping(false);
     setClipIndexRun(null);
     setClipIndexProgress(null);
@@ -409,6 +458,7 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
       if (summary?.queued) {
         queued = true;
         ownsClipRun.current = false;
+        setClipIndexPhase('queued');
         await refreshBackgroundSchedulerStatus();
         return summary;
       }
@@ -420,7 +470,10 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
       return null;
     } finally {
       ownsClipRun.current = false;
-      if (!queued) setClipIndexRunning(false);
+      if (!queued) {
+        setClipIndexRunning(false);
+        setClipIndexPhase('idle');
+      }
       setClipIndexStopping(false);
       setClipIndexProgress(null);
     }
@@ -595,8 +648,12 @@ export function useAdvancedSectionController({ monitorStatus, t }) {
     semanticStatus,
     semanticStatusLoading,
     semanticIndexRunning,
+    semanticIndexPhase,
+    semanticIndexRetryAt,
     semanticIndexRun,
     clipIndexRunning,
+    clipIndexPhase,
+    clipIndexRetryAt,
     clipIndexRun,
     clipIndexStopping,
     clipIndexProgress,

--- a/src/components/settings/useAdvancedSectionController.test.jsx
+++ b/src/components/settings/useAdvancedSectionController.test.jsx
@@ -44,6 +44,18 @@ describe('useAdvancedSectionController', () => {
           clip_backend: { index_run_active: clipRunActive },
         };
       }
+      if (command === 'credential_get_background_processing_enabled') return true;
+      if (command === 'background_scheduler_status') {
+        return {
+          running_task: clipRunActive ? 'clip_index' : null,
+          running_manual: clipRunActive,
+          tasks: [{
+            task_kind: 'clip_index',
+            manual_pending: clipRunActive,
+            status: clipRunActive ? 'running' : 'completed',
+          }],
+        };
+      }
       if (command === 'clip_index_stop_now') return true;
       return undefined;
     });
@@ -207,5 +219,51 @@ describe('useAdvancedSectionController', () => {
 
     expect(hook.result.current.clipIndexRunning).toBe(true);
     expect(hook.result.current.clipIndexRun).toEqual({ queued: true });
+  });
+
+  it('maps a manual scheduler retry wait to a non-running phase', async () => {
+    clipRunActive = false;
+    let schedulerReads = 0;
+    invoke.mockImplementation(async (command) => {
+      if (command === 'get_advanced_config') return {};
+      if (command === 'storage_is_startup_vacuum_in_progress') return false;
+      if (command === 'get_rust_ocr_model_status') return {};
+      if (command === 'get_ml_ocr_status') return {};
+      if (command === 'get_ml_semantic_status') {
+        return {
+          backend: { index_run_active: false },
+          clip_backend: { index_run_active: false },
+        };
+      }
+      if (command === 'credential_get_background_processing_enabled') return true;
+      if (command === 'background_scheduler_status') {
+        schedulerReads += 1;
+        if (schedulerReads > 1) return { running_task: null, running_manual: false };
+        return {
+          running_task: null,
+          running_manual: false,
+          tasks: [{
+            task_kind: 'semantic_index',
+            manual_pending: true,
+            status: 'retry_wait',
+            next_attempt_at_ms: 1_800_000_000_000,
+          }],
+        };
+      }
+      return undefined;
+    });
+
+    const hook = renderHook(() => useAdvancedSectionController({
+      monitorStatus: 'stopped',
+      t,
+    }));
+    await waitFor(() => expect(hook.result.current.config).toEqual({}));
+    await waitFor(() => expect(hook.result.current.semanticIndexPhase).toBe('retry_wait'));
+    expect(hook.result.current.semanticIndexRunning).toBe(false);
+    expect(hook.result.current.semanticIndexRetryAt).toBe(1_800_000_000_000);
+    await act(async () => {
+      await hook.result.current.refreshBackgroundSchedulerStatus();
+    });
+    expect(hook.result.current.semanticIndexPhase).toBe('retry_wait');
   });
 });

--- a/src/components/settings/useAdvancedSectionController.test.jsx
+++ b/src/components/settings/useAdvancedSectionController.test.jsx
@@ -170,4 +170,42 @@ describe('useAdvancedSectionController', () => {
     });
     expect(hook.result.current.clipAnnRetrying).toBe(false);
   });
+
+  it('keeps a queued CLIP drain stoppable while the scheduler owns it', async () => {
+    clipRunActive = false;
+    invoke.mockImplementation(async (command) => {
+      if (command === 'get_advanced_config') return {};
+      if (command === 'storage_is_startup_vacuum_in_progress') return false;
+      if (command === 'get_rust_ocr_model_status') return {};
+      if (command === 'get_ml_ocr_status') return {};
+      if (command === 'get_ml_semantic_status') {
+        return {
+          backend: { index_run_active: false },
+          clip_backend: { index_run_active: false },
+        };
+      }
+      if (command === 'credential_get_background_processing_enabled') return true;
+      if (command === 'background_scheduler_status') {
+        return {
+          running_task: null,
+          running_manual: false,
+          tasks: [{ task_kind: 'clip_index', manual_pending: true }],
+        };
+      }
+      if (command === 'clip_index_run_now') return { queued: true };
+      return undefined;
+    });
+    const hook = renderHook(() => useAdvancedSectionController({
+      monitorStatus: 'stopped',
+      t,
+    }));
+
+    await waitFor(() => expect(hook.result.current.config).toEqual({}));
+    await act(async () => {
+      await hook.result.current.handleRunClipIndexNow();
+    });
+
+    expect(hook.result.current.clipIndexRunning).toBe(true);
+    expect(hook.result.current.clipIndexRun).toEqual({ queued: true });
+  });
 });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -331,7 +331,11 @@
         "run_stopping": "Stopping. The run ends once the current batch finishes.",
         "run_done": "Indexed {{indexed}} screenshot(s); {{remaining}} still waiting.",
         "run_skipped": "This run did not start: {{reason}}.",
-        "run_queued": "Added to the background organization queue."
+        "run_queued": "Added to the background organization queue.",
+        "run_retry_wait": "Indexing paused after a temporary error. It will retry at {{retryAt}}.",
+        "run_retry_wait_no_time": "Indexing paused after a temporary error and will retry automatically.",
+        "run_retry": "Retry now",
+        "run_failed": "Indexing stopped after an error that could not be recovered automatically."
       },
       "clip_backend": {
         "title": "Screenshot image search",
@@ -369,7 +373,11 @@
         "run_stop_pending": "Stopping…",
         "run_stopping": "Stopping. The run ends once the current image finishes.",
         "run_done": "Indexed {{indexed}} image(s); {{remaining}} still waiting.",
-        "run_skipped": "This run did not start: {{reason}}."
+        "run_skipped": "This run did not start: {{reason}}.",
+        "run_retry_wait": "Encoding paused after a temporary error. It will retry at {{retryAt}}.",
+        "run_retry_wait_no_time": "Encoding paused after a temporary error and will retry automatically.",
+        "run_retry": "Retry now",
+        "run_failed": "Encoding stopped after an error that could not be recovered automatically."
       },
       "classification_backend": {
         "title": "Automatic screenshot classification",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -331,7 +331,11 @@
         "run_stopping": "正在停止，当前这一批处理完就会结束。",
         "run_done": "本次索引了 {{indexed}} 张截图，还有 {{remaining}} 张在等待。",
         "run_skipped": "这次没有开始索引：{{reason}}。",
-        "run_queued": "已加入后台整理队列。"
+        "run_queued": "已加入后台整理队列。",
+        "run_retry_wait": "索引遇到临时错误，已暂停，将于 {{retryAt}} 自动重试。",
+        "run_retry_wait_no_time": "索引遇到临时错误，已暂停并将在稍后自动重试。",
+        "run_retry": "立即重试",
+        "run_failed": "索引遇到无法自动恢复的错误，已经停止。"
       },
       "clip_backend": {
         "title": "截图画面检索（文搜图）",
@@ -369,7 +373,11 @@
         "run_stop_pending": "正在停止…",
         "run_stopping": "正在停止。当前这张画面处理完就会结束。",
         "run_done": "本次索引了 {{indexed}} 张画面，还有 {{remaining}} 张在等待。",
-        "run_skipped": "本次没有开始索引：{{reason}}。"
+        "run_skipped": "本次没有开始索引：{{reason}}。",
+        "run_retry_wait": "编码遇到临时错误，已暂停，将于 {{retryAt}} 自动重试。",
+        "run_retry_wait_no_time": "编码遇到临时错误，已暂停并将在稍后自动重试。",
+        "run_retry": "立即重试",
+        "run_failed": "编码遇到无法自动恢复的错误，已经停止。"
       },
       "classification_backend": {
         "title": "截图内容自动分类",


### PR DESCRIPTION
This PR fixed an issue where the background scheduler failed to continuously drain the queue when taking over user-triggered requests for semantic (especially MiniLM) and CLIP index rebuilding, causing tasks to terminate prematurely after processing a single slice; also optimized the real-time synchronization between the frontend settings panel and the backend queuing and execution status.

## Key Changes

### Rust 

* **background_scheduler.rs**:
  * Added `running_manual: bool` in `background_scheduler.rs:186-192` and runtime state to track whether the scheduler's active task was manually triggered.
  * Properly set and reset this flag during slice execution.
* **minilm_index.rs & clip_index.rs**:
  * Refactored `PassMode` logic by adding `yields_after_chunk()` and `reports_failure_in_summary()` helper methods.
  * Updated `PassMode::ScheduledManual` to enter a `drain_until_done` loop to fully drain the queue without yielding after a single chunk, while retaining error propagation to the scheduler's retry backoff mechanism.
  * Added backend unit tests in `minilm_index.rs:1632-1643`.

### React

* **useAdvancedSectionController.js**:
  * When handling `handleRunSemanticIndexNow` / `handleRunClipIndexNow`, if a queued status (`queued: true`) is returned, hand over state management to the scheduler instead of immediately resetting `running` to `false` in `finally`.
  * Accurately update the running and stopped states of MiniLM and CLIP indexes based on `manual_pending` and `running_manual` during periodic polling of scheduler status.
* **useAdvancedSectionController.test.jsx**:
  * Added test cases to verify that the UI correctly maintains the running state when the scheduler takes over a queued task.