### PR TITLE
Fix/delete queue blind index repair

### DIFF
--- a/scripts/security-guards.cjs
+++ b/scripts/security-guards.cjs
@@ -194,6 +194,7 @@ const COMMAND_TIERS = {
   'minilm_migration::list_minilm_rebuild_errors': 'session_required',
   'clip_migration::get_clip_rebuild_status': 'public',
   'clip_migration::list_clip_rebuild_errors': 'session_required',
+  'blind_index_repair::get_blind_index_repair_status': 'public',
   'clip_ann::clip_ann_retry_now': 'session_required',
   'clip_ann::clip_ann_take_failure_notification': 'public',
   'clip_ann::clip_ann_ack_failure_notification': 'public',

--- a/src-tauri/src/blind_index_repair.rs
+++ b/src-tauri/src/blind_index_repair.rs
@@ -1,0 +1,232 @@
+//! One-time repair for stale OCR ids left in the blind bitmap index.
+
+use crate::migration_support;
+use crate::storage::{BlindIndexRepairProgress, StorageState};
+use serde::Serialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tauri::{AppHandle, Manager, State};
+
+const RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BlindIndexRepairStatus {
+    pub running: bool,
+    pub phase: String,
+    pub processed: u64,
+    pub total: u64,
+    pub changed_postings: u64,
+    pub deleted_postings: u64,
+    pub removed_ocr_ids: u64,
+    pub failed: u64,
+    pub last_error: Option<String>,
+}
+
+impl Default for BlindIndexRepairStatus {
+    fn default() -> Self {
+        Self {
+            running: false,
+            phase: "idle".to_string(),
+            processed: 0,
+            total: 0,
+            changed_postings: 0,
+            deleted_postings: 0,
+            removed_ocr_ids: 0,
+            failed: 0,
+            last_error: None,
+        }
+    }
+}
+
+pub struct BlindIndexRepairState {
+    running: AtomicBool,
+    status: Mutex<BlindIndexRepairStatus>,
+}
+
+impl Default for BlindIndexRepairState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BlindIndexRepairState {
+    pub fn new() -> Self {
+        Self {
+            running: AtomicBool::new(false),
+            status: Mutex::new(BlindIndexRepairStatus::default()),
+        }
+    }
+
+    fn update(&self, update: impl FnOnce(&mut BlindIndexRepairStatus)) {
+        let mut status = self
+            .status
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        update(&mut status);
+    }
+
+    fn snapshot(&self) -> BlindIndexRepairStatus {
+        self.status
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone()
+    }
+}
+
+pub fn spawn_blind_index_auto_repair(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            let storage = app.state::<Arc<StorageState>>().inner().clone();
+            let needed =
+                match tokio::task::spawn_blocking(move || storage.is_blind_index_repair_needed())
+                    .await
+                {
+                    Ok(Ok(needed)) => needed,
+                    Ok(Err(error)) => {
+                        tracing::warn!("[BLIND_INDEX_REPAIR] readiness check failed: {error}");
+                        return;
+                    }
+                    Err(error) => {
+                        tracing::warn!("[BLIND_INDEX_REPAIR] readiness task failed: {error}");
+                        return;
+                    }
+                };
+            if !needed {
+                return;
+            }
+
+            if crate::maintenance::is_active() {
+                tokio::time::sleep(RETRY_INTERVAL).await;
+                continue;
+            }
+
+            let state = app.state::<Arc<BlindIndexRepairState>>().inner().clone();
+            match try_start_repair(&app, &state) {
+                Ok(_) => return,
+                Err(error) if error == crate::maintenance::MAINTENANCE_IN_PROGRESS => {
+                    tokio::time::sleep(RETRY_INTERVAL).await;
+                }
+                Err(error) => {
+                    tracing::warn!("[BLIND_INDEX_REPAIR] automatic repair not started: {error}");
+                    return;
+                }
+            }
+        }
+    });
+}
+
+fn try_start_repair(
+    app: &AppHandle,
+    state: &Arc<BlindIndexRepairState>,
+) -> Result<BlindIndexRepairStatus, String> {
+    if state
+        .running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Ok(state.snapshot());
+    }
+
+    let Some(maintenance) = crate::maintenance::enter("blind_index_repair") else {
+        state.running.store(false, Ordering::SeqCst);
+        return Err(crate::maintenance::MAINTENANCE_IN_PROGRESS.to_string());
+    };
+
+    state.update(|status| {
+        *status = BlindIndexRepairStatus {
+            running: true,
+            phase: "scanning_valid_ocr".to_string(),
+            ..BlindIndexRepairStatus::default()
+        };
+    });
+
+    let worker_app = app.clone();
+    let worker_state = state.clone();
+    tauri::async_runtime::spawn(async move {
+        run_repair(worker_app, worker_state, maintenance).await;
+    });
+
+    Ok(state.snapshot())
+}
+
+async fn run_repair(
+    app: AppHandle,
+    state: Arc<BlindIndexRepairState>,
+    maintenance: crate::maintenance::MaintenanceGuard,
+) {
+    tracing::info!("[BLIND_INDEX_REPAIR] starting stale-posting repair");
+
+    let restore = migration_support::pause_capture_for_maintenance(&app).await;
+    let result = match restore.as_ref() {
+        Ok(_) => {
+            let storage = app.state::<Arc<StorageState>>().inner().clone();
+            let progress_state = state.clone();
+            tokio::task::spawn_blocking(move || {
+                storage.run_blind_index_repair(move |progress: BlindIndexRepairProgress| {
+                    progress_state.update(|status| {
+                        status.running = true;
+                        status.phase = "repairing_blind_index".to_string();
+                        status.processed = progress.processed_postings;
+                        status.total = progress.total_postings;
+                        status.changed_postings = progress.changed_postings;
+                        status.deleted_postings = progress.deleted_postings;
+                        status.removed_ocr_ids = progress.removed_ocr_ids;
+                        status.failed = 0;
+                        status.last_error = None;
+                    });
+                })
+            })
+            .await
+            .map_err(|error| format!("Blind-index repair task failed: {error}"))
+            .and_then(|result| result)
+        }
+        Err(error) => Err(error.clone()),
+    };
+
+    if let Ok(restore) = restore.as_ref() {
+        migration_support::restore_monitor_after_migration(&app, restore).await;
+    }
+
+    match result {
+        Ok(summary) => {
+            tracing::info!(
+                "[BLIND_INDEX_REPAIR] complete: processed_postings={}, changed_postings={}, deleted_postings={}, removed_ocr_ids={}",
+                summary.processed_postings,
+                summary.changed_postings,
+                summary.deleted_postings,
+                summary.removed_ocr_ids
+            );
+            state.update(|status| {
+                status.running = false;
+                status.phase = "completed".to_string();
+                status.processed = summary.processed_postings;
+                status.total = summary.total_postings;
+                status.changed_postings = summary.changed_postings;
+                status.deleted_postings = summary.deleted_postings;
+                status.removed_ocr_ids = summary.removed_ocr_ids;
+                status.failed = 0;
+                status.last_error = None;
+            });
+        }
+        Err(error) => {
+            tracing::error!("[BLIND_INDEX_REPAIR] failed: {error}");
+            state.update(|status| {
+                status.running = false;
+                status.phase = "failed".to_string();
+                status.failed = 1;
+                status.last_error = Some(error);
+            });
+        }
+    }
+
+    state.running.store(false, Ordering::SeqCst);
+    drop(maintenance);
+}
+
+#[tauri::command]
+pub fn get_blind_index_repair_status(
+    state: State<'_, Arc<BlindIndexRepairState>>,
+) -> BlindIndexRepairStatus {
+    state.snapshot()
+}

--- a/src-tauri/src/blind_index_repair.rs
+++ b/src-tauri/src/blind_index_repair.rs
@@ -1,4 +1,4 @@
-//! One-time repair for stale OCR ids left in the blind bitmap index.
+//! Repair for stale OCR ids left in the blind bitmap index.
 
 use crate::migration_support;
 use crate::storage::{BlindIndexRepairProgress, StorageState};
@@ -103,7 +103,14 @@ pub fn spawn_blind_index_auto_repair(app: AppHandle) {
 
             let state = app.state::<Arc<BlindIndexRepairState>>().inner().clone();
             match try_start_repair(&app, &state) {
-                Ok(_) => return,
+                Ok(_) => {
+                    while state.running.load(Ordering::SeqCst) {
+                        tokio::time::sleep(RETRY_INTERVAL).await;
+                    }
+                    if state.snapshot().failed > 0 {
+                        return;
+                    }
+                }
                 Err(error) if error == crate::maintenance::MAINTENANCE_IN_PROGRESS => {
                     tokio::time::sleep(RETRY_INTERVAL).await;
                 }

--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -714,7 +714,7 @@ pub async fn storage_get_screenshot_details(
     .map_err(|e| format!("Task join error: {:?}", e))?
 }
 
-/// Permanently deletes one screenshot and asks the vector index to remove its embedding.
+/// Queues one screenshot for safe background deletion and index cleanup.
 ///
 /// Authentication: required. `screenshot_id` identifies the record. Returns
 /// `{ "status": "success", "deleted": boolean, "vector_deleted": number | null }`.
@@ -734,7 +734,7 @@ pub async fn storage_delete_screenshot(
     }))
 }
 
-/// Permanently deletes screenshots in the requested millisecond time range.
+/// Queues screenshots in the requested millisecond time range for safe background deletion.
 ///
 /// Authentication: required. Returns `{ "status": "success", "deleted_count": number,
 /// "vector_deleted": number | null }`. Frontend: `lib/monitor_api.js`.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -230,6 +230,7 @@ async fn run_delete_queue_maintenance_loop(app_handle: tauri::AppHandle) {
 
     let mut last_policy_check =
         std::time::Instant::now() - std::time::Duration::from_secs(POLICY_CHECK_INTERVAL_SECS);
+    let mut blind_index_repair_deferred = false;
 
     loop {
         // Retention and delete-queue work would race the MiniLM migration's
@@ -288,6 +289,7 @@ async fn run_delete_queue_maintenance_loop(app_handle: tauri::AppHandle) {
                 storage::OcrDeleteBatchResult::default()
             }
         };
