### PR TITLE
feat(storage): add WAL startup mode policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,11 @@ $env:CARBONPAPER_WAL_EXPERIMENT = "1"
 npm run debug
 ```
 
-Only a debug build accepts the value `1`; the experiment also checks that the database
-directory is local and writable and has enough free space for a conversion. Removing the
-variable and restarting makes the startup policy convert the database back to DELETE.
-The application stops storage initialization if the requested mode cannot be verified.
+Only a debug build accepts the value `1`; the experiment checks that the database directory
+is local and writable and has enough free space when a conversion is needed. Removing the
+variable and restarting makes the startup policy attempt to convert the database back to
+DELETE. If a supported conversion cannot be completed, startup keeps the current journal
+mode, records the failed transition, and retries on a later startup.
 
 Every Tauri command must document its purpose, authentication requirement, parameters,
 serialized return shape, and the frontend wrapper or component that calls it. Every new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,21 @@ that still explain useful intent. Remove comments that merely restate the next l
 Prefer documenting why a constraint exists, which state transition is expected, and what
 must remain true across an API or FFI boundary.
 
+## Developer WAL Experiment
+
+The normal database journal mode is DELETE. To opt a debug build into the WAL experiment,
+set the process environment variable before starting Tauri:
+
+```powershell
+$env:CARBONPAPER_WAL_EXPERIMENT = "1"
+npm run debug
+```
+
+Only a debug build accepts the value `1`; the experiment also checks that the database
+directory is local and writable and has enough free space for a conversion. Removing the
+variable and restarting makes the startup policy convert the database back to DELETE.
+The application stops storage initialization if the requested mode cannot be verified.
+
 Every Tauri command must document its purpose, authentication requirement, parameters,
 serialized return shape, and the frontend wrapper or component that calls it. Every new
 `unsafe` block or `unsafe impl` must have an adjacent `// SAFETY:` comment explaining the

--- a/src-tauri/semantic-worker/Cargo.lock
+++ b/src-tauri/semantic-worker/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "carbonpaper-semantic-worker"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "hex",
  "image",