+        blind_index_repair_deferred |= ocr_batch.blind_index_repair_requested;
 
         let screenshot_candidates = match tokio::task::spawn_blocking({
             let storage = storage.clone();
@@ -389,13 +391,19 @@ async fn run_delete_queue_maintenance_loop(app_handle: tauri::AppHandle) {
             storage::IncrementalVacuumResult::default()
         };
 
-        if ocr_batch.queue_rows > 0 || finalized_screenshots > 0 || policy_pruned {
+        if ocr_batch.queue_rows > 0
+            || ocr_batch.retry_rows > 0
+            || finalized_screenshots > 0
+            || policy_pruned
+        {
             tracing::info!(
-                "[DELETE_QUEUE] cycle complete: policy_pruned={}, ocr_queue_processed={}, ocr_rows_deleted={}, ocr_queue_stale={}, screenshots_finalized={}",
+                "[DELETE_QUEUE] cycle complete: policy_pruned={}, ocr_queue_processed={}, ocr_rows_deleted={}, ocr_queue_stale={}, ocr_retry_rows={}, ocr_fallback_deleted={}, screenshots_finalized={}",
                 policy_pruned,
                 ocr_batch.queue_rows,
                 ocr_batch.deleted_rows,
                 ocr_batch.stale_queue_rows,
+                ocr_batch.retry_rows,
+                ocr_batch.fallback_deleted_rows,
                 finalized_screenshots
             );
         }
@@ -419,6 +427,11 @@ async fn run_delete_queue_maintenance_loop(app_handle: tauri::AppHandle) {
                     vacuum.freelist_after
                 );
             }
+        }
+
+        if blind_index_repair_deferred && ocr_batch.queue_empty {
+            blind_index_repair::spawn_blind_index_auto_repair(app_handle.clone());
+            blind_index_repair_deferred = false;
         }
 
         let active = ocr_batch.queue_rows > 0 || finalized_screenshots > 0;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod analysis;
 mod ann_format;
 mod autostart;
 mod background_scheduler;
+mod blind_index_repair;
 mod capture;
 mod classification_runtime;
 mod clip_ann;
@@ -224,16 +225,17 @@ async fn run_delete_queue_maintenance_loop(app_handle: tauri::AppHandle) {
     const OCR_BATCH_SIZE: i64 = 500;
     const SCREENSHOT_BATCH_SIZE: i64 = 100;
     const POLICY_CHECK_INTERVAL_SECS: u64 = 60;
+    const ACTIVE_YIELD_MILLIS: u64 = 25;
+    const IDLE_SLEEP_SECS: u64 = 5;
 
     let mut last_policy_check =
         std::time::Instant::now() - std::time::Duration::from_secs(POLICY_CHECK_INTERVAL_SECS);
 
     loop {
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-
         // Retention and delete-queue work would race the MiniLM migration's
         // Chroma snapshot; stand still while maintenance mode is active.
         if maintenance::is_active() {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             continue;
         }
 
@@ -267,20 +269,23 @@ async fn run_delete_queue_maintenance_loop(app_handle: tauri::AppHandle) {
             false
         };
 
-        let ocr_processed = match tokio::task::spawn_blocking({
+        let mut ocr_failed = false;
+        let ocr_batch = match tokio::task::spawn_blocking({
             let storage = storage.clone();
             move || storage.process_ocr_delete_queue_batch(OCR_BATCH_SIZE)
         })
         .await
         {
-            Ok(Ok(count)) => count,
+            Ok(Ok(result)) => result,
             Ok(Err(e)) => {
-                tracing::debug!("[DELETE_QUEUE] OCR batch cleanup failed: {}", e);
-                0
+                tracing::warn!("[DELETE_QUEUE] OCR batch cleanup failed: {}", e);
+                ocr_failed = true;
+                storage::OcrDeleteBatchResult::default()
             }
             Err(e) => {
                 tracing::warn!("[DELETE_QUEUE] OCR cleanup join error: {:?}", e);
-                0
+                ocr_failed = true;
+                storage::OcrDeleteBatchResult::default()
             }
         };
 
@@ -363,32 +368,66 @@ async fn run_delete_queue_maintenance_loop(app_handle: tauri::AppHandle) {
             };
         }
 
-        let vacuum_ran = match tokio::task::spawn_blocking({
-            let storage = storage.clone();
-            move || storage.run_incremental_vacuum_if_idle(500, 500)
-        })
-        .await
-        {
-            Ok(Ok(ran)) => ran,
-            Ok(Err(e)) => {
-                tracing::warn!("[DELETE_QUEUE] incremental_vacuum check failed: {}", e);
-                false
+        let vacuum = if ocr_batch.queue_rows == 0 && finalized_screenshots == 0 && !ocr_failed {
+            match tokio::task::spawn_blocking({
+                let storage = storage.clone();
+                move || storage.run_incremental_vacuum_if_idle(500, 500)
+            })
+            .await
+            {
+                Ok(Ok(result)) => result,
+                Ok(Err(e)) => {
+                    tracing::warn!("[DB_VACUUM] incremental vacuum failed: {}", e);
+                    storage::IncrementalVacuumResult::default()
+                }
+                Err(e) => {
+                    tracing::warn!("[DB_VACUUM] incremental vacuum join error: {:?}", e);
+                    storage::IncrementalVacuumResult::default()
+                }
             }
-            Err(e) => {
-                tracing::warn!("[DELETE_QUEUE] incremental_vacuum join error: {:?}", e);
-                false
-            }
+        } else {
+            storage::IncrementalVacuumResult::default()
         };
 
-        if ocr_processed > 0 || finalized_screenshots > 0 || vacuum_ran || policy_pruned {
+        if ocr_batch.queue_rows > 0 || finalized_screenshots > 0 || policy_pruned {
             tracing::info!(
-                "[DELETE_QUEUE] cycle complete: policy_pruned={}, ocr_processed={}, screenshots_finalized={}, vacuum_ran={}",
+                "[DELETE_QUEUE] cycle complete: policy_pruned={}, ocr_queue_processed={}, ocr_rows_deleted={}, ocr_queue_stale={}, screenshots_finalized={}",
                 policy_pruned,
-                ocr_processed,
-                finalized_screenshots,
-                vacuum_ran
+                ocr_batch.queue_rows,
+                ocr_batch.deleted_rows,
+                ocr_batch.stale_queue_rows,
+                finalized_screenshots
             );
         }
+
+        if vacuum.attempted {
+            if vacuum.reclaimed_pages > 0 {
+                tracing::info!(
+                    "[DB_VACUUM] incremental cycle: requested_pages={}, stepped_pages={}, reclaimed_pages={}, freelist_before={}, freelist_after={}",
+                    vacuum.requested_pages,
+                    vacuum.stepped_pages,
+                    vacuum.reclaimed_pages,
+                    vacuum.freelist_before,
+                    vacuum.freelist_after
+                );
+            } else {
+                tracing::debug!(
+                    "[DB_VACUUM] incremental cycle made no progress: requested_pages={}, stepped_pages={}, freelist_before={}, freelist_after={}",
+                    vacuum.requested_pages,
+                    vacuum.stepped_pages,
+                    vacuum.freelist_before,
+                    vacuum.freelist_after
+                );
+            }
+        }
+
+        let active = ocr_batch.queue_rows > 0 || finalized_screenshots > 0;
+        let delay = if active && !ocr_failed {
+            std::time::Duration::from_millis(ACTIVE_YIELD_MILLIS)
+        } else {
+            std::time::Duration::from_secs(IDLE_SLEEP_SECS)
+        };
+        tokio::time::sleep(delay).await;
     }
 }
 
@@ -781,6 +820,7 @@ pub fn run() {
         .manage(Arc::new(office_runtime::OfficeRuntimeState::new()))
         .manage(Arc::new(semantic_runtime::SemanticRuntimeState::new()))
         .manage(Arc::new(background_scheduler::BackgroundSchedulerState::default()))
+        .manage(Arc::new(blind_index_repair::BlindIndexRepairState::new()))
         .manage(Arc::new(minilm_migration::MinilmMigrationState::new()))
         .manage(Arc::new(clip_migration::ClipMigrationState::new()))
         .manage(Arc::new(clip_index::ClipIndexRunState::default()))
@@ -951,6 +991,12 @@ pub fn run() {
                         std::thread::spawn(move || {
                             StorageState::backfill_plaintext_process_names(storage_clone);
                         });
+
+                        // Repair the text-search postings before any other
+                        // sentinel-gated migration is allowed to take maintenance.
+                        blind_index_repair::spawn_blind_index_auto_repair(
+                            app.handle().clone(),
+                        );
 
                         // Sentinel-gated one-time Chroma copies; each waits for
                         // unlock internally before starting. The CLIP one also
@@ -1161,6 +1207,7 @@ pub fn run() {
             minilm_migration::list_minilm_rebuild_errors,
             clip_migration::get_clip_rebuild_status,
             clip_migration::list_clip_rebuild_errors,
+            blind_index_repair::get_blind_index_repair_status,
             maintenance::get_maintenance_status,
             monitor::monitor_remove_local_anchors_by_process,
             // 安全告警调试触发（设置 → 高级 → 调试）

--- a/src-tauri/src/storage/migration/bitmap_index.rs
+++ b/src-tauri/src/storage/migration/bitmap_index.rs
@@ -20,6 +20,23 @@ impl StorageState {
     const BLIND_INDEX_REPAIR_REMOVED_IDS_KEY: &'static str =
         "blind_index_repair_stale_postings_v1_removed_ids";
 
+    /// Re-arm a full stale-posting scan after cleanup had to delete an indexed
+    /// OCR row without knowing which token postings referenced it.
+    pub(crate) fn mark_blind_index_repair_needed_on_conn(conn: &Connection) -> Result<(), String> {
+        for key in [
+            Self::BLIND_INDEX_REPAIR_DONE_KEY,
+            Self::BLIND_INDEX_REPAIR_CURSOR_KEY,
+            Self::BLIND_INDEX_REPAIR_PROCESSED_KEY,
+            Self::BLIND_INDEX_REPAIR_CHANGED_KEY,
+            Self::BLIND_INDEX_REPAIR_DELETED_KEY,
+            Self::BLIND_INDEX_REPAIR_REMOVED_IDS_KEY,
+        ] {
+            conn.execute("DELETE FROM app_metadata WHERE key = ?1", [key])
+                .map_err(|error| format!("Failed to re-arm blind-index repair: {error}"))?;
+        }
+        Ok(())
+    }
+
     /// Whether this database still needs the stale-posting repair introduced
     /// after screenshot deletion could outrun OCR bitmap cleanup.
     pub fn is_blind_index_repair_needed(&self) -> Result<bool, String> {

--- a/src-tauri/src/storage/migration/bitmap_index.rs
+++ b/src-tauri/src/storage/migration/bitmap_index.rs
@@ -1,12 +1,278 @@
 //! Bitmap index lazy indexing and maintenance.
 
-use super::super::StorageState;
+use super::super::{BlindIndexRepairProgress, StorageState};
 use rusqlite::{params, Connection, OptionalExtension};
 use std::sync::atomic::Ordering;
 
 impl StorageState {
     /// Number of OCR rows to process per batch for lazy indexing.
     const LAZY_INDEXING_BATCH: i64 = 100;
+    const BLIND_INDEX_REPAIR_BATCH: i64 = 500;
+    const BLIND_INDEX_REPAIR_DONE_KEY: &'static str = "blind_index_repair_stale_postings_v1_done";
+    const BLIND_INDEX_REPAIR_CURSOR_KEY: &'static str =
+        "blind_index_repair_stale_postings_v1_cursor";
+    const BLIND_INDEX_REPAIR_PROCESSED_KEY: &'static str =
+        "blind_index_repair_stale_postings_v1_processed";
+    const BLIND_INDEX_REPAIR_CHANGED_KEY: &'static str =
+        "blind_index_repair_stale_postings_v1_changed";
+    const BLIND_INDEX_REPAIR_DELETED_KEY: &'static str =
+        "blind_index_repair_stale_postings_v1_deleted";
+    const BLIND_INDEX_REPAIR_REMOVED_IDS_KEY: &'static str =
+        "blind_index_repair_stale_postings_v1_removed_ids";
+
+    /// Whether this database still needs the stale-posting repair introduced
+    /// after screenshot deletion could outrun OCR bitmap cleanup.
+    pub fn is_blind_index_repair_needed(&self) -> Result<bool, String> {
+        let guard = self.get_connection_named("blind_index_repair_check")?;
+        let conn = guard.as_ref().unwrap();
+        let done = conn
+            .query_row(
+                "SELECT 1 FROM app_metadata WHERE key = ?1",
+                [Self::BLIND_INDEX_REPAIR_DONE_KEY],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        Ok(!done)
+    }
+
+    /// Remove every OCR id that no longer belongs to a query-visible row from
+    /// each Roaring posting list. The database remains exclusively owned for
+    /// the run; progress and the lexical token cursor commit with each batch.
+    pub fn run_blind_index_repair<F>(
+        &self,
+        mut progress_callback: F,
+    ) -> Result<BlindIndexRepairProgress, String>
+    where
+        F: FnMut(BlindIndexRepairProgress),
+    {
+        let _maintenance = self.database_maintenance("blind_index_repair");
+        let guard = self.get_connection_named("blind_index_repair")?;
+        let conn = guard.as_ref().unwrap();
+
+        let done = conn
+            .query_row(
+                "SELECT 1 FROM app_metadata WHERE key = ?1",
+                [Self::BLIND_INDEX_REPAIR_DONE_KEY],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        if done {
+            return Ok(BlindIndexRepairProgress::default());
+        }
+
+        let metadata_u64 = |key: &str| -> u64 {
+            conn.query_row(
+                "SELECT value FROM app_metadata WHERE key = ?1",
+                [key],
+                |row| row.get::<_, String>(0),
+            )
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0)
+        };
+        let mut cursor = conn
+            .query_row(
+                "SELECT value FROM app_metadata WHERE key = ?1",
+                [Self::BLIND_INDEX_REPAIR_CURSOR_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|error| format!("Failed to load blind-index repair cursor: {error}"))?
+            .unwrap_or_default();
+
+        let mut valid_ocr_ids = roaring::RoaringBitmap::new();
+        {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT o.id
+                     FROM ocr_results o
+                     JOIN screenshots s ON s.id = o.screenshot_id
+                     WHERE o.is_deleted = 0 AND s.is_deleted = 0
+                     ORDER BY o.id ASC",
+                )
+                .map_err(|error| format!("Failed to prepare valid OCR id scan: {error}"))?;
+            let ids = stmt
+                .query_map([], |row| row.get::<_, i64>(0))
+                .map_err(|error| format!("Failed to scan valid OCR ids: {error}"))?;
+            for id in ids {
+                let id = id.map_err(|error| format!("Failed to decode valid OCR id: {error}"))?;
+                let bitmap_id = u32::try_from(id)
+                    .map_err(|_| format!("OCR row {id} exceeds bitmap id capacity"))?;
+                valid_ocr_ids.insert(bitmap_id);
+            }
+        }
+
+        let mut status = BlindIndexRepairProgress {
+            processed_postings: metadata_u64(Self::BLIND_INDEX_REPAIR_PROCESSED_KEY),
+            changed_postings: metadata_u64(Self::BLIND_INDEX_REPAIR_CHANGED_KEY),
+            deleted_postings: metadata_u64(Self::BLIND_INDEX_REPAIR_DELETED_KEY),
+            removed_ocr_ids: metadata_u64(Self::BLIND_INDEX_REPAIR_REMOVED_IDS_KEY),
+            ..BlindIndexRepairProgress::default()
+        };
+        let remaining: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM blind_bitmap_index WHERE token_hash > ?1",
+                [&cursor],
+                |row| row.get(0),
+            )
+            .map_err(|error| format!("Failed to count remaining blind postings: {error}"))?;
+        status.total_postings = status
+            .processed_postings
+            .saturating_add(remaining.max(0) as u64);
+        progress_callback(status.clone());
+
+        loop {
+            let batch: Vec<(String, Vec<u8>)> = {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT token_hash, postings_blob
+                         FROM blind_bitmap_index
+                         WHERE token_hash > ?1
+                         ORDER BY token_hash ASC
+                         LIMIT ?2",
+                    )
+                    .map_err(|error| {
+                        format!("Failed to prepare blind-index repair batch: {error}")
+                    })?;
+                let rows = stmt
+                    .query_map(params![&cursor, Self::BLIND_INDEX_REPAIR_BATCH], |row| {
+                        Ok((row.get(0)?, row.get(1)?))
+                    })
+                    .map_err(|error| format!("Failed to read blind-index repair batch: {error}"))?;
+                rows.collect::<Result<Vec<_>, _>>()
+                    .map_err(|error| format!("Failed to decode blind-index posting: {error}"))?
+            };
+
+            if batch.is_empty() {
+                break;
+            }
+
+            let visited = batch.len() as u64;
+            let last_hash = batch
+                .last()
+                .map(|(hash, _)| hash.clone())
+                .unwrap_or_default();
+            let mut replacements: Vec<(String, Vec<u8>)> = Vec::new();
+            let mut deletions: Vec<String> = Vec::new();
+            let mut removed_in_batch = 0u64;
+
+            for (token_hash, blob) in batch {
+                let mut bitmap =
+                    roaring::RoaringBitmap::deserialize_from(&blob[..]).map_err(|error| {
+                        format!("Failed to deserialize blind posting {token_hash}: {error}")
+                    })?;
+                let before = bitmap.len();
+                bitmap &= &valid_ocr_ids;
+                let removed = before.saturating_sub(bitmap.len());
+                if removed == 0 {
+                    continue;
+                }
+                removed_in_batch = removed_in_batch.saturating_add(removed);
+                if bitmap.is_empty() {
+                    deletions.push(token_hash);
+                } else {
+                    let mut repaired = Vec::new();
+                    bitmap.serialize_into(&mut repaired).map_err(|error| {
+                        format!("Failed to serialize repaired posting {token_hash}: {error}")
+                    })?;
+                    replacements.push((token_hash, repaired));
+                }
+            }
+
+            let batch_len = replacements.len() + deletions.len();
+
+            let tx = conn.unchecked_transaction().map_err(|error| {
+                format!("Failed to start blind-index repair transaction: {error}")
+            })?;
+            {
+                let mut update = tx
+                    .prepare_cached(
+                        "UPDATE blind_bitmap_index SET postings_blob = ?2 WHERE token_hash = ?1",
+                    )
+                    .map_err(|error| format!("Failed to prepare posting update: {error}"))?;
+                for (token_hash, blob) in &replacements {
+                    update.execute(params![token_hash, blob]).map_err(|error| {
+                        format!("Failed to update posting {token_hash}: {error}")
+                    })?;
+                }
+            }
+            {
+                let mut delete = tx
+                    .prepare_cached("DELETE FROM blind_bitmap_index WHERE token_hash = ?1")
+                    .map_err(|error| format!("Failed to prepare posting delete: {error}"))?;
+                for token_hash in &deletions {
+                    delete.execute([token_hash]).map_err(|error| {
+                        format!("Failed to delete posting {token_hash}: {error}")
+                    })?;
+                }
+            }
+
+            status.processed_postings = status.processed_postings.saturating_add(visited);
+            status.changed_postings = status.changed_postings.saturating_add(batch_len as u64);
+            status.deleted_postings = status
+                .deleted_postings
+                .saturating_add(deletions.len() as u64);
+            status.removed_ocr_ids = status.removed_ocr_ids.saturating_add(removed_in_batch);
+
+            let progress_values = [
+                (Self::BLIND_INDEX_REPAIR_CURSOR_KEY, last_hash.clone()),
+                (
+                    Self::BLIND_INDEX_REPAIR_PROCESSED_KEY,
+                    status.processed_postings.to_string(),
+                ),
+                (
+                    Self::BLIND_INDEX_REPAIR_CHANGED_KEY,
+                    status.changed_postings.to_string(),
+                ),
+                (
+                    Self::BLIND_INDEX_REPAIR_DELETED_KEY,
+                    status.deleted_postings.to_string(),
+                ),
+                (
+                    Self::BLIND_INDEX_REPAIR_REMOVED_IDS_KEY,
+                    status.removed_ocr_ids.to_string(),
+                ),
+            ];
+            for (key, value) in progress_values {
+                tx.execute(
+                    "INSERT OR REPLACE INTO app_metadata (key, value) VALUES (?1, ?2)",
+                    params![key, value],
+                )
+                .map_err(|error| {
+                    format!("Failed to persist blind-index repair progress: {error}")
+                })?;
+            }
+            tx.commit()
+                .map_err(|error| format!("Failed to commit blind-index repair batch: {error}"))?;
+
+            cursor = last_hash;
+            progress_callback(status.clone());
+        }
+
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|error| format!("Failed to finish blind-index repair: {error}"))?;
+        tx.execute(
+            "INSERT OR REPLACE INTO app_metadata (key, value) VALUES (?1, '1')",
+            [Self::BLIND_INDEX_REPAIR_DONE_KEY],
+        )
+        .map_err(|error| format!("Failed to mark blind-index repair complete: {error}"))?;
+        for key in [
+            Self::BLIND_INDEX_REPAIR_CURSOR_KEY,
+            Self::BLIND_INDEX_REPAIR_PROCESSED_KEY,
+            Self::BLIND_INDEX_REPAIR_CHANGED_KEY,
+            Self::BLIND_INDEX_REPAIR_DELETED_KEY,
+            Self::BLIND_INDEX_REPAIR_REMOVED_IDS_KEY,
+        ] {
+            tx.execute("DELETE FROM app_metadata WHERE key = ?1", [key])
+                .map_err(|error| format!("Failed to clear blind-index repair cursor: {error}"))?;
+        }
+        tx.commit()
+            .map_err(|error| format!("Failed to commit blind-index repair completion: {error}"))?;
+
+        progress_callback(status.clone());
+        Ok(status)
+    }
 
     /// Attempt to start the lazy indexer (and check migration status).
     /// Called after user authentication succeeds.
@@ -40,6 +306,11 @@ impl StorageState {
                 continue;
             }
 
+            if crate::maintenance::is_active() {
+                std::thread::sleep(std::time::Duration::from_secs(1));
+                continue;
+            }
+
             std::thread::sleep(std::time::Duration::from_millis(1000));
 
             // Process unindexed rows (text_hash = '') even if a full migration (old hashes -> HMAC) is pending.
@@ -68,7 +339,11 @@ impl StorageState {
             let conn = guard.as_ref().unwrap();
             let mut stmt = conn
                 .prepare(
-                    "SELECT id, text_enc, text_key_encrypted FROM ocr_results WHERE text_hash = '' ORDER BY id ASC LIMIT ?1",
+                    "SELECT id, text_enc, text_key_encrypted
+                     FROM ocr_results
+                     WHERE text_hash = '' AND is_deleted = 0
+                     ORDER BY id ASC
+                     LIMIT ?1",
                 )
                 .map_err(|e| format!("lazy prepare: {}", e))?;
             let mapped = stmt
@@ -88,6 +363,42 @@ impl StorageState {
         }
 
         self.index_batch_internal(rows, &hmac_key)
+    }
+
+    fn query_visible_ocr_bitmap(
+        conn: &Connection,
+        ids: &[i64],
+        context: &str,
+    ) -> Result<roaring::RoaringBitmap, String> {
+        let mut active = roaring::RoaringBitmap::new();
+        if ids.is_empty() {
+            return Ok(active);
+        }
+
+        let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT o.id
+             FROM ocr_results o
+             JOIN screenshots s ON s.id = o.screenshot_id
+             WHERE o.id IN ({placeholders})
+               AND o.is_deleted = 0
+               AND s.is_deleted = 0"
+        );
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|error| format!("{context} active-row prepare: {error}"))?;
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(ids.iter()), |row| {
+                row.get::<_, i64>(0)
+            })
+            .map_err(|error| format!("{context} active-row query: {error}"))?;
+        for id in rows {
+            let id = id.map_err(|error| format!("{context} active-row decode: {error}"))?;
+            let bitmap_id = u32::try_from(id)
+                .map_err(|_| format!("OCR row {id} exceeds bitmap id capacity"))?;
+            active.insert(bitmap_id);
+        }
+        Ok(active)
     }
 
     /// Internal helper to re-index a batch of rows.
@@ -128,10 +439,16 @@ impl StorageState {
             let conn = guard.as_mut().unwrap();
             let tx = conn.transaction().map_err(|e| format!("lazy tx: {}", e))?;
 
+            let ids: Vec<i64> = row_hashes.iter().map(|(id, _)| *id).collect();
+            let active_ids = Self::query_visible_ocr_bitmap(&tx, &ids, "lazy index")?;
+
             // Update text_hash
             {
                 let mut upd_stmt = tx
-                    .prepare_cached("UPDATE ocr_results SET text_hash = ?1 WHERE id = ?2")
+                    .prepare_cached(
+                        "UPDATE ocr_results SET text_hash = ?1
+                         WHERE id = ?2 AND is_deleted = 0",
+                    )
                     .map_err(|e| format!("lazy upd prep: {}", e))?;
                 for (id, hash) in &row_hashes {
                     upd_stmt.execute(params![hash, id]).ok();
@@ -151,7 +468,11 @@ impl StorageState {
                     )
                     .map_err(|e| format!("lazy put prep: {}", e))?;
 
-                for (hash, new_bitmap) in &batch_tokens {
+                for (hash, candidate_bitmap) in &batch_tokens {
+                    let new_bitmap = candidate_bitmap & &active_ids;
+                    if new_bitmap.is_empty() {
+                        continue;
+                    }
                     let existing_blob: Option<Vec<u8>> = get_stmt
                         .query_row(params![hash], |row| row.get(0))
                         .optional()
@@ -160,10 +481,10 @@ impl StorageState {
                     let merged = if let Some(blob) = existing_blob {
                         let mut existing = roaring::RoaringBitmap::deserialize_from(&blob[..])
                             .map_err(|e| format!("lazy deser: {}", e))?;
-                        existing |= new_bitmap;
+                        existing |= &new_bitmap;
                         existing
                     } else {
-                        new_bitmap.clone()
+                        new_bitmap
                     };
 
                     let mut buf = Vec::new();
@@ -218,8 +539,14 @@ impl StorageState {
         // Atomic update for the batch
         let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
         {
+            let ids: Vec<i64> = row_hashes.iter().map(|(id, _)| *id).collect();
+            let active_ids = Self::query_visible_ocr_bitmap(&tx, &ids, "HMAC index")?;
+
             let mut upd_stmt = tx
-                .prepare_cached("UPDATE ocr_results SET text_hash = ?1 WHERE id = ?2")
+                .prepare_cached(
+                    "UPDATE ocr_results SET text_hash = ?1
+                     WHERE id = ?2 AND is_deleted = 0",
+                )
                 .map_err(|e| e.to_string())?;
             for (id, hash) in &row_hashes {
                 let _ = upd_stmt.execute(params![hash, id]);
@@ -236,20 +563,24 @@ impl StorageState {
                 )
                 .map_err(|e| e.to_string())?;
 
-            for (hash, new_bitmap) in &batch_tokens {
+            for (hash, candidate_bitmap) in &batch_tokens {
+                let new_bitmap = candidate_bitmap & &active_ids;
+                if new_bitmap.is_empty() {
+                    continue;
+                }
                 let existing_blob: Option<Vec<u8>> = get_stmt
                     .query_row(params![hash], |row| row.get(0))
                     .optional()
                     .unwrap_or(None);
                 let merged = if let Some(blob) = existing_blob {
                     if let Ok(mut existing) = roaring::RoaringBitmap::deserialize_from(&blob[..]) {
-                        existing |= new_bitmap;
+                        existing |= &new_bitmap;
                         existing
                     } else {
-                        new_bitmap.clone()
+                        new_bitmap
                     }
                 } else {
-                    new_bitmap.clone()
+                    new_bitmap
                 };
 
                 let mut buf = Vec::new();
@@ -260,5 +591,140 @@ impl StorageState {
         }
         tx.commit().map_err(|e| e.to_string())?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credential_manager::CredentialManagerState;
+    use roaring::RoaringBitmap;
+    use std::sync::Arc;
+
+    fn test_storage() -> (tempfile::TempDir, StorageState) {
+        let temp = tempfile::tempdir().expect("temp storage directory");
+        let credential = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        let storage = StorageState::new(temp.path().to_path_buf(), credential);
+        let connection = Connection::open_in_memory().expect("in-memory database");
+        storage.init_tables(&connection).expect("initialize schema");
+        *storage.db.lock().unwrap_or_else(|error| error.into_inner()) = Some(connection);
+        (temp, storage)
+    }
+
+    fn serialize(ids: &[u32]) -> Vec<u8> {
+        let bitmap: RoaringBitmap = ids.iter().copied().collect();
+        let mut blob = Vec::new();
+        bitmap.serialize_into(&mut blob).expect("serialize bitmap");
+        blob
+    }
+
+    #[test]
+    fn blind_index_repair_removes_only_non_query_visible_ids() {
+        let (_temp, storage) = test_storage();
+        {
+            let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+            let connection = guard.as_ref().expect("database");
+            connection
+                .execute_batch(
+                    "INSERT INTO screenshots (id, image_path, image_hash, is_deleted) VALUES
+                        (1, '1.enc', 'h1', 0),
+                        (2, '2.enc', 'h2', 1),
+                        (3, '3.enc', 'h3', 0),
+                        (4, '4.enc', 'h4', 1);
+                     INSERT INTO ocr_results (id, screenshot_id, text_hash, is_deleted) VALUES
+                        (1, 1, 'a', 0),
+                        (2, 2, 'b', 1),
+                        (3, 3, 'c', 0),
+                        (4, 4, 'd', 0);",
+                )
+                .expect("insert OCR fixture");
+            connection
+                .execute(
+                    "INSERT INTO blind_bitmap_index (token_hash, postings_blob) VALUES (?1, ?2)",
+                    params!["active-and-stale", serialize(&[1, 2, 4, 99])],
+                )
+                .expect("insert mixed posting");
+            connection
+                .execute(
+                    "INSERT INTO blind_bitmap_index (token_hash, postings_blob) VALUES (?1, ?2)",
+                    params!["active-only", serialize(&[3])],
+                )
+                .expect("insert active posting");
+            connection
+                .execute(
+                    "INSERT INTO blind_bitmap_index (token_hash, postings_blob) VALUES (?1, ?2)",
+                    params!["stale-only", serialize(&[2, 99])],
+                )
+                .expect("insert stale posting");
+        }
+
+        assert!(storage.is_blind_index_repair_needed().unwrap());
+        let mut snapshots = Vec::new();
+        let summary = storage
+            .run_blind_index_repair(|progress| snapshots.push(progress))
+            .expect("repair blind index");
+
+        assert_eq!(summary.processed_postings, 3);
+        assert_eq!(summary.total_postings, 3);
+        assert_eq!(summary.changed_postings, 2);
+        assert_eq!(summary.deleted_postings, 1);
+        assert_eq!(summary.removed_ocr_ids, 5);
+        assert!(snapshots.len() >= 2);
+        assert!(!storage.is_blind_index_repair_needed().unwrap());
+
+        let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+        let connection = guard.as_ref().expect("database");
+        let mixed: Vec<u8> = connection
+            .query_row(
+                "SELECT postings_blob FROM blind_bitmap_index WHERE token_hash = 'active-and-stale'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("mixed posting survives");
+        let mixed = RoaringBitmap::deserialize_from(&mixed[..]).expect("decode mixed posting");
+        assert_eq!(mixed.iter().collect::<Vec<_>>(), vec![1]);
+
+        let active: Vec<u8> = connection
+            .query_row(
+                "SELECT postings_blob FROM blind_bitmap_index WHERE token_hash = 'active-only'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("active posting survives");
+        let active = RoaringBitmap::deserialize_from(&active[..]).expect("decode active posting");
+        assert_eq!(active.iter().collect::<Vec<_>>(), vec![3]);
+
+        let stale_exists: bool = connection
+            .query_row(
+                "SELECT 1 FROM blind_bitmap_index WHERE token_hash = 'stale-only'",
+                [],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        assert!(!stale_exists);
+    }
+
+    #[test]
+    fn query_visible_ocr_bitmap_rechecks_both_row_and_parent_state() {
+        let (_temp, storage) = test_storage();
+        let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+        let connection = guard.as_ref().expect("database");
+        connection
+            .execute_batch(
+                "INSERT INTO screenshots (id, image_path, image_hash, is_deleted) VALUES
+                    (10, '10.enc', 'h10', 0),
+                    (11, '11.enc', 'h11', 1),
+                    (12, '12.enc', 'h12', 0);
+                 INSERT INTO ocr_results (id, screenshot_id, text_hash, is_deleted) VALUES
+                    (100, 10, '', 0),
+                    (101, 11, '', 0),
+                    (102, 12, '', 1);",
+            )
+            .expect("insert visibility fixture");
+
+        let active =
+            StorageState::query_visible_ocr_bitmap(connection, &[100, 101, 102, 999], "test")
+                .expect("query visible OCR ids");
+        assert_eq!(active.iter().collect::<Vec<_>>(), vec![100]);
     }
 }

--- a/src-tauri/src/storage/migration/hmac.rs
+++ b/src-tauri/src/storage/migration/hmac.rs
@@ -119,9 +119,15 @@ impl StorageState {
 
                 // A. FETCH
                 let rows: Vec<(i64, Vec<u8>, Vec<u8>)> = {
-                    let mut stmt = conn.prepare(
-                        "SELECT id, text_enc, text_key_encrypted FROM ocr_results WHERE id > ?1 ORDER BY id ASC LIMIT ?2"
-                    ).map_err(|e| e.to_string())?;
+                    let mut stmt = conn
+                        .prepare(
+                            "SELECT id, text_enc, text_key_encrypted
+                         FROM ocr_results
+                         WHERE id > ?1 AND is_deleted = 0
+                         ORDER BY id ASC
+                         LIMIT ?2",
+                        )
+                        .map_err(|e| e.to_string())?;
 
                     let mapped = stmt
                         .query_map(params![cursor, MIGRATE_BATCH_SIZE], |r| {

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -675,7 +675,8 @@ impl StorageState {
             );
 
             CREATE TABLE IF NOT EXISTS delete_queue_ocr (
-                id INTEGER PRIMARY KEY
+                id INTEGER PRIMARY KEY,
+                failure_count INTEGER NOT NULL DEFAULT 0
             );
 
             -- Blind bigram bitmap index table (stores postings as RoaringBitmap)
@@ -967,6 +968,12 @@ impl StorageState {
             conn,
             "ocr_results",
             "is_deleted",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "delete_queue_ocr",
+            "failure_count",
             "INTEGER NOT NULL DEFAULT 0",
         )?;
 
@@ -1339,7 +1346,8 @@ impl StorageState {
             "delete_queue_ocr",
             r#"
             CREATE TABLE IF NOT EXISTS delete_queue_ocr (
-                id INTEGER PRIMARY KEY
+                id INTEGER PRIMARY KEY,
+                failure_count INTEGER NOT NULL DEFAULT 0
             )
             "#,
         )?;

--- a/src-tauri/src/storage/screenshot.rs
+++ b/src-tauri/src/storage/screenshot.rs
@@ -12,9 +12,10 @@ use std::sync::atomic::Ordering;
 use super::types::{RawRecentCaptureRow, RawScreenshotRow};
 use super::{
     wire_time, BackgroundReadError, BackgroundScreenshotSummary, DeleteQueueStatus, DensityBucket,
-    DerivedIndexKind, IndexStorageStats, OcrResultInput, QueueScreenshotCandidate, RecentCapture,
-    SaveScreenshotRequest, SaveScreenshotResponse, ScreenshotRecord, SoftDeleteResult,
-    SoftDeleteScreenshotsResult, StorageState,
+    DerivedIndexKind, IncrementalVacuumResult, IndexStorageStats, OcrDeleteBatchResult,
+    OcrResultInput, QueueScreenshotCandidate, RecentCapture, SaveScreenshotRequest,
+    SaveScreenshotResponse, ScreenshotRecord, SoftDeleteResult, SoftDeleteScreenshotsResult,
+    StorageState,
 };
 
 const MAX_OCR_POSTPROCESS_ATTEMPTS: i64 = 5;
@@ -2598,65 +2599,13 @@ impl StorageState {
         Ok(final_map)
     }
 
-    /// Delete a screenshot by ID.
+    /// Queue a screenshot for safe physical deletion by ID.
     pub fn delete_screenshot(&self, id: i64) -> Result<bool, String> {
-        let (deleted, image_path, ocr_count) = {
-            let guard = self.get_connection_named("delete_screenshot")?;
-            let conn = guard.as_ref().unwrap();
-
-            // Get image path first
-            let image_path: Option<String> = conn
-                .query_row(
-                    "SELECT image_path FROM screenshots WHERE id = ? AND is_deleted = 0",
-                    [id],
-                    |row| row.get(0),
-                )
-                .ok();
-
-            // Count OCR rows that will be cascade-deleted
-            let ocr_count: i64 = conn
-                .query_row(
-                    "SELECT COUNT(*) FROM ocr_results WHERE screenshot_id = ? AND is_deleted = 0",
-                    [id],
-                    |row| row.get(0),
-                )
-                .unwrap_or(0);
-
-            // Delete database record
-            let deleted = conn
-                .execute(
-                    "DELETE FROM screenshots WHERE id = ? AND is_deleted = 0",
-                    [id],
-                )
-                .map_err(|e| format!("Failed to delete screenshot: {}", e))?;
-
-            if deleted > 0 {
-                // Clean up orphaned dedup entries while the DB connection is held.
-                let _ = Self::cleanup_orphaned_dedup_entries(conn);
-            }
-            drop(guard);
-            (deleted, image_path, ocr_count)
-        };
-
-        // Try to delete image file
-        if deleted > 0 {
-            if let Some(path) = image_path {
-                let abs_path = self.resolve_image_path(&path);
-                let _ = std::fs::remove_file(&abs_path);
-                let thumb = Self::thumbnail_path_for(&abs_path);
-                let _ = std::fs::remove_file(&thumb);
-            }
-            let _ = self
-                .ocr_row_count
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                    Some(v.saturating_sub(ocr_count as u64))
-                });
-        }
-
-        Ok(deleted > 0)
+        let result = self.soft_delete_screenshots(&[id])?;
+        Ok(result.screenshots_marked > 0)
     }
 
-    /// Delete screenshots within a time range.
+    /// Queue screenshots within a time range for safe physical deletion.
     pub fn delete_screenshots_by_time_range(
         &self,
         start_ts: f64,
@@ -2670,64 +2619,28 @@ impl StorageState {
             .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string())
             .unwrap_or_default();
 
-        let (paths, deleted, ocr_count) = {
+        let ids: Vec<i64> = {
             let guard = self.get_connection_named("delete_screenshots_by_time_range")?;
             let conn = guard.as_ref().unwrap();
 
-            // Get all image paths to delete
             let mut stmt = conn
-                .prepare("SELECT image_path FROM screenshots WHERE is_deleted = 0 AND created_at BETWEEN ? AND ?")
+                .prepare(
+                    "SELECT id FROM screenshots
+                     WHERE is_deleted = 0 AND created_at BETWEEN ?1 AND ?2
+                     ORDER BY id ASC",
+                )
                 .map_err(|e| format!("Failed to prepare query: {}", e))?;
 
-            let paths: Vec<String> = stmt
+            let rows = stmt
                 .query_map([&start_dt, &end_dt], |row| row.get(0))
                 .map_err(|e| format!("Failed to execute query: {}", e))?
-                .filter_map(|r| r.ok())
-                .collect();
-
-            // Count OCR rows that will be cascade-deleted
-            let ocr_count: i64 = conn
-                .query_row(
-                    "SELECT COUNT(*) FROM ocr_results WHERE is_deleted = 0 AND screenshot_id IN (SELECT id FROM screenshots WHERE is_deleted = 0 AND created_at BETWEEN ? AND ?)",
-                    [&start_dt, &end_dt],
-                    |row| row.get(0),
-                )
-                .unwrap_or(0);
-
-            // Delete database records
-            let deleted = conn
-                .execute(
-                    "DELETE FROM screenshots WHERE is_deleted = 0 AND created_at BETWEEN ? AND ?",
-                    [&start_dt, &end_dt],
-                )
-                .map_err(|e| format!("Failed to delete screenshots: {}", e))?;
-
-            if deleted > 0 {
-                // Clean up orphaned dedup entries while the DB connection is held.
-                let _ = Self::cleanup_orphaned_dedup_entries(conn);
-            }
-            drop(stmt);
-            drop(guard);
-            (paths, deleted, ocr_count)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("Failed to decode screenshot id: {}", e))?;
+            rows
         };
 
-        if deleted > 0 {
-            let _ = self
-                .ocr_row_count
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                    Some(v.saturating_sub(ocr_count as u64))
-                });
-        }
-
-        // Try to delete image files
-        for path in paths {
-            let abs_path = self.resolve_image_path(&path);
-            let _ = std::fs::remove_file(&abs_path);
-            let thumb = Self::thumbnail_path_for(&abs_path);
-            let _ = std::fs::remove_file(&thumb);
-        }
-
-        Ok(deleted as i32)
+        let result = self.soft_delete_screenshots(&ids)?;
+        Ok(result.screenshots_marked.clamp(0, i32::MAX as i64) as i32)
     }
 
     /// Soft-delete screenshots by process (and optional month key `YYYY-MM`) and enqueue IDs.
@@ -3111,17 +3024,24 @@ impl StorageState {
     }
 
     /// Process one OCR delete queue batch and unlink each row from blind bitmap index.
-    pub fn process_ocr_delete_queue_batch(&self, batch_size: i64) -> Result<usize, String> {
+    pub fn process_ocr_delete_queue_batch(
+        &self,
+        batch_size: i64,
+    ) -> Result<OcrDeleteBatchResult, String> {
         let safe_batch_size = batch_size.clamp(1, 2000);
-        let hmac_key = self.credential_state.get_hmac_key()?;
 
-        let mut guard = self.get_connection_named("process_ocr_delete_queue_batch")?;
-        let conn = guard.as_mut().unwrap();
-
-        let rows: Vec<(i64, Option<Vec<u8>>, Option<Vec<u8>>)> = {
+        let rows: Vec<(
+            i64,
+            Option<i64>,
+            Option<String>,
+            Option<Vec<u8>>,
+            Option<Vec<u8>>,
+        )> = {
+            let guard = self.get_connection_named("process_ocr_delete_queue_batch_read")?;
+            let conn = guard.as_ref().unwrap();
             let mut read_stmt = conn
                 .prepare(
-                    "SELECT q.id, o.text_enc, o.text_key_encrypted
+                    "SELECT q.id, o.id, o.text, o.text_enc, o.text_key_encrypted
                      FROM delete_queue_ocr q
                      LEFT JOIN ocr_results o ON o.id = q.id
                      ORDER BY q.id ASC
@@ -3131,43 +3051,86 @@ impl StorageState {
 
             let mapped_rows = read_stmt
                 .query_map([safe_batch_size], |row| {
-                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
                 })
                 .map_err(|e| format!("Failed to read OCR queue rows: {}", e))?;
 
-            let collected: Vec<(i64, Option<Vec<u8>>, Option<Vec<u8>>)> =
-                mapped_rows.filter_map(|r| r.ok()).collect();
-            collected
+            mapped_rows
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("Failed to decode OCR queue row: {}", e))?
         };
 
         if rows.is_empty() {
-            return Ok(0);
+            return Ok(OcrDeleteBatchResult::default());
         }
 
         let mut removals: std::collections::HashMap<String, RoaringBitmap> =
             std::collections::HashMap::new();
         let mut queue_ids: Vec<i64> = Vec::with_capacity(rows.len());
+        let mut stale_queue_rows = 0usize;
 
-        for (ocr_id, text_enc, text_key_enc) in &rows {
+        let has_live_rows = rows
+            .iter()
+            .any(|(_, existing_id, _, _, _)| existing_id.is_some());
+        let hmac_key = if has_live_rows {
+            Some(self.credential_state.get_hmac_key()?)
+        } else {
+            None
+        };
+
+        for (ocr_id, existing_id, legacy_text, text_enc, text_key_enc) in &rows {
             queue_ids.push(*ocr_id);
+
+            if existing_id.is_none() {
+                stale_queue_rows += 1;
+                continue;
+            }
+
             let plaintext = match (text_enc.as_ref(), text_key_enc.as_ref()) {
-                (Some(enc), Some(key_enc)) => self
-                    .decrypt_payload_with_row_key(enc, key_enc)
-                    .ok()
-                    .and_then(|bytes| String::from_utf8(bytes).ok()),
-                _ => None,
+                (Some(enc), Some(key_enc)) => match self.decrypt_payload_with_row_key(enc, key_enc)
+                {
+                    Ok(bytes) => match String::from_utf8(bytes) {
+                        Ok(text) => text,
+                        Err(_) => legacy_text
+                            .clone()
+                            .ok_or_else(|| format!("OCR row {} contains invalid UTF-8", ocr_id))?,
+                    },
+                    Err(error) => legacy_text.clone().ok_or_else(|| {
+                        format!(
+                            "Failed to decrypt OCR row {} for delete cleanup: {}",
+                            ocr_id, error
+                        )
+                    })?,
+                },
+                _ => legacy_text
+                    .clone()
+                    .ok_or_else(|| format!("OCR row {} has no readable text payload", ocr_id))?,
             };
 
-            if let Some(text) = plaintext {
-                for token in Self::bigram_tokenize(&text) {
-                    let token_hash = Self::compute_hmac_hash(&token, &hmac_key);
-                    removals
-                        .entry(token_hash)
-                        .or_insert_with(RoaringBitmap::new)
-                        .insert(*ocr_id as u32);
-                }
+            let bitmap_id = u32::try_from(*ocr_id)
+                .map_err(|_| format!("OCR row {} exceeds bitmap id capacity", ocr_id))?;
+            for token in Self::bigram_tokenize(&plaintext) {
+                let token_hash = Self::compute_hmac_hash(
+                    &token,
+                    hmac_key
+                        .as_deref()
+                        .expect("live OCR rows require an HMAC key"),
+                );
+                removals
+                    .entry(token_hash)
+                    .or_insert_with(RoaringBitmap::new)
+                    .insert(bitmap_id);
             }
         }
+
+        let mut guard = self.get_connection_named("process_ocr_delete_queue_batch_write")?;
+        let conn = guard.as_mut().unwrap();
 
         let tx = conn
             .transaction()
@@ -3221,13 +3184,15 @@ impl StorageState {
             }
         }
 
+        let mut deleted_rows = 0usize;
         for chunk in queue_ids.chunks(500) {
             let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
 
             let sql_delete_ocr = format!("DELETE FROM ocr_results WHERE id IN ({})", placeholders);
             let params_ocr: Vec<&dyn rusqlite::ToSql> =
                 chunk.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
-            tx.execute(&sql_delete_ocr, params_ocr.as_slice())
+            deleted_rows += tx
+                .execute(&sql_delete_ocr, params_ocr.as_slice())
                 .map_err(|e| format!("Failed to hard-delete OCR rows: {}", e))?;
 
             let sql_delete_queue = format!(
@@ -3245,7 +3210,11 @@ impl StorageState {
         // `ocr_row_count` is adjusted on soft-delete when rows become inactive.
         // Hard-delete queue processing is physical cleanup only and must not decrement again.
 
-        Ok(queue_ids.len())
+        Ok(OcrDeleteBatchResult {
+            queue_rows: queue_ids.len(),
+            deleted_rows,
+            stale_queue_rows,
+        })
     }
 
     /// Read screenshot cleanup candidates from queue (batch).
@@ -3262,6 +3231,10 @@ impl StorageState {
                 "SELECT q.id, s.image_hash, s.image_path
                  FROM delete_queue_screenshots q
                  LEFT JOIN screenshots s ON s.id = q.id
+                 WHERE s.id IS NULL
+                    OR NOT EXISTS (
+                        SELECT 1 FROM ocr_results o WHERE o.screenshot_id = q.id
+                    )
                  ORDER BY q.id ASC
                  LIMIT ?1",
             )
@@ -3272,8 +3245,8 @@ impl StorageState {
                 Ok((row.get(0)?, row.get(1)?, row.get(2)?))
             })
             .map_err(|e| format!("Failed to read screenshot queue rows: {}", e))?
-            .filter_map(|r| r.ok())
-            .collect();
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Failed to decode screenshot queue row: {}", e))?;
 
         let mut stale_ids = Vec::new();
         let mut candidates = Vec::new();
@@ -3353,41 +3326,72 @@ impl StorageState {
         &self,
         freelist_threshold: i64,
         vacuum_pages: i64,
-    ) -> Result<bool, String> {
+    ) -> Result<IncrementalVacuumResult, String> {
         let Some(_maintenance) = self.try_database_maintenance("run_incremental_vacuum_if_idle")
         else {
-            return Ok(false);
+            return Ok(IncrementalVacuumResult::default());
         };
         let guard = self.get_connection_named("run_incremental_vacuum_if_idle")?;
         let conn = guard.as_ref().unwrap();
 
-        let pending_screenshots: i64 = conn
-            .query_row("SELECT COUNT(*) FROM delete_queue_screenshots", [], |row| {
-                row.get(0)
-            })
-            .map_err(|e| format!("Failed to count screenshot queue: {}", e))?;
-        let pending_ocr: i64 = conn
-            .query_row("SELECT COUNT(*) FROM delete_queue_ocr", [], |row| {
-                row.get(0)
-            })
-            .map_err(|e| format!("Failed to count OCR queue: {}", e))?;
+        let queues_busy: i64 = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM delete_queue_screenshots LIMIT 1)
+                     OR EXISTS(SELECT 1 FROM delete_queue_ocr LIMIT 1)",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("Failed to inspect delete queues before vacuum: {}", e))?;
 
-        if pending_screenshots > 0 || pending_ocr > 0 {
-            return Ok(false);
+        if queues_busy != 0 {
+            return Ok(IncrementalVacuumResult::default());
         }
 
-        let freelist_count: i64 = conn
+        let freelist_before: i64 = conn
             .query_row("PRAGMA freelist_count;", [], |row| row.get(0))
             .map_err(|e| format!("Failed to read freelist_count: {}", e))?;
 
-        if freelist_count <= freelist_threshold {
-            return Ok(false);
+        if freelist_before <= freelist_threshold {
+            return Ok(IncrementalVacuumResult::default());
         }
 
         let pages = vacuum_pages.max(1);
-        conn.execute_batch(&format!("PRAGMA incremental_vacuum({});", pages))
-            .map_err(|e| format!("Failed to run incremental_vacuum: {}", e))?;
-        Ok(true)
+        let page_count_before: i64 = conn
+            .query_row("PRAGMA page_count;", [], |row| row.get(0))
+            .map_err(|e| format!("Failed to read page_count before vacuum: {}", e))?;
+
+        let mut stmt = conn
+            .prepare(&format!("PRAGMA incremental_vacuum({});", pages))
+            .map_err(|e| format!("Failed to prepare incremental_vacuum: {}", e))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| format!("Failed to start incremental_vacuum: {}", e))?;
+        let mut stepped_pages = 0usize;
+        while rows
+            .next()
+            .map_err(|e| format!("Failed while stepping incremental_vacuum: {}", e))?
+            .is_some()
+        {
+            stepped_pages += 1;
+        }
+        drop(rows);
+        drop(stmt);
+
+        let freelist_after: i64 = conn
+            .query_row("PRAGMA freelist_count;", [], |row| row.get(0))
+            .map_err(|e| format!("Failed to read freelist_count after vacuum: {}", e))?;
+        let page_count_after: i64 = conn
+            .query_row("PRAGMA page_count;", [], |row| row.get(0))
+            .map_err(|e| format!("Failed to read page_count after vacuum: {}", e))?;
+
+        Ok(IncrementalVacuumResult {
+            attempted: true,
+            requested_pages: pages,
+            stepped_pages,
+            reclaimed_pages: page_count_before.saturating_sub(page_count_after),
+            freelist_before,
+            freelist_after,
+        })
     }
 
     /// Canonicalize a list of visible links into a deterministic JSON string.
@@ -3571,6 +3575,83 @@ mod ocr_lifecycle_tests {
         // h1 is one image vector despite three OCR rows; h2/h3 each contribute
         // one; h4 is deleted; h5 has no OCR row.
         assert_eq!(storage.count_expected_clip_image_rows().unwrap(), 3);
+    }
+
+    #[test]
+    fn screenshot_queue_waits_until_all_child_ocr_rows_are_gone() {
+        let temp = tempfile::tempdir().expect("temp storage directory");
+        let credential_state = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        let storage = StorageState::new(temp.path().to_path_buf(), credential_state);
+        let connection = Connection::open_in_memory().expect("in-memory database");
+        storage.init_tables(&connection).expect("initialize schema");
+        connection
+            .execute_batch(
+                "INSERT INTO screenshots (id, image_path, image_hash, is_deleted) VALUES
+                    (1, '1.enc', 'h1', 1),
+                    (2, '2.enc', 'h2', 1);
+                 INSERT INTO ocr_results (id, screenshot_id, text_hash, is_deleted)
+                    VALUES (10, 1, 'x', 1);
+                 INSERT INTO delete_queue_screenshots (id) VALUES (1), (2);",
+            )
+            .expect("insert delete queue fixture");
+        *storage.db.lock().unwrap_or_else(|error| error.into_inner()) = Some(connection);
+
+        let ready = storage
+            .fetch_screenshot_delete_candidates(10)
+            .expect("read screenshot queue");
+        assert_eq!(ready.iter().map(|row| row.id).collect::<Vec<_>>(), vec![2]);
+
+        {
+            let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+            guard
+                .as_ref()
+                .unwrap()
+                .execute("DELETE FROM ocr_results WHERE id = 10", [])
+                .expect("remove final OCR row");
+        }
+        let ready = storage
+            .fetch_screenshot_delete_candidates(10)
+            .expect("read unblocked screenshot queue");
+        assert_eq!(
+            ready.iter().map(|row| row.id).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+    }
+
+    #[test]
+    fn incremental_vacuum_exhausts_more_than_one_pragma_step() {
+        let temp = tempfile::tempdir().expect("temp storage directory");
+        let credential_state = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        let storage = StorageState::new(temp.path().to_path_buf(), credential_state);
+        let db_path = temp.path().join("vacuum.db");
+        let connection = Connection::open(&db_path).expect("open vacuum fixture");
+        connection
+            .execute_batch(
+                "PRAGMA auto_vacuum = INCREMENTAL;
+                 VACUUM;
+                 CREATE TABLE delete_queue_screenshots (id INTEGER PRIMARY KEY);
+                 CREATE TABLE delete_queue_ocr (id INTEGER PRIMARY KEY);
+                 CREATE TABLE payloads (id INTEGER PRIMARY KEY, payload BLOB NOT NULL);
+                 WITH RECURSIVE rows(id) AS (
+                    SELECT 1 UNION ALL SELECT id + 1 FROM rows WHERE id < 800
+                 )
+                 INSERT INTO payloads (id, payload) SELECT id, zeroblob(3500) FROM rows;
+                 DELETE FROM payloads;",
+            )
+            .expect("create vacuum fixture");
+        let freelist_before: i64 = connection
+            .query_row("PRAGMA freelist_count", [], |row| row.get(0))
+            .expect("read initial freelist");
+        assert!(freelist_before > 50);
+        *storage.db.lock().unwrap_or_else(|error| error.into_inner()) = Some(connection);
+
+        let result = storage
+            .run_incremental_vacuum_if_idle(0, 50)
+            .expect("run incremental vacuum");
+        assert!(result.attempted);
+        assert!(result.stepped_pages > 1);
+        assert!(result.reclaimed_pages > 1);
+        assert!(result.freelist_after < result.freelist_before);
     }
 
     #[test]

--- a/src-tauri/src/storage/screenshot.rs
+++ b/src-tauri/src/storage/screenshot.rs
@@ -19,6 +19,37 @@ use super::{
 };
 
 const MAX_OCR_POSTPROCESS_ATTEMPTS: i64 = 5;
+const MAX_OCR_DELETE_CLEANUP_FAILURES: i64 = 3;
+
+struct OcrDeleteQueueRow {
+    id: i64,
+    existing_id: Option<i64>,
+    failure_count: i64,
+    legacy_text: Option<String>,
+    text_hash: Option<String>,
+    text_enc: Option<Vec<u8>>,
+    text_key_encrypted: Option<Vec<u8>>,
+}
+
+impl OcrDeleteQueueRow {
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get(0)?,
+            failure_count: row.get(1)?,
+            existing_id: row.get(2)?,
+            legacy_text: row.get(3)?,
+            text_hash: row.get(4)?,
+            text_enc: row.get(5)?,
+            text_key_encrypted: row.get(6)?,
+        })
+    }
+}
+
+struct OcrDeleteCleanupFailure {
+    id: i64,
+    failure_count: i64,
+    error: String,
+}
 
 struct EncryptedOcrResultRow {
     id: i64,
@@ -3030,18 +3061,13 @@ impl StorageState {
     ) -> Result<OcrDeleteBatchResult, String> {
         let safe_batch_size = batch_size.clamp(1, 2000);
 
-        let rows: Vec<(
-            i64,
-            Option<i64>,
-            Option<String>,
-            Option<Vec<u8>>,
-            Option<Vec<u8>>,
-        )> = {
+        let rows: Vec<OcrDeleteQueueRow> = {
             let guard = self.get_connection_named("process_ocr_delete_queue_batch_read")?;
             let conn = guard.as_ref().unwrap();
             let mut read_stmt = conn
                 .prepare(
-                    "SELECT q.id, o.id, o.text, o.text_enc, o.text_key_encrypted
+                    "SELECT q.id, q.failure_count, o.id, o.text, o.text_hash,
+                            o.text_enc, o.text_key_encrypted
                      FROM delete_queue_ocr q
                      LEFT JOIN ocr_results o ON o.id = q.id
                      ORDER BY q.id ASC
@@ -3050,15 +3076,7 @@ impl StorageState {
                 .map_err(|e| format!("Failed to prepare OCR queue read: {}", e))?;
 
             let mapped_rows = read_stmt
-                .query_map([safe_batch_size], |row| {
-                    Ok((
-                        row.get(0)?,
-                        row.get(1)?,
-                        row.get(2)?,
-                        row.get(3)?,
-                        row.get(4)?,
-                    ))
-                })
+                .query_map([safe_batch_size], OcrDeleteQueueRow::from_row)
                 .map_err(|e| format!("Failed to read OCR queue rows: {}", e))?;
 
             mapped_rows
@@ -3067,61 +3085,90 @@ impl StorageState {
         };
 
         if rows.is_empty() {
-            return Ok(OcrDeleteBatchResult::default());
+            return Ok(OcrDeleteBatchResult {
+                queue_empty: true,
+                ..OcrDeleteBatchResult::default()
+            });
         }
 
         let mut removals: std::collections::HashMap<String, RoaringBitmap> =
             std::collections::HashMap::new();
-        let mut queue_ids: Vec<i64> = Vec::with_capacity(rows.len());
+        let mut delete_ids: Vec<i64> = Vec::with_capacity(rows.len());
+        let mut retry_failures: Vec<OcrDeleteCleanupFailure> = Vec::new();
+        let mut fallback_failures: Vec<OcrDeleteCleanupFailure> = Vec::new();
         let mut stale_queue_rows = 0usize;
+        let mut hmac_key: Option<Vec<u8>> = None;
 
-        let has_live_rows = rows
-            .iter()
-            .any(|(_, existing_id, _, _, _)| existing_id.is_some());
-        let hmac_key = if has_live_rows {
-            Some(self.credential_state.get_hmac_key()?)
-        } else {
-            None
-        };
-
-        for (ocr_id, existing_id, legacy_text, text_enc, text_key_enc) in &rows {
-            queue_ids.push(*ocr_id);
-
-            if existing_id.is_none() {
+        for row in &rows {
+            if row.existing_id.is_none() {
+                delete_ids.push(row.id);
                 stale_queue_rows += 1;
                 continue;
             }
 
-            let plaintext = match (text_enc.as_ref(), text_key_enc.as_ref()) {
-                (Some(enc), Some(key_enc)) => match self.decrypt_payload_with_row_key(enc, key_enc)
-                {
-                    Ok(bytes) => match String::from_utf8(bytes) {
-                        Ok(text) => text,
-                        Err(_) => legacy_text
-                            .clone()
-                            .ok_or_else(|| format!("OCR row {} contains invalid UTF-8", ocr_id))?,
-                    },
-                    Err(error) => legacy_text.clone().ok_or_else(|| {
-                        format!(
-                            "Failed to decrypt OCR row {} for delete cleanup: {}",
-                            ocr_id, error
-                        )
-                    })?,
-                },
-                _ => legacy_text
+            // An empty text hash is the durable marker for a row that never
+            // reached the bitmap index, so it has no postings to unlink.
+            if row.text_hash.as_deref().unwrap_or_default().is_empty() {
+                delete_ids.push(row.id);
+                continue;
+            }
+
+            let plaintext = match (row.text_enc.as_ref(), row.text_key_encrypted.as_ref()) {
+                (Some(enc), Some(key_enc)) => {
+                    match self.decrypt_payload_with_row_key(enc, key_enc) {
+                        Ok(bytes) => match String::from_utf8(bytes) {
+                            Ok(text) => Ok(text),
+                            Err(_) => row.legacy_text.clone().ok_or_else(|| {
+                                format!("OCR row {} contains invalid UTF-8", row.id)
+                            }),
+                        },
+                        Err(error) => row.legacy_text.clone().ok_or_else(|| {
+                            format!(
+                                "Failed to decrypt OCR row {} for delete cleanup: {}",
+                                row.id, error
+                            )
+                        }),
+                    }
+                }
+                _ => row
+                    .legacy_text
                     .clone()
-                    .ok_or_else(|| format!("OCR row {} has no readable text payload", ocr_id))?,
+                    .ok_or_else(|| format!("OCR row {} has no readable text payload", row.id)),
             };
 
-            let bitmap_id = u32::try_from(*ocr_id)
-                .map_err(|_| format!("OCR row {} exceeds bitmap id capacity", ocr_id))?;
+            let cleanup_input = plaintext.and_then(|text| {
+                u32::try_from(row.id)
+                    .map(|bitmap_id| (text, bitmap_id))
+                    .map_err(|_| format!("OCR row {} exceeds bitmap id capacity", row.id))
+            });
+
+            let (plaintext, bitmap_id) = match cleanup_input {
+                Ok(input) => input,
+                Err(error) => {
+                    let failure_count = row.failure_count.max(0).saturating_add(1);
+                    let failure = OcrDeleteCleanupFailure {
+                        id: row.id,
+                        failure_count,
+                        error,
+                    };
+                    if failure_count >= MAX_OCR_DELETE_CLEANUP_FAILURES {
+                        delete_ids.push(row.id);
+                        fallback_failures.push(failure);
+                    } else {
+                        retry_failures.push(failure);
+                    }
+                    continue;
+                }
+            };
+
+            if hmac_key.is_none() {
+                hmac_key = Some(self.credential_state.get_hmac_key()?);
+            }
+            let hmac_key = hmac_key
+                .as_deref()
+                .expect("OCR posting cleanup requires an HMAC key");
             for token in Self::bigram_tokenize(&plaintext) {
-                let token_hash = Self::compute_hmac_hash(
-                    &token,
-                    hmac_key
-                        .as_deref()
-                        .expect("live OCR rows require an HMAC key"),
-                );
+                let token_hash = Self::compute_hmac_hash(&token, hmac_key);
                 removals
                     .entry(token_hash)
                     .or_insert_with(RoaringBitmap::new)
@@ -3184,8 +3231,19 @@ impl StorageState {
             }
         }
 
+        if !retry_failures.is_empty() {
+            let mut update_stmt = tx
+                .prepare_cached("UPDATE delete_queue_ocr SET failure_count = ?2 WHERE id = ?1")
+                .map_err(|e| format!("Failed to prepare OCR retry update: {}", e))?;
+            for failure in &retry_failures {
+                update_stmt
+                    .execute(params![failure.id, failure.failure_count])
+                    .map_err(|e| format!("Failed to persist OCR cleanup retry: {}", e))?;
+            }
+        }
+
         let mut deleted_rows = 0usize;
-        for chunk in queue_ids.chunks(500) {
+        for chunk in delete_ids.chunks(500) {
             let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
 
             let sql_delete_ocr = format!("DELETE FROM ocr_results WHERE id IN ({})", placeholders);
@@ -3205,15 +3263,50 @@ impl StorageState {
                 .map_err(|e| format!("Failed to clear OCR queue rows: {}", e))?;
         }
 
+        let blind_index_repair_requested = !fallback_failures.is_empty();
+        if blind_index_repair_requested {
+            Self::mark_blind_index_repair_needed_on_conn(&tx)?;
+        }
+
+        let queue_empty: bool = tx
+            .query_row(
+                "SELECT NOT EXISTS(SELECT 1 FROM delete_queue_ocr LIMIT 1)",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("Failed to inspect OCR queue after cleanup: {}", e))?;
+
         tx.commit()
             .map_err(|e| format!("Failed to commit OCR cleanup: {}", e))?;
         // `ocr_row_count` is adjusted on soft-delete when rows become inactive.
         // Hard-delete queue processing is physical cleanup only and must not decrement again.
 
+        for failure in &retry_failures {
+            tracing::warn!(
+                "[DELETE_QUEUE] OCR row {} cleanup failed ({}/{}); retrying later: {}",
+                failure.id,
+                failure.failure_count,
+                MAX_OCR_DELETE_CLEANUP_FAILURES,
+                failure.error
+            );
+        }
+        for failure in &fallback_failures {
+            tracing::warn!(
+                "[DELETE_QUEUE] OCR row {} cleanup failed {} times; hard-deleted without bitmap unlink and scheduled repair: {}",
+                failure.id,
+                failure.failure_count,
+                failure.error
+            );
+        }
+
         Ok(OcrDeleteBatchResult {
-            queue_rows: queue_ids.len(),
+            queue_rows: delete_ids.len(),
             deleted_rows,
             stale_queue_rows,
+            retry_rows: retry_failures.len(),
+            fallback_deleted_rows: fallback_failures.len(),
+            blind_index_repair_requested,
+            queue_empty,
         })
     }
 
@@ -3616,6 +3709,122 @@ mod ocr_lifecycle_tests {
             ready.iter().map(|row| row.id).collect::<Vec<_>>(),
             vec![1, 2]
         );
+    }
+
+    #[test]
+    fn ocr_delete_queue_isolates_unreadable_rows_and_rearms_repair() {
+        let temp = tempfile::tempdir().expect("temp storage directory");
+        let credential_state = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        let storage = StorageState::new(temp.path().to_path_buf(), credential_state);
+        let connection = Connection::open_in_memory().expect("in-memory database");
+        storage.init_tables(&connection).expect("initialize schema");
+        connection
+            .execute_batch(
+                "INSERT INTO screenshots (id, image_path, image_hash, is_deleted) VALUES
+                    (1, '1.enc', 'h1', 1),
+                    (2, '2.enc', 'h2', 1);
+                 INSERT INTO ocr_results
+                    (id, screenshot_id, text, text_hash, text_enc, text_key_encrypted, is_deleted)
+                    VALUES
+                    (10, 1, NULL, 'indexed', NULL, NULL, 1),
+                    (20, 2, NULL, '', NULL, NULL, 1);
+                 INSERT INTO delete_queue_ocr (id) VALUES (10), (20);
+                 INSERT INTO delete_queue_screenshots (id) VALUES (1), (2);",
+            )
+            .expect("insert delete queue fixture");
+        *storage.db.lock().unwrap_or_else(|error| error.into_inner()) = Some(connection);
+
+        storage
+            .run_blind_index_repair(|_| {})
+            .expect("mark initial repair complete");
+        assert!(!storage.is_blind_index_repair_needed().unwrap());
+
+        let first = storage
+            .process_ocr_delete_queue_batch(10)
+            .expect("process first OCR delete batch");
+        assert_eq!(first.queue_rows, 1);
+        assert_eq!(first.deleted_rows, 1);
+        assert_eq!(first.retry_rows, 1);
+        assert_eq!(first.fallback_deleted_rows, 0);
+        assert!(!first.blind_index_repair_requested);
+        assert!(!first.queue_empty);
+
+        {
+            let guard = storage.db.lock().unwrap_or_else(|error| error.into_inner());
+            let conn = guard.as_ref().expect("database");
+            let failure_count: i64 = conn
+                .query_row(
+                    "SELECT failure_count FROM delete_queue_ocr WHERE id = 10",
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("persist first failure");
+            assert_eq!(failure_count, 1);
+            assert_eq!(
+                conn.query_row(
+                    "SELECT COUNT(*) FROM ocr_results WHERE id = 20",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+                0
+            );
+        }
+
+        let ready = storage
+            .fetch_screenshot_delete_candidates(10)
+            .expect("read partially unblocked screenshot queue");
+        assert_eq!(ready.iter().map(|row| row.id).collect::<Vec<_>>(), vec![2]);
+
+        let second = storage
+            .process_ocr_delete_queue_batch(10)
+            .expect("process second OCR delete batch");
+        assert_eq!(second.queue_rows, 0);
+        assert_eq!(second.retry_rows, 1);
+        assert!(!second.queue_empty);
+
+        let third = storage
+            .process_ocr_delete_queue_batch(10)
+            .expect("process fallback OCR delete batch");
+        assert_eq!(third.queue_rows, 1);
+        assert_eq!(third.deleted_rows, 1);
+        assert_eq!(third.retry_rows, 0);
+        assert_eq!(third.fallback_deleted_rows, 1);
+        assert!(third.blind_index_repair_requested);
+        assert!(third.queue_empty);
+        assert!(storage.is_blind_index_repair_needed().unwrap());
+
+        let ready = storage
+            .fetch_screenshot_delete_candidates(10)
+            .expect("read fully unblocked screenshot queue");
+        assert_eq!(
+            ready.iter().map(|row| row.id).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+    }
+
+    #[test]
+    fn schema_upgrade_adds_ocr_delete_failure_count() {
+        let temp = tempfile::tempdir().expect("temp storage directory");
+        let credential_state = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        let storage = StorageState::new(temp.path().to_path_buf(), credential_state);
+        let connection = Connection::open_in_memory().expect("in-memory database");
+        connection
+            .execute("CREATE TABLE delete_queue_ocr (id INTEGER PRIMARY KEY)", [])
+            .expect("create legacy OCR queue");
+
+        storage.init_tables(&connection).expect("upgrade schema");
+
+        let failure_count_exists = connection
+            .prepare("PRAGMA table_info(delete_queue_ocr)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .iter()
+            .any(|column| column == "failure_count");
+        assert!(failure_count_exists);
     }
 
     #[test]

--- a/src-tauri/src/storage/types.rs
+++ b/src-tauri/src/storage/types.rs
@@ -461,6 +461,35 @@ pub struct DeleteQueueStatus {
     pub running: bool,
 }
 
+/// Outcome of one durable OCR delete-queue batch.
+#[derive(Debug, Clone, Default)]
+pub struct OcrDeleteBatchResult {
+    pub queue_rows: usize,
+    pub deleted_rows: usize,
+    pub stale_queue_rows: usize,
+}
+
+/// Observable result of one incremental-vacuum attempt.
+#[derive(Debug, Clone, Default)]
+pub struct IncrementalVacuumResult {
+    pub attempted: bool,
+    pub requested_pages: i64,
+    pub stepped_pages: usize,
+    pub reclaimed_pages: i64,
+    pub freelist_before: i64,
+    pub freelist_after: i64,
+}
+
+/// Persisted progress emitted by the one-time blind-index repair.
+#[derive(Debug, Clone, Default)]
+pub struct BlindIndexRepairProgress {
+    pub processed_postings: u64,
+    pub total_postings: u64,
+    pub changed_postings: u64,
+    pub deleted_postings: u64,
+    pub removed_ocr_ids: u64,
+}
+
 /// Counts used by the index health panel.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexStorageStats {

--- a/src-tauri/src/storage/types.rs
+++ b/src-tauri/src/storage/types.rs
@@ -467,6 +467,10 @@ pub struct OcrDeleteBatchResult {
     pub queue_rows: usize,
     pub deleted_rows: usize,
     pub stale_queue_rows: usize,
+    pub retry_rows: usize,
+    pub fallback_deleted_rows: usize,
+    pub blind_index_repair_requested: bool,
+    pub queue_empty: bool,
 }
 
 /// Observable result of one incremental-vacuum attempt.
@@ -480,7 +484,7 @@ pub struct IncrementalVacuumResult {
     pub freelist_after: i64,
 }
 
-/// Persisted progress emitted by the one-time blind-index repair.
+/// Persisted progress emitted by the blind-index repair.
 #[derive(Debug, Clone, Default)]
 pub struct BlindIndexRepairProgress {
     pub processed_postings: u64,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -301,8 +301,7 @@ function App() {
         <StartupVacuumDialog />
 
         {/* Top-level, non-dismissable maintenance overlay: covers the whole
-            window (TopBar included) whenever the app is in maintenance mode,
-            which currently means either vector migration. */}
+            window (TopBar included) whenever the app is in maintenance mode. */}
         <VectorMigrationOverlay />
 
         {isAuthenticated && <HmacMigrationDialog />}

--- a/src/components/VectorMigrationOverlay.jsx
+++ b/src/components/VectorMigrationOverlay.jsx
@@ -1,7 +1,16 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Database, Image as ImageIcon, KeyRound, Loader2, ShieldAlert, Wrench } from 'lucide-react';
 import {
+  Database,
+  Image as ImageIcon,
+  KeyRound,
+  Loader2,
+  SearchCheck,
+  ShieldAlert,
+  Wrench,
+} from 'lucide-react';
+import {
+  getBlindIndexRepairStatus,
   getClipRebuildStatus,
   getMaintenanceStatus,
   getMinilmRebuildStatus,
@@ -19,6 +28,7 @@ const PROGRESS_SOURCES = {
   publishing_write: ['publish_current', 'publish_total'],
   publishing_sync: ['publish_current', 'publish_total'],
   publishing_verify: ['publish_current', 'publish_total'],
+  repairing_blind_index: ['processed', 'total'],
 };
 
 /**
@@ -31,6 +41,11 @@ const MIGRATION_KINDS = {
   minilm_migration: { id: 'minilm', icon: Database, read: getMinilmRebuildStatus },
   clip_migration: { id: 'clip', icon: ImageIcon, read: getClipRebuildStatus },
   clip_ann_bootstrap: { id: 'clip', icon: ImageIcon, read: null, phase: 'building_ann' },
+  blind_index_repair: {
+    id: 'blindIndex',
+    icon: SearchCheck,
+    read: getBlindIndexRepairStatus,
+  },
 };
 
 function formatEta(seconds) {
@@ -43,8 +58,8 @@ function formatEta(seconds) {
 }
 
 /**
- * Full-window, non-dismissable maintenance overlay for the sentinel-triggered
- * vector migrations. Neither run can be cancelled: closing the app merely
+ * Full-window, non-dismissable maintenance overlay for sentinel-triggered
+ * index maintenance. Runs cannot be cancelled: closing the app merely
  * interrupts it, and it resumes on the next launch/unlock.
  *
  * Visibility is decided by *maintenance mode*, not by any one migration's

--- a/src/components/VectorMigrationOverlay.test.jsx
+++ b/src/components/VectorMigrationOverlay.test.jsx
@@ -9,6 +9,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('../lib/task_api', () => ({
+  getBlindIndexRepairStatus: vi.fn(),
   getMaintenanceStatus: vi.fn(),
   getMinilmRebuildStatus: vi.fn(),
   getClipRebuildStatus: vi.fn(),
@@ -20,6 +21,7 @@ vi.mock('../lib/auth_api', () => ({
 
 import VectorMigrationOverlay from './VectorMigrationOverlay';
 import {
+  getBlindIndexRepairStatus,
   getClipRebuildStatus,
   getMaintenanceStatus,
   getMinilmRebuildStatus,
@@ -53,6 +55,14 @@ describe('VectorMigrationOverlay', () => {
     getMaintenanceStatus.mockResolvedValue({ active: true, reason: 'minilm_migration' });
     getMinilmRebuildStatus.mockResolvedValue(runningStatus());
     getClipRebuildStatus.mockResolvedValue(runningStatus());
+    getBlindIndexRepairStatus.mockResolvedValue({
+      running: true,
+      phase: 'repairing_blind_index',
+      processed: 20,
+      total: 100,
+      failed: 0,
+      last_error: null,
+    });
   });
 
   afterEach(() => {
@@ -93,6 +103,19 @@ describe('VectorMigrationOverlay', () => {
     expect(getMinilmRebuildStatus).not.toHaveBeenCalled();
   });
 
+  it('shows blocking progress for the blind text-index repair', async () => {
+    getMaintenanceStatus.mockResolvedValue({ active: true, reason: 'blind_index_repair' });
+    render(<VectorMigrationOverlay />);
+    await pollTick();
+
+    expect(screen.getByText('vectorMigration.kinds.blindIndex.title')).toBeInTheDocument();
+    expect(screen.getByText(/20\s*\/\s*100\s*\(20%\)/)).toBeInTheDocument();
+    expect(getBlindIndexRepairStatus).toHaveBeenCalled();
+    expect(getMinilmRebuildStatus).not.toHaveBeenCalled();
+    expect(getClipRebuildStatus).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
   it('stays hidden when the app is not in maintenance mode', async () => {
     getMaintenanceStatus.mockResolvedValue({ active: false, reason: null });
     render(<VectorMigrationOverlay />);
@@ -103,6 +126,7 @@ describe('VectorMigrationOverlay', () => {
     // No detail read is worth making when the cheap outer flag already says no.
     expect(getMinilmRebuildStatus).not.toHaveBeenCalled();
     expect(getClipRebuildStatus).not.toHaveBeenCalled();
+    expect(getBlindIndexRepairStatus).not.toHaveBeenCalled();
   });
 
   it('still explains itself when the reason is unrecognised', async () => {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1487,6 +1487,10 @@
         "title": "Migrating the image index",
         "subtitle": "Screenshot-image vectors are being moved into the local Rust index. The app is in maintenance mode while this runs."
       },
+      "blindIndex": {
+        "title": "Repairing text search",
+        "subtitle": "Search records left by deleted snapshots are being cleaned up. The app is unavailable until this finishes."
+      },
       "unknown": {
         "title": "Maintenance in progress",
         "subtitle": "The app is running a maintenance task. Some features stay unavailable until it finishes."
@@ -1497,7 +1501,7 @@
     "waitingForAuth": "Your session has expired. Complete Windows Hello authentication and the migration will continue automatically.",
     "reauth": "Authenticate",
     "errorCount": "{{count}} records could not be migrated. Details were written to the migration diagnostics.",
-    "blockedHint": "Other operations are unavailable during migration. If the app exits, migration resumes after the next launch and unlock.",
+    "blockedHint": "Other operations are unavailable during maintenance. If the app exits, the task resumes on the next launch.",
     "phases": {
       "starting": "Preparing…",
       "preflight": "Checking disk space…",
@@ -1509,7 +1513,11 @@
       "publishing_verify": "Verifying the index file…",
       "publishing_commit": "Committing the index…",
       "building_ann": "Building the accelerated image-search index…",
+      "scanning_valid_ocr": "Checking active search records…",
+      "repairing_blind_index": "Repairing text search…",
       "waiting_for_auth": "Waiting for authentication…",
+      "completed": "Repair complete",
+      "failed": "Repair incomplete",
       "working": "Working…"
     }
   },

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1487,6 +1487,10 @@
         "title": "画面索引迁移中",
         "subtitle": "正在把截图画面的向量迁移到本地 Rust 索引。迁移期间应用处于维护模式。"
       },
+      "blindIndex": {
+        "title": "正在修复文本搜索索引",
+        "subtitle": "正在清理已删除快照留下的搜索记录。完成前应用暂不可用。"
+      },
       "unknown": {
         "title": "正在进行维护",
         "subtitle": "应用正在执行一项维护任务，完成之前部分功能不可用。"
@@ -1497,7 +1501,7 @@
     "waitingForAuth": "会话已过期。请完成 Windows Hello 认证，迁移随后会自动继续。",
     "reauth": "重新认证",
     "errorCount": "有 {{count}} 条记录无法迁移，详情已写入迁移诊断。",
-    "blockedHint": "迁移期间其它操作暂不可用；若应用退出，将在下次启动并解锁后自动继续。",
+    "blockedHint": "维护期间其它操作暂不可用；若应用退出，将在下次启动后自动继续。",
     "phases": {
       "starting": "正在准备…",
       "preflight": "正在检查磁盘空间…",
@@ -1509,7 +1513,11 @@
       "publishing_verify": "正在校验索引文件…",
       "publishing_commit": "正在提交索引…",
       "building_ann": "正在构建图片搜索加速索引…",
+      "scanning_valid_ocr": "正在检查有效搜索记录…",
+      "repairing_blind_index": "正在修复文本搜索索引…",
       "waiting_for_auth": "等待身份认证…",
+      "completed": "修复已完成",
+      "failed": "修复未完成",
       "working": "正在处理…"
     }
   },

--- a/src/lib/task_api.js
+++ b/src/lib/task_api.js
@@ -163,6 +163,11 @@ export async function getClipRebuildStatus() {
   return invoke('get_clip_rebuild_status');
 }
 
+/** Read progress for the mandatory stale text-search index repair. */
+export async function getBlindIndexRepairStatus() {
+  return invoke('get_blind_index_repair_status');
+}
+
 /** List diagnostics for the CLIP migration run. */
 export async function listClipRebuildErrors(offset = 0, limit = 100) {
   return withAuth(() => invoke('list_clip_rebuild_errors', { offset, limit }));

--- a/src/lib/task_api.test.js
+++ b/src/lib/task_api.test.js
@@ -23,6 +23,7 @@ import {
   getMinilmRebuildStatus,
   listMinilmRebuildErrors,
   getClipRebuildStatus,
+  getBlindIndexRepairStatus,
   listClipRebuildErrors,
   getMaintenanceStatus,
 } from './task_api';
@@ -113,15 +114,17 @@ describe('task_api', () => {
     invoke.mockResolvedValue({ running: true });
 
     await getMinilmRebuildStatus();
+    await getBlindIndexRepairStatus();
     await listMinilmRebuildErrors(5, 25);
     await getMaintenanceStatus();
 
     expect(invoke).toHaveBeenNthCalledWith(1, 'get_minilm_rebuild_status');
-    expect(invoke).toHaveBeenNthCalledWith(2, 'list_minilm_rebuild_errors', {
+    expect(invoke).toHaveBeenNthCalledWith(2, 'get_blind_index_repair_status');
+    expect(invoke).toHaveBeenNthCalledWith(3, 'list_minilm_rebuild_errors', {
       offset: 5,
       limit: 25,
     });
-    expect(invoke).toHaveBeenNthCalledWith(3, 'get_maintenance_status');
+    expect(invoke).toHaveBeenNthCalledWith(4, 'get_maintenance_status');
     expectWithAuth(1);
   });
 


### PR DESCRIPTION
This PR fixed following problems:

First, the legacy mechanisms for deleting individual screenshots or deleting by time range relied on immediate, hard deletion: the `screenshots` row was deleted directly within the calling thread, followed by the deletion of the image file and thumbnail. There was no guarantee of atomicity between the database commit and the file deletion; if the process was interrupted, inconsistencies between the actual files and the database records would arise.

Second, the background OCR deletion queue was susceptible to contamination by uninterpretable rows. In the legacy implementation, rows that failed decryption or suffered from encoding corruption were hard-deleted during batch processing, yet their corresponding entries—specifically the postings within the RoaringBitmap-based inverted index were not removed. Consequently, traces of the deleted content persisted in the search index, potentially causing "ghost matches" and leading to continuous index bloat.

## Key Changes

- `delete_screenshot` and `delete_screenshots_by_time_range` have been updated to call `soft_delete_screenshots`: rows are first marked as deleted and queued, while physical cleanup is handled by a background maintenance loop.

- Added a `failure_count` column to the queue table; existing databases are upgraded idempotently using `add_column_if_missing`.
- Row decoding errors are no longer silently suppressed; separate connections are now used for queue reads and writes to reduce lock hold times; batch operations return a structured `OcrDeleteBatchResult` count, with corresponding refinements to logging.

- Automatic repair check on startup: Scans `blind_bitmap_index` to remove OCR IDs from index entries if they no longer correspond to visible rows (i.e., neither the OCR row nor its associated screenshot has been deleted); entries left empty after this process are deleted entirely.
- Runs in maintenance mode: Exclusively locks the database and pauses screenshot capture; displays a non-dismissible progress overlay on the frontend.
- Progress and cursor state are persisted in `app_metadata`, allowing the process to resume upon restart if the application exits midway; the mechanism re-arms itself after a cleanup run completes to allow for subsequent passes.

- HMAC migration processes only non-deleted rows; it no longer regenerates ciphertext for previously deleted data.
- Re-verifies the parent screenshot's status when queuing or updating lazy indices; rows marked as soft-deleted are no longer written to the bitmap index.

- Polling interval reduces from a fixed 5 seconds to 25 milliseconds when the queue is active (remaining at 5 seconds when idle), significantly accelerating cleanup speeds for bulk deletions.
- Incremental VACUUM executes only when both deletion queues are empty and no failed rows remain; metrics such as requested pages, actual reclaimed pages, and free page counts (before/after) are logged.
- Added a read-only command, `get_blind_index_repair_status`, for the frontend to query repair progress; registered in the security guard script at the public access level (consistent with other status queries, requiring no session authentication).