--- a/src-tauri/src/commands/credential.rs
+++ b/src-tauri/src/commands/credential.rs
@@ -38,6 +38,14 @@ pub async fn credential_initialize(
             .map_err(|e| format!("Failed to create master key: {}", e))?;
 
         storage_state.initialize()?;
+        // First-run initialization can happen after the Tauri setup callback
+        // failed to load/export the public key. Start Office observation at the
+        // same post-storage boundary used by the normal startup path.
+        if let Some(office_runtime) =
+            app.try_state::<Arc<crate::office_runtime::OfficeRuntimeState>>()
+        {
+            office_runtime.start(app.clone(), storage_state.inner().clone());
+        }
         if let Some(scheduler) =
             app.try_state::<Arc<crate::background_scheduler::BackgroundSchedulerState>>()
         {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -71,7 +71,7 @@ use power::PowerState;
 use sensitive_filter::SensitiveFilterState;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use storage::StorageState;
+use storage::{database_mode_policy_from_environment, StorageState};
 use tauri::menu::{MenuBuilder, MenuItem, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::Emitter;
@@ -798,6 +798,23 @@ pub fn run() {
     let data_dir = get_data_dir();
     let _log_guard = logging::init_logging(&data_dir);
 
+    // Resolve the experiment switch once. The resulting policy is carried by
+    // StorageState so reopens after restore or directory migration cannot
+    // change mode halfway through a process.
+    let database_mode_policy = match database_mode_policy_from_environment() {
+        Ok(policy) => policy,
+        Err(error) => {
+            tracing::error!("Database journal mode experiment configuration is invalid: {error}");
+            return;
+        }
+    };
+    tracing::info!(
+        "Database startup journal mode policy target={} wal_experiment={} debug_build={}",
+        database_mode_policy.as_str(),
+        database_mode_policy.is_wal(),
+        cfg!(debug_assertions)
+    );
+
     // 检查是否应该隐藏启动
     let start_hidden = std::env::var("CARBONPAPER_START_HIDDEN").is_ok()
         || registry_config::get_bool("start_with_window_hidden").unwrap_or(false);
@@ -813,9 +830,10 @@ pub fn run() {
         // state, including the interval before setup creates the tray.
         credential_state.set_foreground_state(false);
     }
-    let storage_state = Arc::new(StorageState::new(
+    let storage_state = Arc::new(StorageState::new_with_mode_policy(
         data_dir.clone(),
         credential_state.clone(),
+        database_mode_policy,
     ));
     let lightweight_state = Arc::new(LightweightModeState::new());
 
@@ -922,13 +940,6 @@ pub fn run() {
 
                 logging::spawn_maintenance_task(data_dir.clone());
 
-                let office_runtime = app
-                    .state::<Arc<office_runtime::OfficeRuntimeState>>()
-                    .inner()
-                    .clone();
-                let office_storage = app.state::<Arc<StorageState>>().inner().clone();
-                office_runtime.start(app.handle().clone(), office_storage);
-
                 tracing::info!(
                     r#"
   _____               _                    _____
@@ -987,6 +998,17 @@ pub fn run() {
                     if let Err(e) = storage.initialize() {
                         tracing::error!("Failed to initialize storage: {}", e);
                     } else {
+                        // Storage publishes its primary connection only after
+                        // the startup journal-mode policy has completed. Start
+                        // Office observation after that boundary so no worker
+                        // can create a read connection during conversion.
+                        let office_runtime = app
+                            .state::<Arc<office_runtime::OfficeRuntimeState>>()
+                            .inner()
+                            .clone();
+                        let office_storage = storage.inner().clone();
+                        office_runtime.start(app.handle().clone(), office_storage);
+
                         match storage.discard_incomplete_ocr_postprocess() {
                             Ok(discarded) if discarded > 0 => tracing::info!(
                                 "[ML:POSTPROCESS] discarded {} incomplete rows from the previous application process",

--- a/src-tauri/src/storage/connection.rs
+++ b/src-tauri/src/storage/connection.rs
@@ -431,10 +431,9 @@ pub(crate) fn preserve_wal_sidecars_on_close(conn: &Connection) -> Result<(), St
 
 /// Request a journal mode and verify SQLite's effective result.
 ///
-/// V1 does not call this during startup. Later WAL experiments can use it and
-/// receive a clear diagnostic when a read-only connection, filesystem, or
-/// SQLite build cannot establish the requested mode.
-#[allow(dead_code)]
+/// Startup and controlled mode transitions use this helper and receive a clear
+/// diagnostic when a read-only connection, filesystem, or SQLite build cannot
+/// establish the requested mode.
 pub(crate) fn set_journal_mode(
     conn: &Connection,
     requested: JournalMode,

--- a/src-tauri/src/storage/connection.rs
+++ b/src-tauri/src/storage/connection.rs
@@ -9,6 +9,15 @@ use std::time::{Duration, Instant};
 /// Keep lock waits bounded and explicit on every connection.
 pub(crate) const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Keep SQLite's normal automatic checkpoint policy explicit across the
+/// bundled primary and independent connections.
+pub(crate) const WAL_AUTOCHECKPOINT_PAGES: i64 = 1_000;
+
+/// Bound the amount of reusable WAL capacity retained after a checkpoint.
+/// This limits the physical sidecar without forcing a truncate on every small
+/// transaction.
+pub(crate) const WAL_JOURNAL_SIZE_LIMIT_BYTES: i64 = 64 * 1024 * 1024;
+
 /// Preserve the existing durability policy while DELETE remains the default
 /// journal mode. WAL experiments can choose a different policy explicitly.
 const SYNCHRONOUS_FULL: &str = "FULL";
@@ -35,6 +44,13 @@ pub(crate) struct ConnectionStatus {
     pub(crate) journal_mode: String,
     pub(crate) synchronous: String,
     pub(crate) engine: SqliteEngineIdentity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WalCheckpointResult {
+    pub(crate) busy: i64,
+    pub(crate) log_frames: i64,
+    pub(crate) checkpointed_frames: i64,
 }
 
 #[derive(Default)]
@@ -299,6 +315,8 @@ pub(crate) fn configure_connection_pragmas(conn: &Connection) -> Result<Connecti
     conn.busy_timeout(BUSY_TIMEOUT)?;
     conn.pragma_update(None, "foreign_keys", true)?;
     conn.pragma_update(None, "synchronous", SYNCHRONOUS_FULL)?;
+    conn.pragma_update(None, "wal_autocheckpoint", WAL_AUTOCHECKPOINT_PAGES)?;
+    conn.pragma_update(None, "journal_size_limit", WAL_JOURNAL_SIZE_LIMIT_BYTES)?;
     inspect_connection(conn)
 }
 
@@ -348,6 +366,21 @@ pub(crate) fn inspect_sqlite_engine(conn: &Connection) -> Result<SqliteEngineIde
         sqlite_source_id,
         cipher_version,
     })
+}
+
+/// Checkpoint and physically truncate a WAL file after all readers have been
+/// drained by the caller's maintenance gate.
+pub(crate) fn checkpoint_wal_truncate(
+    conn: &Connection,
+) -> std::result::Result<WalCheckpointResult, String> {
+    conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+        Ok(WalCheckpointResult {
+            busy: row.get(0)?,
+            log_frames: row.get(1)?,
+            checkpointed_frames: row.get(2)?,
+        })
+    })
+    .map_err(|error| format!("Failed to run WAL TRUNCATE checkpoint: {error}"))
 }
 
 fn ensure_supported_sqlite_engine(
@@ -490,6 +523,14 @@ mod tests {
             .pragma_query_value(None, "busy_timeout", |row| row.get(0))
             .expect("read busy_timeout");
         assert_eq!(busy_timeout, BUSY_TIMEOUT.as_millis() as i64);
+        let wal_autocheckpoint: i64 = conn
+            .pragma_query_value(None, "wal_autocheckpoint", |row| row.get(0))
+            .expect("read wal_autocheckpoint");
+        assert_eq!(wal_autocheckpoint, WAL_AUTOCHECKPOINT_PAGES);
+        let journal_size_limit: i64 = conn
+            .pragma_query_value(None, "journal_size_limit", |row| row.get(0))
+            .expect("read journal_size_limit");
+        assert_eq!(journal_size_limit, WAL_JOURNAL_SIZE_LIMIT_BYTES);
     }
 
     #[test]
@@ -551,6 +592,34 @@ mod tests {
 
         let status = set_journal_mode(&conn, JournalMode::Delete).expect("restore DELETE");
         assert_eq!(status.journal_mode, "delete");
+    }
+
+    #[test]
+    fn wal_truncate_checkpoint_reports_progress() {
+        let temp = tempfile::tempdir().expect("create temporary directory");
+        let path = temp.path().join("checkpoint.db");
+        let wal_path = temp.path().join("checkpoint.db-wal");
+        let conn = Connection::open(&path).expect("open database");
+        conn.execute_batch(
+            "CREATE TABLE records(value TEXT);
+             PRAGMA journal_mode=WAL;
+             INSERT INTO records VALUES ('committed');",
+        )
+        .expect("create WAL fixture");
+        assert!(
+            std::fs::metadata(&wal_path)
+                .expect("inspect populated WAL")
+                .len()
+                > 0
+        );
+
+        let result = checkpoint_wal_truncate(&conn).expect("run WAL checkpoint");
+        assert_eq!(result.busy, 0);
+        assert!(result.log_frames >= result.checkpointed_frames);
+        let wal_size_after = std::fs::metadata(&wal_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        assert_eq!(wal_size_after, 0);
     }
 
     #[test]

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -37,7 +37,9 @@ pub use derived_migration::*;
 pub use document_ref::STALE_DOCUMENT_REF_GENERATION;
 #[allow(unused_imports)]
 pub use image_io::{read_encrypted_image_as_base64, read_image_as_base64};
-pub(crate) use mode::{DatabaseModeEligibility, DatabaseModeMetadata};
+pub(crate) use mode::{
+    database_mode_policy_from_environment, DatabaseModeEligibility, DatabaseModeMetadata,
+};
 pub(crate) use policy::disk_totals_for_path;
 #[allow(unused_imports)]
 pub use semantic_cache::SEMANTIC_CACHE_IDLE_TTL;
@@ -81,6 +83,9 @@ pub struct StorageState {
     pub screenshot_dir: Mutex<PathBuf>,
     /// Credential manager state for encryption key management
     credential_state: Arc<CredentialManagerState>,
+    /// Journal mode selected once for this process. The default constructor
+    /// intentionally remains DELETE for tests and all non-experimental paths.
+    database_mode_policy: mode::DatabaseModePolicy,
     initialized: Mutex<bool>,
     migration_cancel_requested: AtomicBool,
     migration_in_progress: AtomicBool,
@@ -193,6 +198,14 @@ impl Drop for NamedConnectionGuard<'_> {
 
 impl StorageState {
     pub fn new(data_dir: PathBuf, credential_state: Arc<CredentialManagerState>) -> Self {
+        Self::new_with_mode_policy(data_dir, credential_state, mode::DatabaseModePolicy::Delete)
+    }
+
+    pub(crate) fn new_with_mode_policy(
+        data_dir: PathBuf,
+        credential_state: Arc<CredentialManagerState>,
+        database_mode_policy: mode::DatabaseModePolicy,
+    ) -> Self {
         let screenshot_dir = data_dir.join("screenshots");
 
         Self {
@@ -200,6 +213,7 @@ impl StorageState {
             data_dir: Mutex::new(data_dir),
             screenshot_dir: Mutex::new(screenshot_dir),
             credential_state,
+            database_mode_policy,
             initialized: Mutex::new(false),
             migration_cancel_requested: AtomicBool::new(false),
             migration_in_progress: AtomicBool::new(false),
@@ -408,6 +422,9 @@ impl StorageState {
     ) -> Result<connection::IndependentReadConnection, String> {
         let started = std::time::Instant::now();
         let activity = self.independent_db_activity.read(caller);
+        if !self.is_initialized() {
+            return Err("Database not initialized".to_string());
+        }
         let data_dir = self
             .data_dir
             .lock()
@@ -538,5 +555,15 @@ mod tests {
         assert!(storage
             .try_database_maintenance("test_maintenance_after_reader")
             .is_some());
+    }
+
+    #[test]
+    fn independent_read_connection_cannot_open_before_storage_initializes() {
+        let (_temp, storage) = test_storage();
+        let error = match storage.open_read_connection_named("read_before_initialize") {
+            Ok(_) => panic!("startup must publish storage before independent reads"),
+            Err(error) => error,
+        };
+        assert_eq!(error, "Database not initialized");
     }
 }

--- a/src-tauri/src/storage/mode.rs
+++ b/src-tauri/src/storage/mode.rs
@@ -18,6 +18,108 @@ const TRANSITION_FAILED: &str = "failed";
 const SAFETY_FREE_BYTES: u64 = 64 * 1024 * 1024;
 const SQLITE_JOURNAL_MODES: [&str; 6] = ["delete", "truncate", "persist", "memory", "wal", "off"];
 
+pub(crate) const WAL_EXPERIMENT_ENV: &str = "CARBONPAPER_WAL_EXPERIMENT";
+
+/// The journal mode selected once for the lifetime of a process.
+///
+/// DELETE is deliberately the only default. WAL is available solely to a
+/// debug build whose caller explicitly sets the experiment environment flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DatabaseModePolicy {
+    Delete,
+    Wal,
+}
+
+impl DatabaseModePolicy {
+    pub(crate) const fn target(self) -> JournalMode {
+        match self {
+            Self::Delete => JournalMode::Delete,
+            Self::Wal => JournalMode::Wal,
+        }
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        self.target().as_str()
+    }
+
+    pub(crate) const fn is_wal(self) -> bool {
+        matches!(self, Self::Wal)
+    }
+}
+
+/// Parse the developer opt-in independently of the compiled build mode.
+///
+/// Keeping the `debug_build` argument explicit makes the safety boundary
+/// testable without mutating the process environment or pretending a release
+/// binary is a development binary.
+pub(crate) fn parse_database_mode_policy(
+    raw_value: Option<&str>,
+    debug_build: bool,
+) -> Result<DatabaseModePolicy, String> {
+    let value = raw_value.map(str::trim).filter(|value| !value.is_empty());
+    if !debug_build {
+        return Ok(DatabaseModePolicy::Delete);
+    }
+
+    match value {
+        None | Some("0") => Ok(DatabaseModePolicy::Delete),
+        Some("1") => Ok(DatabaseModePolicy::Wal),
+        Some(value) => Err(format!(
+            "Invalid {WAL_EXPERIMENT_ENV} value '{value}'; expected 1 or 0"
+        )),
+    }
+}
+
+/// Resolve the startup policy once, before the `StorageState` is constructed.
+pub(crate) fn database_mode_policy_from_environment() -> Result<DatabaseModePolicy, String> {
+    let raw_value = std::env::var(WAL_EXPERIMENT_ENV).ok();
+    let policy = parse_database_mode_policy(raw_value.as_deref(), cfg!(debug_assertions))?;
+
+    if !cfg!(debug_assertions) {
+        if let Some(value) = raw_value
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        {
+            tracing::warn!(
+                "Ignoring {WAL_EXPERIMENT_ENV}={value} in a non-debug build; database mode remains DELETE"
+            );
+        }
+    }
+
+    Ok(policy)
+}
+
+const MODE_TABLE_SCHEMA: &str = r#"
+    CREATE TABLE IF NOT EXISTS database_mode_metadata (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        actual_journal_mode TEXT NOT NULL CHECK (
+            actual_journal_mode IN ('delete', 'truncate', 'persist', 'memory', 'wal', 'off')
+        ),
+        requested_journal_mode TEXT NOT NULL CHECK (
+            requested_journal_mode IN ('delete', 'truncate', 'persist', 'memory', 'wal', 'off')
+        ),
+        transition_state TEXT NOT NULL CHECK (
+            transition_state IN ('stable', 'transitioning', 'failed')
+        ),
+        transition_id TEXT,
+        previous_journal_mode TEXT CHECK (
+            previous_journal_mode IS NULL OR
+            previous_journal_mode IN ('delete', 'truncate', 'persist', 'memory', 'wal', 'off')
+        ),
+        last_error TEXT,
+        started_at TEXT,
+        completed_at TEXT,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+"#;
+
+/// Create the small mode ledger before any startup conversion can run.
+pub(crate) fn ensure_mode_table(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(MODE_TABLE_SCHEMA)
+        .map_err(|error| format!("Failed to initialize database mode metadata table: {error}"))
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct DatabaseModeMetadata {
     pub actual_journal_mode: String,
@@ -138,42 +240,58 @@ fn database_group_size(directory: &Path) -> u64 {
 
 fn evaluate_eligibility(
     current_mode: &str,
+    target_mode: &str,
     writable_result: Result<(), String>,
     local_filesystem: bool,
     available_free_bytes: Option<u64>,
     required_free_bytes: u64,
+    skip_stable_delete_checks: bool,
 ) -> DatabaseModeEligibility {
     let writable = writable_result.is_ok();
     let current = current_mode.trim().to_ascii_lowercase();
+    let target = target_mode.trim().to_ascii_lowercase();
     let free_ok = available_free_bytes
         .map(|free| free >= required_free_bytes)
         .unwrap_or(false);
+    let requires_filesystem_checks =
+        !(skip_stable_delete_checks && current == "delete" && target == "delete");
     let mut reasons = Vec::new();
-    if let Err(error) = writable_result {
-        reasons.push(error);
+    if requires_filesystem_checks {
+        if let Err(error) = writable_result {
+            reasons.push(error);
+        }
+        if !local_filesystem {
+            reasons.push("Database directory is on a non-local filesystem".to_string());
+        }
+        if available_free_bytes.is_none() {
+            reasons.push("Unable to determine free space on the database volume".to_string());
+        } else if !free_ok {
+            reasons.push(format!(
+                "Insufficient free space: required {required_free_bytes} bytes"
+            ));
+        }
     }
-    if !local_filesystem {
-        reasons.push("Database directory is on a non-local filesystem".to_string());
-    }
-    if available_free_bytes.is_none() {
-        reasons.push("Unable to determine free space on the database volume".to_string());
-    } else if !free_ok {
-        reasons.push(format!(
-            "Insufficient free space: required {required_free_bytes} bytes"
-        ));
-    }
-    let can_transition =
-        current == "delete" || (current == "wal" && writable && local_filesystem && free_ok);
-    if current == "delete" {
+
+    let checks_ok = !requires_filesystem_checks || (writable && local_filesystem && free_ok);
+    let can_transition = match (current.as_str(), target.as_str()) {
+        ("delete", "delete") => true,
+        ("delete", "wal") | ("wal", "delete") | ("wal", "wal") => checks_ok,
+        _ => false,
+    };
+
+    if current == target && current == "delete" {
         reasons.push("Database already uses DELETE journal mode".to_string());
-    } else if current != "wal" {
+    } else if !matches!(
+        (current.as_str(), target.as_str()),
+        ("delete", "delete") | ("delete", "wal") | ("wal", "delete") | ("wal", "wal")
+    ) {
         reasons.push(format!(
-            "Controlled transition only supports WAL, got {current}"
+            "Controlled startup transition only supports DELETE and WAL, got {current} -> {target}"
         ));
     }
     DatabaseModeEligibility {
         current_journal_mode: current,
-        target_journal_mode: "delete".to_string(),
+        target_journal_mode: target,
         writable_filesystem: writable,
         local_filesystem,
         available_free_bytes,
@@ -336,19 +454,226 @@ impl StorageState {
     fn database_mode_eligibility_under_maintenance(
         &self,
         current_mode: &str,
+        target_mode: &str,
+        skip_stable_delete_checks: bool,
     ) -> DatabaseModeEligibility {
         let data_dir = self
             .data_dir
             .lock()
             .unwrap_or_else(|error| error.into_inner())
             .clone();
-        let writable_result = writable_probe(&data_dir);
-        let local = is_local_filesystem(&data_dir);
+        let current = current_mode.trim().to_ascii_lowercase();
+        let target = target_mode.trim().to_ascii_lowercase();
+        // A DELETE database that is already the requested default needs no
+        // filesystem probe. Every conversion and every WAL startup still has
+        // to prove that the file group can be safely rewritten.
+        let requires_checks =
+            !(skip_stable_delete_checks && current == "delete" && target == "delete");
+        let writable_result = if requires_checks {
+            writable_probe(&data_dir)
+        } else {
+            Ok(())
+        };
+        let local = !requires_checks || is_local_filesystem(&data_dir);
         let required = database_group_size(&data_dir)
             .saturating_mul(2)
             .saturating_add(SAFETY_FREE_BYTES);
-        let available = disk_totals_for_path(&data_dir).map(|(_, free)| free);
-        evaluate_eligibility(current_mode, writable_result, local, available, required)
+        let available = if requires_checks {
+            disk_totals_for_path(&data_dir).map(|(_, free)| free)
+        } else {
+            None
+        };
+        evaluate_eligibility(
+            current_mode,
+            target_mode,
+            writable_result,
+            local,
+            available,
+            required,
+            skip_stable_delete_checks,
+        )
+    }
+
+    fn remove_wal_sidecars(&self) -> Result<(), String> {
+        let data_dir = self
+            .data_dir
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone();
+        for sidecar in ["screenshots.db-wal", "screenshots.db-shm"] {
+            let path = data_dir.join(sidecar);
+            match fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(format!(
+                        "Failed to remove obsolete WAL sidecar {}: {error}",
+                        path.display()
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Switch an already-open connection between the two supported modes and
+    /// verify SQLite's effective result before returning.
+    fn transition_connection_to_target(
+        &self,
+        connection: &Connection,
+        current_mode: &str,
+        target_mode: &str,
+    ) -> Result<connection::ConnectionStatus, String> {
+        match (current_mode, target_mode) {
+            ("delete", "wal") => connection::set_journal_mode(connection, JournalMode::Wal)
+                .map_err(|error| format!("Failed to switch SQLite journal mode to WAL: {error}")),
+            ("wal", "delete") => {
+                let checkpointed: i64 = connection
+                    .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get(0))
+                    .map_err(|error| {
+                        format!("Failed to checkpoint WAL before DELETE transition: {error}")
+                    })?;
+                if checkpointed != 0 {
+                    return Err(format!(
+                        "WAL checkpoint reported busy status {checkpointed}"
+                    ));
+                }
+                let status = connection::set_journal_mode(connection, JournalMode::Delete)
+                    .map_err(|error| {
+                        format!("Failed to switch SQLite journal mode to DELETE: {error}")
+                    })?;
+                if status.journal_mode != "delete" {
+                    return Err(format!(
+                        "SQLite retained journal mode {}",
+                        status.journal_mode
+                    ));
+                }
+                self.remove_wal_sidecars()?;
+                Ok(status)
+            }
+            _ => Err(format!(
+                "Controlled startup transition only supports DELETE and WAL, got {current_mode} -> {target_mode}"
+            )),
+        }
+    }
+
+    fn persist_transition_failure(
+        &self,
+        connection: &Connection,
+        current_mode: &str,
+        target_mode: &str,
+        id: &str,
+        started: &str,
+        error: &str,
+    ) -> Result<(), String> {
+        let actual_after = connection::inspect_connection(connection)
+            .map(|status| status.journal_mode)
+            .unwrap_or_else(|_| current_mode.to_string());
+        write_metadata(
+            connection,
+            &actual_after,
+            target_mode,
+            TRANSITION_FAILED,
+            Some(id),
+            Some(current_mode),
+            Some(error),
+            Some(started),
+            Some(&now_text()),
+        )
+    }
+
+    /// Apply the fixed process startup policy while the caller owns the
+    /// maintenance gate and before the primary connection is published.
+    pub(crate) fn apply_startup_database_mode(
+        &self,
+        connection: &Connection,
+        current_status: &connection::ConnectionStatus,
+    ) -> Result<connection::ConnectionStatus, String> {
+        let current = normalize_mode(&current_status.journal_mode)?;
+        let target = self.database_mode_policy.as_str();
+        let eligibility = self.database_mode_eligibility_under_maintenance(&current, target, true);
+        if !eligibility.can_transition {
+            let id = transition_id();
+            let started = now_text();
+            let error = format!(
+                "Database is not eligible for startup journal mode {target}: {}",
+                eligibility.reasons.join("; ")
+            );
+            if let Err(metadata_error) =
+                self.persist_transition_failure(connection, &current, target, &id, &started, &error)
+            {
+                return Err(format!(
+                    "{error}; failed to persist transition failure: {metadata_error}"
+                ));
+            }
+            return Err(error);
+        }
+
+        if current == target {
+            if target == JournalMode::Delete.as_str() {
+                // A prior conversion may have reached DELETE just before its
+                // sidecar cleanup was interrupted. DELETE-mode startup owns
+                // that cleanup boundary, so stale WAL files cannot survive
+                // merely because SQLite already reports the target mode.
+                self.remove_wal_sidecars()?;
+            }
+            write_metadata(
+                connection,
+                &current,
+                target,
+                TRANSITION_STABLE,
+                None,
+                None,
+                None,
+                None,
+                Some(&now_text()),
+            )?;
+            return connection::inspect_connection(connection).map_err(|error| {
+                format!("Failed to verify startup journal mode {target}: {error}")
+            });
+        }
+
+        let id = transition_id();
+        let started = now_text();
+        write_metadata(
+            connection,
+            &current,
+            target,
+            TRANSITIONING,
+            Some(&id),
+            Some(&current),
+            None,
+            Some(&started),
+            None,
+        )?;
+
+        let transition_result = self.transition_connection_to_target(connection, &current, target);
+        match transition_result {
+            Ok(status) => {
+                write_metadata(
+                    connection,
+                    &status.journal_mode,
+                    target,
+                    TRANSITION_STABLE,
+                    None,
+                    Some(&current),
+                    None,
+                    Some(&started),
+                    Some(&now_text()),
+                )?;
+                Ok(status)
+            }
+            Err(error) => {
+                if let Err(metadata_error) = self
+                    .persist_transition_failure(connection, &current, target, &id, &started, &error)
+                {
+                    return Err(format!(
+                        "{error}; failed to persist transition failure: {metadata_error}"
+                    ));
+                }
+                Err(error)
+            }
+        }
     }
 
     pub(crate) fn check_database_mode_eligibility(
@@ -361,7 +686,7 @@ impl StorageState {
             .ok_or_else(|| "Database not initialized".to_string())?;
         let status = connection::inspect_connection(connection)
             .map_err(|error| format!("Failed to inspect database journal mode: {error}"))?;
-        Ok(self.database_mode_eligibility_under_maintenance(&status.journal_mode))
+        Ok(self.database_mode_eligibility_under_maintenance(&status.journal_mode, "delete", false))
     }
 
     pub(crate) fn transition_wal_to_delete(&self) -> Result<DatabaseModeMetadata, String> {
@@ -392,7 +717,8 @@ impl StorageState {
                 "Controlled transition only supports WAL, got {current}"
             ));
         }
-        let eligibility = self.database_mode_eligibility_under_maintenance(&current);
+        let eligibility =
+            self.database_mode_eligibility_under_maintenance(&current, "delete", false);
         if !eligibility.can_transition {
             return Err(format!(
                 "Database is not eligible for WAL to DELETE transition: {}",
@@ -414,43 +740,7 @@ impl StorageState {
             None,
         )?;
         let transition_result = (|| {
-            let checkpointed: i64 = connection
-                .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get(0))
-                .map_err(|error| format!("Failed to checkpoint WAL before transition: {error}"))?;
-            if checkpointed != 0 {
-                return Err(format!(
-                    "WAL checkpoint reported busy status {checkpointed}"
-                ));
-            }
-            connection::set_journal_mode(connection, JournalMode::Delete).map_err(|error| {
-                format!("Failed to switch SQLite journal mode to DELETE: {error}")
-            })?;
-            let final_status = connection::inspect_connection(connection)
-                .map_err(|error| format!("Failed to verify DELETE journal mode: {error}"))?;
-            if final_status.journal_mode != "delete" {
-                return Err(format!(
-                    "SQLite retained journal mode {}",
-                    final_status.journal_mode
-                ));
-            }
-            let data_dir = self
-                .data_dir
-                .lock()
-                .unwrap_or_else(|error| error.into_inner())
-                .clone();
-            for sidecar in ["screenshots.db-wal", "screenshots.db-shm"] {
-                let path = data_dir.join(sidecar);
-                match fs::remove_file(&path) {
-                    Ok(()) => {}
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(error) => {
-                        return Err(format!(
-                            "Failed to remove obsolete WAL sidecar {}: {error}",
-                            path.display()
-                        ));
-                    }
-                }
-            }
+            self.transition_connection_to_target(connection, "wal", "delete")?;
             write_metadata(
                 connection,
                 "delete",
@@ -467,22 +757,9 @@ impl StorageState {
         match transition_result {
             Ok(metadata) => Ok(metadata),
             Err(error) => {
-                let actual_after = connection::inspect_connection(connection)
-                    .map(|status| status.journal_mode)
-                    .unwrap_or_else(|_| current.clone());
-                let metadata_error = write_metadata(
-                    connection,
-                    &actual_after,
-                    "delete",
-                    TRANSITION_FAILED,
-                    Some(&id),
-                    Some("wal"),
-                    Some(&error),
-                    Some(&started),
-                    Some(&now_text()),
-                )
-                .err();
-                if let Some(metadata_error) = metadata_error {
+                if let Err(metadata_error) = self.persist_transition_failure(
+                    connection, &current, "delete", &id, &started, &error,
+                ) {
                     Err(format!(
                         "{error}; failed to persist transition failure: {metadata_error}"
                     ))
@@ -500,6 +777,27 @@ mod tests {
     use crate::credential_manager::CredentialManagerState;
     use std::sync::Arc;
     use tempfile::tempdir;
+
+    #[test]
+    fn database_mode_policy_requires_an_explicit_debug_opt_in() {
+        assert_eq!(
+            parse_database_mode_policy(None, true).unwrap(),
+            DatabaseModePolicy::Delete
+        );
+        assert_eq!(
+            parse_database_mode_policy(Some("0"), true).unwrap(),
+            DatabaseModePolicy::Delete
+        );
+        assert_eq!(
+            parse_database_mode_policy(Some(" 1 "), true).unwrap(),
+            DatabaseModePolicy::Wal
+        );
+        assert!(parse_database_mode_policy(Some("true"), true).is_err());
+        assert_eq!(
+            parse_database_mode_policy(Some("1"), false).unwrap(),
+            DatabaseModePolicy::Delete
+        );
+    }
 
     fn create_mode_table(conn: &Connection) {
         conn.execute_batch(
@@ -633,17 +931,19 @@ mod tests {
     fn eligibility_reports_wal_requirements_without_touching_sqlite() {
         let eligibility = evaluate_eligibility(
             "wal",
+            "delete",
             Ok(()),
             true,
             Some(128 * 1024 * 1024),
             64 * 1024 * 1024,
+            false,
         );
         assert!(eligibility.can_transition);
         assert!(eligibility.writable_filesystem);
         assert!(eligibility.local_filesystem);
         assert!(eligibility.reasons.is_empty());
 
-        let insufficient = evaluate_eligibility("wal", Ok(()), true, Some(1), 64);
+        let insufficient = evaluate_eligibility("wal", "delete", Ok(()), true, Some(1), 64, false);
         assert!(!insufficient.can_transition);
         assert!(insufficient
             .reasons
@@ -652,15 +952,92 @@ mod tests {
 
         let unavailable = evaluate_eligibility(
             "wal",
+            "delete",
             Err("Filesystem is not writable".into()),
             false,
             None,
             64,
+            false,
         );
         assert!(!unavailable.can_transition);
         assert!(!unavailable.writable_filesystem);
         assert!(!unavailable.local_filesystem);
         assert!(unavailable.reasons.len() >= 3);
+    }
+
+    #[test]
+    fn wal_startup_conversion_records_stable_mode_before_publish() {
+        let temp = tempdir().unwrap();
+        let credential = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        crate::credential_manager::save_public_key_to_file(&credential, b"wal-startup-key")
+            .unwrap();
+        let storage = StorageState::new_with_mode_policy(
+            temp.path().to_path_buf(),
+            credential,
+            DatabaseModePolicy::Wal,
+        );
+
+        storage.initialize().unwrap();
+
+        let metadata = storage.database_mode_metadata().unwrap();
+        assert_eq!(metadata.actual_journal_mode, "wal");
+        assert_eq!(metadata.requested_journal_mode, "wal");
+        assert_eq!(metadata.transition_state, TRANSITION_STABLE);
+        let read = storage
+            .open_read_connection_named("wal_startup_mode_read")
+            .unwrap();
+        let status = connection::inspect_connection(&read).unwrap();
+        assert_eq!(status.journal_mode, "wal");
+    }
+
+    #[test]
+    fn delete_startup_policy_reverts_an_existing_wal_database() {
+        let temp = tempdir().unwrap();
+        let credential = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        crate::credential_manager::save_public_key_to_file(&credential, b"wal-revert-key").unwrap();
+        let wal_storage = StorageState::new_with_mode_policy(
+            temp.path().to_path_buf(),
+            credential.clone(),
+            DatabaseModePolicy::Wal,
+        );
+        wal_storage.initialize().unwrap();
+        {
+            let guard = wal_storage.get_connection_named("wal_revert_seed").unwrap();
+            guard
+                .as_ref()
+                .unwrap()
+                .execute(
+                    "INSERT INTO app_metadata(key, value) VALUES ('wal-revert', 'preserved')",
+                    [],
+                )
+                .unwrap();
+        }
+        wal_storage.shutdown().unwrap();
+
+        let delete_storage = StorageState::new_with_mode_policy(
+            temp.path().to_path_buf(),
+            credential,
+            DatabaseModePolicy::Delete,
+        );
+        delete_storage.initialize().unwrap();
+        let metadata = delete_storage.database_mode_metadata().unwrap();
+        assert_eq!(metadata.actual_journal_mode, "delete");
+        assert_eq!(metadata.requested_journal_mode, "delete");
+        let guard = delete_storage
+            .get_connection_named("wal_revert_verify")
+            .unwrap();
+        let value: String = guard
+            .as_ref()
+            .unwrap()
+            .query_row(
+                "SELECT value FROM app_metadata WHERE key = 'wal-revert'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(value, "preserved");
+        assert!(!temp.path().join("screenshots.db-wal").exists());
+        assert!(!temp.path().join("screenshots.db-shm").exists());
     }
 
     #[test]

--- a/src-tauri/src/storage/mode.rs
+++ b/src-tauri/src/storage/mode.rs
@@ -533,14 +533,15 @@ impl StorageState {
             ("delete", "wal") => connection::set_journal_mode(connection, JournalMode::Wal)
                 .map_err(|error| format!("Failed to switch SQLite journal mode to WAL: {error}")),
             ("wal", "delete") => {
-                let checkpointed: i64 = connection
-                    .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get(0))
-                    .map_err(|error| {
-                        format!("Failed to checkpoint WAL before DELETE transition: {error}")
-                    })?;
-                if checkpointed != 0 {
+                let checkpoint = connection::checkpoint_wal_truncate(connection).map_err(|error| {
+                    format!("Failed to checkpoint WAL before DELETE transition: {error}")
+                })?;
+                if checkpoint.busy != 0 {
                     return Err(format!(
-                        "WAL checkpoint reported busy status {checkpointed}"
+                        "WAL checkpoint reported busy status {} (log_frames={}, checkpointed_frames={})",
+                        checkpoint.busy,
+                        checkpoint.log_frames,
+                        checkpoint.checkpointed_frames
                     ));
                 }
                 let status = connection::set_journal_mode(connection, JournalMode::Delete)

--- a/src-tauri/src/storage/mode.rs
+++ b/src-tauri/src/storage/mode.rs
@@ -166,6 +166,13 @@ fn normalize_mode(mode: &str) -> Result<String, String> {
     }
 }
 
+fn is_supported_mode_conversion(current_mode: &str, target_mode: &str) -> bool {
+    matches!(
+        (current_mode, target_mode),
+        ("delete", "wal") | ("wal", "delete")
+    )
+}
+
 #[cfg(windows)]
 fn is_local_filesystem(path: &Path) -> bool {
     use std::os::windows::ffi::OsStrExt;
@@ -245,16 +252,16 @@ fn evaluate_eligibility(
     local_filesystem: bool,
     available_free_bytes: Option<u64>,
     required_free_bytes: u64,
-    skip_stable_delete_checks: bool,
+    skip_startup_noop_checks: bool,
 ) -> DatabaseModeEligibility {
     let writable = writable_result.is_ok();
     let current = current_mode.trim().to_ascii_lowercase();
     let target = target_mode.trim().to_ascii_lowercase();
+    let same_mode = current == target;
     let free_ok = available_free_bytes
         .map(|free| free >= required_free_bytes)
         .unwrap_or(false);
-    let requires_filesystem_checks =
-        !(skip_stable_delete_checks && current == "delete" && target == "delete");
+    let requires_filesystem_checks = !(skip_startup_noop_checks && same_mode);
     let mut reasons = Vec::new();
     if requires_filesystem_checks {
         if let Err(error) = writable_result {
@@ -274,8 +281,8 @@ fn evaluate_eligibility(
 
     let checks_ok = !requires_filesystem_checks || (writable && local_filesystem && free_ok);
     let can_transition = match (current.as_str(), target.as_str()) {
-        ("delete", "delete") => true,
-        ("delete", "wal") | ("wal", "delete") | ("wal", "wal") => checks_ok,
+        ("delete", "delete") | ("wal", "wal") => true,
+        ("delete", "wal") | ("wal", "delete") => checks_ok,
         _ => false,
     };
 
@@ -455,7 +462,7 @@ impl StorageState {
         &self,
         current_mode: &str,
         target_mode: &str,
-        skip_stable_delete_checks: bool,
+        skip_startup_noop_checks: bool,
     ) -> DatabaseModeEligibility {
         let data_dir = self
             .data_dir
@@ -464,11 +471,9 @@ impl StorageState {
             .clone();
         let current = current_mode.trim().to_ascii_lowercase();
         let target = target_mode.trim().to_ascii_lowercase();
-        // A DELETE database that is already the requested default needs no
-        // filesystem probe. Every conversion and every WAL startup still has
-        // to prove that the file group can be safely rewritten.
-        let requires_checks =
-            !(skip_stable_delete_checks && current == "delete" && target == "delete");
+        // A startup no-op does not rewrite the database file group. Actual
+        // DELETE/WAL conversions still need the full filesystem preflight.
+        let requires_checks = !(skip_startup_noop_checks && current == target);
         let writable_result = if requires_checks {
             writable_probe(&data_dir)
         } else {
@@ -490,7 +495,7 @@ impl StorageState {
             local,
             available,
             required,
-            skip_stable_delete_checks,
+            skip_startup_noop_checks,
         )
     }
 
@@ -582,8 +587,50 @@ impl StorageState {
         )
     }
 
+    /// Keep startup available when an optional journal-mode conversion cannot
+    /// be completed. The effective mode is re-read because a conversion may
+    /// have changed SQLite's mode before a later cleanup step failed.
+    fn defer_startup_transition(
+        &self,
+        connection: &Connection,
+        current_status: &connection::ConnectionStatus,
+        current_mode: &str,
+        target_mode: &str,
+        id: &str,
+        started: &str,
+        error: &str,
+    ) -> Result<connection::ConnectionStatus, String> {
+        let effective_status =
+            connection::inspect_connection(connection).unwrap_or_else(|_| current_status.clone());
+        if let Err(metadata_error) = self.persist_transition_failure(
+            connection,
+            current_mode,
+            target_mode,
+            id,
+            started,
+            error,
+        ) {
+            tracing::warn!(
+                "Failed to persist deferred startup journal mode transition {} -> {}: {}",
+                current_mode,
+                target_mode,
+                metadata_error
+            );
+        }
+        tracing::warn!(
+            "Deferring startup journal mode transition {} -> {}; continuing with {}: {}",
+            current_mode,
+            target_mode,
+            effective_status.journal_mode,
+            error
+        );
+        Ok(effective_status)
+    }
+
     /// Apply the fixed process startup policy while the caller owns the
-    /// maintenance gate and before the primary connection is published.
+    /// maintenance gate and before the primary connection is published. A
+    /// supported conversion is best-effort so low disk space cannot make an
+    /// already-open database permanently unavailable at startup.
     pub(crate) fn apply_startup_database_mode(
         &self,
         connection: &Connection,
@@ -599,6 +646,17 @@ impl StorageState {
                 "Database is not eligible for startup journal mode {target}: {}",
                 eligibility.reasons.join("; ")
             );
+            if is_supported_mode_conversion(&current, target) {
+                return self.defer_startup_transition(
+                    connection,
+                    current_status,
+                    &current,
+                    target,
+                    &id,
+                    &started,
+                    &error,
+                );
+            }
             if let Err(metadata_error) =
                 self.persist_transition_failure(connection, &current, target, &id, &started, &error)
             {
@@ -664,6 +722,17 @@ impl StorageState {
                 Ok(status)
             }
             Err(error) => {
+                if is_supported_mode_conversion(&current, target) {
+                    return self.defer_startup_transition(
+                        connection,
+                        current_status,
+                        &current,
+                        target,
+                        &id,
+                        &started,
+                        &error,
+                    );
+                }
                 if let Err(metadata_error) = self
                     .persist_transition_failure(connection, &current, target, &id, &started, &error)
                 {
@@ -963,6 +1032,55 @@ mod tests {
         assert!(!unavailable.writable_filesystem);
         assert!(!unavailable.local_filesystem);
         assert!(unavailable.reasons.len() >= 3);
+    }
+
+    #[test]
+    fn same_mode_wal_startup_does_not_require_conversion_space() {
+        let eligibility = evaluate_eligibility(
+            "wal",
+            "wal",
+            Err("Filesystem is not writable".into()),
+            false,
+            Some(1),
+            64,
+            true,
+        );
+
+        assert!(eligibility.can_transition);
+        assert!(eligibility.reasons.is_empty());
+    }
+
+    #[test]
+    fn deferred_startup_transition_keeps_effective_mode_and_records_failure() {
+        let temp = tempdir().unwrap();
+        let credential = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        let storage = StorageState::new(temp.path().to_path_buf(), credential);
+        let connection = Connection::open(temp.path().join("deferred-transition.db")).unwrap();
+        let current_status = connection::set_journal_mode(&connection, JournalMode::Wal).unwrap();
+        ensure_mode_table(&connection).unwrap();
+
+        let status = storage
+            .defer_startup_transition(
+                &connection,
+                &current_status,
+                "wal",
+                "delete",
+                "deferred-test",
+                "started",
+                "Insufficient free space: test",
+            )
+            .unwrap();
+
+        assert_eq!(status.journal_mode, "wal");
+        let metadata = read_metadata(&connection).unwrap();
+        assert_eq!(metadata.actual_journal_mode, "wal");
+        assert_eq!(metadata.requested_journal_mode, "delete");
+        assert_eq!(metadata.transition_state, TRANSITION_FAILED);
+        assert!(metadata
+            .last_error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Insufficient free space"));
     }
 
     #[test]

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -74,8 +74,9 @@ impl StorageState {
         let pragma_dur = t2.elapsed();
 
         // The mode ledger must exist before a startup conversion can record a
-        // transitioning or failed result. No primary or read-only connection
-        // is published until this policy has completed and been verified.
+        // transitioning or failed result. A supported conversion may be
+        // deferred, but no primary or read-only connection is published until
+        // the effective journal mode has been verified.
         mode::ensure_mode_table(&conn)?;
         let connection_status = self.apply_startup_database_mode(&conn, &connection_status)?;
 

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -4,8 +4,10 @@ use crate::credential_manager::{
     derive_db_key_from_public_key, get_cached_public_key, load_public_key_from_file,
 };
 use rusqlite::{params, Connection};
+use std::path::Path;
 use std::sync::atomic::Ordering;
 
+use super::policy::disk_totals_for_path;
 use super::{connection, database_snapshot, mode, StorageState};
 
 impl StorageState {
@@ -73,6 +75,11 @@ impl StorageState {
             .map_err(|e| format!("Failed to configure database connection: {}", e))?;
         let pragma_dur = t2.elapsed();
 
+        // Set the auto-vacuum capability before creating the first table. New
+        // databases then start in incremental mode and do not need a full
+        // VACUUM just to materialize the pointer-map pages.
+        Self::set_auto_vacuum_incremental(&conn)?;
+
         // The mode ledger must exist before a startup conversion can record a
         // transitioning or failed result. A supported conversion may be
         // deferred, but no primary or read-only connection is published until
@@ -85,7 +92,9 @@ impl StorageState {
         self.init_tables(&conn)?;
         self.initialize_database_mode_metadata(&conn, &connection_status.journal_mode)?;
         self.cleanup_derived_index_sidecars_at_startup(&conn, &data_dir)?;
-        Self::set_auto_vacuum_incremental(&conn)?;
+        if let Err(error) = self.trim_oversized_wal_under_maintenance(&conn) {
+            tracing::warn!("[DB] Deferring oversized WAL cleanup at startup: {error}");
+        }
         database_snapshot::mark_storage_initialized(&data_dir)?;
         let tables_dur = t3.elapsed();
 
@@ -779,22 +788,163 @@ impl StorageState {
         Ok(())
     }
 
+    const VACUUM_SAFETY_FREE_BYTES: u64 = 64 * 1024 * 1024;
+
+    fn database_runtime_group_size(data_dir: &Path) -> u64 {
+        [
+            "screenshots.db",
+            "screenshots.db-wal",
+            "screenshots.db-shm",
+            "screenshots.db-journal",
+        ]
+        .iter()
+        .filter_map(|name| std::fs::metadata(data_dir.join(name)).ok())
+        .map(|metadata| metadata.len())
+        .sum()
+    }
+
+    fn vacuum_space_check(&self) -> Result<(), String> {
+        let data_dir = self
+            .data_dir
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone();
+        let group_size = Self::database_runtime_group_size(&data_dir);
+        let required = group_size
+            .saturating_mul(2)
+            .saturating_add(Self::VACUUM_SAFETY_FREE_BYTES);
+        let available = disk_totals_for_path(&data_dir)
+            .map(|(_, free)| free)
+            .ok_or_else(|| {
+                format!(
+                    "Unable to determine free space on the database volume; full VACUUM requires at least {} bytes",
+                    required
+                )
+            })?;
+        if available < required {
+            return Err(format!(
+                "Insufficient free space for full VACUUM: available={} required={} database_group_size={}",
+                available, required, group_size
+            ));
+        }
+        Ok(())
+    }
+
     fn set_auto_vacuum_incremental(conn: &Connection) -> Result<(), String> {
         conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL;")
             .map_err(|e| format!("Failed to set PRAGMA auto_vacuum=INCREMENTAL: {}", e))
     }
 
+    fn auto_vacuum_mode(conn: &Connection) -> Result<i64, String> {
+        conn.pragma_query_value(None, "auto_vacuum", |row| row.get(0))
+            .map_err(|e| format!("Failed to read PRAGMA auto_vacuum: {}", e))
+    }
+
     fn is_startup_vacuum_pending(conn: &Connection) -> Result<bool, String> {
-        let mode: i64 = conn
-            .pragma_query_value(None, "auto_vacuum", |row| row.get(0))
-            .map_err(|e| format!("Failed to read PRAGMA auto_vacuum: {}", e))?;
-        Ok(mode != 2)
+        Ok(Self::auto_vacuum_mode(conn)? != 2)
+    }
+
+    fn startup_vacuum_allowed(&self, conn: &Connection) -> Result<bool, String> {
+        let status = connection::inspect_connection(conn).map_err(|error| {
+            format!("Failed to inspect database before startup VACUUM: {error}")
+        })?;
+        let target_mode = self.database_mode_policy.as_str();
+        if status.journal_mode != target_mode {
+            tracing::warn!(
+                "[DB] Deferring startup auto-vacuum conversion because journal mode is '{}' while policy target is '{}'",
+                status.journal_mode,
+                target_mode
+            );
+            return Ok(false);
+        }
+        if !Self::is_startup_vacuum_pending(conn)? {
+            return Ok(false);
+        }
+        if let Err(error) = self.vacuum_space_check() {
+            tracing::warn!("[DB] Deferring startup auto-vacuum conversion: {error}");
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
+    fn checkpoint_wal_after_vacuum(conn: &Connection) -> Result<(), String> {
+        let status = connection::inspect_connection(conn)
+            .map_err(|error| format!("Failed to inspect journal mode after VACUUM: {error}"))?;
+        if status.journal_mode != "wal" {
+            return Ok(());
+        }
+
+        let checkpoint = connection::checkpoint_wal_truncate(conn)?;
+        if checkpoint.busy != 0 {
+            return Err(format!(
+                "WAL TRUNCATE checkpoint after VACUUM was busy: status={}, log_frames={}, checkpointed_frames={}",
+                checkpoint.busy, checkpoint.log_frames, checkpoint.checkpointed_frames
+            ));
+        }
+        tracing::info!(
+            "[DB] WAL TRUNCATE checkpoint after VACUUM completed: log_frames={}, checkpointed_frames={}",
+            checkpoint.log_frames,
+            checkpoint.checkpointed_frames
+        );
+        Ok(())
+    }
+
+    /// Reclaim an oversized reusable WAL allocation while initialization holds
+    /// the exclusive database maintenance permit.
+    fn trim_oversized_wal_under_maintenance(&self, conn: &Connection) -> Result<(), String> {
+        let status = connection::inspect_connection(conn)
+            .map_err(|error| format!("Failed to inspect journal mode for WAL cleanup: {error}"))?;
+        if status.journal_mode != "wal" {
+            return Ok(());
+        }
+
+        let data_dir = self
+            .data_dir
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone();
+        let wal_path = data_dir.join("screenshots.db-wal");
+        let wal_size = match std::fs::metadata(&wal_path) {
+            Ok(metadata) => metadata.len(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(format!(
+                    "Failed to inspect WAL sidecar {}: {error}",
+                    wal_path.display()
+                ));
+            }
+        };
+        let limit = connection::WAL_JOURNAL_SIZE_LIMIT_BYTES as u64;
+        if wal_size <= limit {
+            return Ok(());
+        }
+
+        let checkpoint = connection::checkpoint_wal_truncate(conn)?;
+        if checkpoint.busy != 0 {
+            tracing::warn!(
+                "[DB] WAL sidecar remains oversized after a busy checkpoint: bytes={}, limit={}, status={}, log_frames={}, checkpointed_frames={}",
+                wal_size,
+                limit,
+                checkpoint.busy,
+                checkpoint.log_frames,
+                checkpoint.checkpointed_frames
+            );
+            return Ok(());
+        }
+        tracing::info!(
+            "[DB] Truncated oversized WAL sidecar: previous_bytes={}, limit={}, log_frames={}, checkpointed_frames={}",
+            wal_size,
+            limit,
+            checkpoint.log_frames,
+            checkpoint.checkpointed_frames
+        );
+        Ok(())
     }
 
     pub fn check_startup_vacuum_needed(&self) -> Result<bool, String> {
         let guard = self.get_connection_named("startup_vacuum_check")?;
         let conn = guard.as_ref().unwrap();
-        Self::is_startup_vacuum_pending(conn)
+        self.startup_vacuum_allowed(conn)
     }
 
     pub fn is_mcp_privacy_acknowledged(&self) -> Result<bool, String> {
@@ -837,7 +987,7 @@ impl StorageState {
             let conn = guard.as_ref().unwrap();
             Self::set_auto_vacuum_incremental(conn)?;
 
-            if !Self::is_startup_vacuum_pending(conn)? {
+            if !self.startup_vacuum_allowed(conn)? {
                 return Ok(false);
             }
 
@@ -850,6 +1000,18 @@ impl StorageState {
                     e
                 )
             })?;
+            let mode_after = Self::auto_vacuum_mode(conn)?;
+            if mode_after != 2 {
+                return Err(format!(
+                    "Full VACUUM completed but PRAGMA auto_vacuum remained {} instead of INCREMENTAL",
+                    mode_after
+                ));
+            }
+            if let Err(error) = Self::checkpoint_wal_after_vacuum(conn) {
+                tracing::warn!(
+                    "[DB] Incremental auto-vacuum conversion completed, but WAL cleanup was deferred: {error}"
+                );
+            }
 
             Ok(true)
         })();
@@ -875,10 +1037,16 @@ impl StorageState {
             let guard = self.get_connection_named("manual_vacuum_run")?;
             let conn = guard.as_ref().unwrap();
             Self::set_auto_vacuum_incremental(conn)?;
+            self.vacuum_space_check()?;
 
             tracing::info!("[DB] Manual VACUUM started from settings");
             conn.execute_batch("VACUUM;")
                 .map_err(|e| format!("Failed to run manual VACUUM: {}", e))?;
+            if let Err(error) = Self::checkpoint_wal_after_vacuum(conn) {
+                tracing::warn!(
+                    "[DB] Manual VACUUM completed, but WAL cleanup was deferred: {error}"
+                );
+            }
 
             Ok(())
         })();
@@ -1544,6 +1712,38 @@ mod tests {
             .expect("create schema after setting auto-vacuum");
 
         assert!(!StorageState::is_startup_vacuum_pending(&conn).expect("inspect auto-vacuum mode"));
+    }
+
+    #[test]
+    fn fresh_wal_database_starts_incremental_without_a_full_vacuum() {
+        let temp = tempfile::tempdir().expect("temp storage directory");
+        let credential = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        crate::credential_manager::save_public_key_to_file(
+            &credential,
+            b"fresh-incremental-wal-key",
+        )
+        .expect("save public key");
+        let storage = StorageState::new_with_mode_policy(
+            temp.path().to_path_buf(),
+            credential,
+            mode::DatabaseModePolicy::Wal,
+        );
+
+        storage.initialize().expect("initialize WAL database");
+
+        let guard = storage
+            .get_connection_named("fresh_wal_auto_vacuum_test")
+            .expect("open primary connection");
+        let conn = guard.as_ref().expect("primary connection exists");
+        assert_eq!(StorageState::auto_vacuum_mode(conn).unwrap(), 2);
+        assert_eq!(
+            connection::inspect_connection(conn).unwrap().journal_mode,
+            "wal"
+        );
+        drop(guard);
+        assert!(!storage
+            .check_startup_vacuum_needed()
+            .expect("check startup vacuum"));
     }
 
     /// The upgrade path a released install actually takes: MiniLM-named tables

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -6,7 +6,7 @@ use crate::credential_manager::{
 use rusqlite::{params, Connection};
 use std::sync::atomic::Ordering;
 
-use super::{connection, database_snapshot, StorageState};
+use super::{connection, database_snapshot, mode, StorageState};
 
 impl StorageState {
     const MCP_PRIVACY_ACKNOWLEDGED_KEY: &'static str = "mcp_privacy_acknowledged";
@@ -67,12 +67,17 @@ impl StorageState {
         let open_dur = t1.elapsed();
 
         // Set the SQLCipher key, verify it, and apply shared connection-local
-        // policy. The helper intentionally leaves journal mode unchanged;
-        // V1 remains on the existing DELETE default.
+        // policy before changing the persistent journal mode.
         let t2 = std::time::Instant::now();
         let connection_status = connection::configure_sqlcipher_connection(&conn, &db_key)
             .map_err(|e| format!("Failed to configure database connection: {}", e))?;
         let pragma_dur = t2.elapsed();
+
+        // The mode ledger must exist before a startup conversion can record a
+        // transitioning or failed result. No primary or read-only connection
+        // is published until this policy has completed and been verified.
+        mode::ensure_mode_table(&conn)?;
+        let connection_status = self.apply_startup_database_mode(&conn, &connection_status)?;
 
         // Initialize table schema
         let t3 = std::time::Instant::now();
@@ -109,15 +114,18 @@ impl StorageState {
         *initialized = true;
 
         tracing::info!(
-            "[DIAG:INIT] SQLCipher initialized in {:?} (key_derive={:?}, db_open={:?}, pragma={:?}, sqlite_version={}, sqlite_source_id={}, cipher_version={}, journal_mode={}, synchronous={}, init_tables={:?})",
+            "[DIAG:INIT] SQLCipher initialized in {:?} (app_version={}, key_derive={:?}, db_open={:?}, pragma={:?}, requested_journal_mode={}, journal_mode={}, wal_experiment={}, sqlite_version={}, sqlite_source_id={}, cipher_version={}, synchronous={}, init_tables={:?})",
             init_start.elapsed(),
+            env!("CARGO_PKG_VERSION"),
             key_derive_dur,
             open_dur,
             pragma_dur,
+            self.database_mode_policy.as_str(),
+            connection_status.journal_mode,
+            self.database_mode_policy.is_wal(),
             connection_status.engine.sqlite_version,
             connection_status.engine.sqlite_source_id,
             connection_status.engine.cipher_version,
-            connection_status.journal_mode,
             connection_status.synchronous,
             tables_dur
         );
@@ -160,6 +168,7 @@ impl StorageState {
         // create the new empty tables first and leave the legacy rows stranded
         // under the old names.
         Self::upgrade_migration_tables_to_derived(conn)?;
+        mode::ensure_mode_table(conn)?;
 
         conn.execute_batch(
             r#"
@@ -716,32 +725,6 @@ impl StorageState {
                 key TEXT PRIMARY KEY,
                 value TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            );
-
-            -- Persist the effective SQLite journal mode and the last
-            -- controlled-transition outcome.  The row is deliberately kept
-            -- in the authoritative database so a restart can diagnose an
-            -- interrupted WAL-to-DELETE request without relying on sidecars.
-            CREATE TABLE IF NOT EXISTS database_mode_metadata (
-                id INTEGER PRIMARY KEY CHECK (id = 1),
-                actual_journal_mode TEXT NOT NULL CHECK (
-                    actual_journal_mode IN ('delete', 'truncate', 'persist', 'memory', 'wal', 'off')
-                ),
-                requested_journal_mode TEXT NOT NULL CHECK (
-                    requested_journal_mode IN ('delete', 'truncate', 'persist', 'memory', 'wal', 'off')
-                ),
-                transition_state TEXT NOT NULL CHECK (
-                    transition_state IN ('stable', 'transitioning', 'failed')
-                ),
-                transition_id TEXT,
-                previous_journal_mode TEXT CHECK (
-                    previous_journal_mode IS NULL OR
-                    previous_journal_mode IN ('delete', 'truncate', 'persist', 'memory', 'wal', 'off')
-                ),
-                last_error TEXT,
-                started_at TEXT,
-                completed_at TEXT,
-                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
 
             -- One durable row per automatic background task. The scheduler

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -779,37 +779,22 @@ impl StorageState {
         Ok(())
     }
 
-    const AUTO_VACUUM_SENTINEL_PREFIX: &'static str = "auto_vacuum_incremental_done_v";
-
-    fn startup_vacuum_sentinel_key() -> String {
-        format!(
-            "{}{}",
-            Self::AUTO_VACUUM_SENTINEL_PREFIX,
-            env!("CARGO_PKG_VERSION")
-        )
-    }
-
     fn set_auto_vacuum_incremental(conn: &Connection) -> Result<(), String> {
         conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL;")
             .map_err(|e| format!("Failed to set PRAGMA auto_vacuum=INCREMENTAL: {}", e))
     }
 
-    fn is_startup_vacuum_pending(conn: &Connection) -> bool {
-        let sentinel_key = Self::startup_vacuum_sentinel_key();
-        let done: bool = conn
-            .query_row(
-                "SELECT 1 FROM app_metadata WHERE key = ?1",
-                params![sentinel_key],
-                |_| Ok(true),
-            )
-            .unwrap_or(false);
-        !done
+    fn is_startup_vacuum_pending(conn: &Connection) -> Result<bool, String> {
+        let mode: i64 = conn
+            .pragma_query_value(None, "auto_vacuum", |row| row.get(0))
+            .map_err(|e| format!("Failed to read PRAGMA auto_vacuum: {}", e))?;
+        Ok(mode != 2)
     }
 
     pub fn check_startup_vacuum_needed(&self) -> Result<bool, String> {
         let guard = self.get_connection_named("startup_vacuum_check")?;
         let conn = guard.as_ref().unwrap();
-        Ok(Self::is_startup_vacuum_pending(conn))
+        Self::is_startup_vacuum_pending(conn)
     }
 
     pub fn is_mcp_privacy_acknowledged(&self) -> Result<bool, String> {
@@ -836,7 +821,7 @@ impl StorageState {
         Ok(())
     }
 
-    /// Run the versioned one-time full VACUUM if needed.
+    /// Run the one-time full VACUUM needed to enable incremental auto-vacuum.
     pub fn run_startup_vacuum_if_needed(&self) -> Result<bool, String> {
         if self
             .startup_vacuum_in_progress
@@ -852,16 +837,12 @@ impl StorageState {
             let conn = guard.as_ref().unwrap();
             Self::set_auto_vacuum_incremental(conn)?;
 
-            if !Self::is_startup_vacuum_pending(conn) {
+            if !Self::is_startup_vacuum_pending(conn)? {
                 return Ok(false);
             }
 
-            let version = env!("CARGO_PKG_VERSION");
-            let sentinel_key = Self::startup_vacuum_sentinel_key();
-
             tracing::info!(
-                "[DB] First startup for version {}, running full VACUUM for incremental auto_vacuum",
-                version
+                "[DB] Converting database to incremental auto_vacuum with a one-time full VACUUM"
             );
             conn.execute_batch("VACUUM;").map_err(|e| {
                 format!(
@@ -869,12 +850,6 @@ impl StorageState {
                     e
                 )
             })?;
-
-            conn.execute(
-                "INSERT OR IGNORE INTO app_metadata (key, value) VALUES (?1, ?2)",
-                params![sentinel_key, version],
-            )
-            .map_err(|e| format!("Failed to write auto_vacuum sentinel: {}", e))?;
 
             Ok(true)
         })();
@@ -886,9 +861,6 @@ impl StorageState {
     }
 
     /// Run full VACUUM manually from UI.
-    ///
-    /// Also writes current-version sentinel so next startup does not re-run
-    /// the one-time startup VACUUM.
     pub fn run_manual_vacuum(&self) -> Result<(), String> {
         if self
             .startup_vacuum_in_progress
@@ -907,19 +879,6 @@ impl StorageState {
             tracing::info!("[DB] Manual VACUUM started from settings");
             conn.execute_batch("VACUUM;")
                 .map_err(|e| format!("Failed to run manual VACUUM: {}", e))?;
-
-            let version = env!("CARGO_PKG_VERSION");
-            let sentinel_key = Self::startup_vacuum_sentinel_key();
-            conn.execute(
-                "INSERT OR REPLACE INTO app_metadata (key, value) VALUES (?1, ?2)",
-                params![sentinel_key, version],
-            )
-            .map_err(|e| {
-                format!(
-                    "Failed to update auto_vacuum sentinel after manual VACUUM: {}",
-                    e
-                )
-            })?;
 
             Ok(())
         })();
@@ -1562,6 +1521,29 @@ mod tests {
                  ('{run_id}', 'copy_chroma_hot_layer', 'revision-1', 'completed', 'finished');"
         ))
         .expect("insert legacy run row");
+    }
+
+    #[test]
+    fn legacy_version_marker_does_not_mask_an_unmigrated_database() {
+        let conn = Connection::open_in_memory().expect("in-memory database");
+        conn.execute_batch(
+            "CREATE TABLE app_metadata (key TEXT PRIMARY KEY, value TEXT);
+             INSERT INTO app_metadata (key, value)
+             VALUES ('auto_vacuum_incremental_done_v0.8.5', '0.8.5');",
+        )
+        .expect("install legacy auto-vacuum marker");
+
+        assert!(StorageState::is_startup_vacuum_pending(&conn).expect("inspect auto-vacuum mode"));
+    }
+
+    #[test]
+    fn incremental_auto_vacuum_mode_skips_startup_rebuild_without_a_marker() {
+        let conn = Connection::open_in_memory().expect("in-memory database");
+        StorageState::set_auto_vacuum_incremental(&conn).expect("enable incremental auto-vacuum");
+        conn.execute_batch("CREATE TABLE app_metadata (key TEXT PRIMARY KEY, value TEXT);")
+            .expect("create schema after setting auto-vacuum");
+
+        assert!(!StorageState::is_startup_vacuum_pending(&conn).expect("inspect auto-vacuum mode"));
     }
 
     /// The upgrade path a released install actually takes: MiniLM-named tables


### PR DESCRIPTION
﻿This PR experimentally introduces WAL journal mode as an opt-in developer experiment for the SQLite storage layer, while keeping DELETE as the sole default. 

A debug build can opt in via the `CARBONPAPER_WAL_EXPERIMENT=1` environment variable; release builds ignore the flag. Startup resolves the policy once, converts the journal mode under eligibility checks (local, writable directory with enough free space), records every attempt in a mode ledger table, and defers a failed conversion to a later startup instead of failing hard. WAL sidecar growth is bounded by autocheckpoint and journal size limits, and full VACUUM paths gain disk-space guards.

## Key Changes

- `src-tauri/src/storage/mode.rs`: add `DatabaseModePolicy` (Delete/Wal) resolved once per process from `CARBONPAPER_WAL_EXPERIMENT`, with debug-build-only opt-in; add the `database_mode_metadata` ledger table; evaluate conversion eligibility (writable, local filesystem, free space) for delete/wal transitions and apply them at startup with stable/transitioning/failed tracking.
- `src-tauri/src/storage/schema.rs`: apply the startup journal-mode policy before creating tables; set `auto_vacuum = INCREMENTAL` before the first table so fresh databases never need a full VACUUM; guard startup and manual VACUUM with a disk-space check (2x database group size + 64 MB) and journal-mode verification; checkpoint WAL after VACUUM and trim oversized WAL sidecars at startup.
- `src-tauri/src/storage/connection.rs`: set `wal_autocheckpoint = 1000` and `journal_size_limit = 64 MB` on every connection; add the `checkpoint_wal_truncate` helper with structured busy/frame reporting.
- `src-tauri/src/storage/mod.rs`: carry the mode policy in `StorageState` via `new_with_mode_policy`; reject independent read connections until storage initialization has published the post-conversion state.
- `src-tauri/src/lib.rs`: resolve and log the mode policy once at startup, pass it into `StorageState`, and start Office observation only after storage initialization completes so no worker opens a read connection during conversion.
- `src-tauri/src/commands/credential.rs`: start the Office runtime at the same post-storage boundary on first-run credential initialization.
- `CONTRIBUTING.md`: document how to enable the developer WAL experiment and the fallback behavior when a conversion cannot complete.
- `src-tauri/semantic-worker/Cargo.lock`: align the worker lockfile with the v0.8.5 version bump.
