### PR TITLE
fix(storage): split UI reads and enable release WAL opt-in

### DIFF
--- a/scripts/verify-wal-foundation.ps1
+++ b/scripts/verify-wal-foundation.ps1
@@ -37,6 +37,8 @@ try {
         'storage::migration::data_dir',
         'storage::connection::tests',
         'storage::mode',
+        'storage::tests',
+        'storage::screenshot::ocr_lifecycle_tests',
         'credential_manager::tests::import_snapshot_restores_cached_state_without_touching_credential_file'
     )
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -801,13 +801,7 @@ pub fn run() {
     // Resolve the experiment switch once. The resulting policy is carried by
     // StorageState so reopens after restore or directory migration cannot
     // change mode halfway through a process.
-    let database_mode_policy = match database_mode_policy_from_environment() {
-        Ok(policy) => policy,
-        Err(error) => {
-            tracing::error!("Database journal mode experiment configuration is invalid: {error}");
-            return;
-        }
-    };
+    let database_mode_policy = database_mode_policy_from_environment();
     tracing::info!(
         "Database startup journal mode policy target={} wal_experiment={} debug_build={}",
         database_mode_policy.as_str(),

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -505,6 +505,13 @@ impl StorageState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::{params, TransactionBehavior};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    const READ_TEST_TIMESTAMP: i64 = 1_700_000_040;
+    const THREAD_TIMEOUT: Duration = Duration::from_secs(5);
 
     fn test_storage() -> (tempfile::TempDir, StorageState) {
         let temp = tempfile::tempdir().expect("create temporary storage directory");
@@ -565,5 +572,230 @@ mod tests {
             Err(error) => error,
         };
         assert_eq!(error, "Database not initialized");
+    }
+
+    fn initialized_read_storage(
+        policy: mode::DatabaseModePolicy,
+    ) -> (tempfile::TempDir, Arc<StorageState>) {
+        let temp = tempfile::tempdir().expect("temporary encrypted storage");
+        let credential = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        // These reads need only a SQLCipher key derived from the public bytes.
+        // No test creates or unlocks the user's Windows CNG key.
+        crate::credential_manager::save_public_key_to_file(&credential, b"read-test-public-key")
+            .unwrap();
+        let storage = Arc::new(StorageState::new_with_mode_policy(
+            temp.path().to_path_buf(),
+            credential,
+            policy,
+        ));
+        storage.initialize().expect("initialize encrypted storage");
+        assert_eq!(
+            storage
+                .database_mode_metadata()
+                .unwrap()
+                .actual_journal_mode,
+            policy.as_str()
+        );
+        {
+            let guard = storage.get_connection_named("seed_read_fixture").unwrap();
+            let conn = guard.as_ref().unwrap();
+            conn.execute_batch(
+                "INSERT INTO screenshots
+                    (id, image_path, image_hash, process_name, created_at, is_deleted)
+                 VALUES
+                    (1, 'one.enc', 'one', 'Editor', '2023-11-14 22:14:00', 0),
+                    (2, 'two.enc', 'two', 'Editor', '2023-11-14 22:14:10', 0),
+                    (3, 'three.enc', 'three', 'Browser', '2023-11-14 22:15:00', 0),
+                    (4, 'deleted.enc', 'deleted', 'Deleted', '2023-11-14 22:14:00', 1);",
+            )
+            .unwrap();
+            for (id, screenshot_id, x, y, deleted) in [
+                (10, 1, 20.0, 5.0, 0),
+                (11, 1, 0.0, 5.0, 0),
+                (12, 1, 0.0, 25.0, 0),
+                (13, 1, 0.0, 0.0, 1),
+                (14, 2, 0.0, 0.0, 0),
+            ] {
+                conn.execute(
+                    "INSERT INTO ocr_results
+                        (id, screenshot_id, text_hash, text, confidence,
+                         box_x1, box_y1, box_x2, box_y2, box_x3, box_y3, box_x4, box_y4,
+                         created_at, is_deleted)
+                     VALUES (?1, ?2, '', 'legacy plaintext', 0.75,
+                             ?3, ?4, ?5, ?4, ?5, ?6, ?3, ?6,
+                             '2023-11-14 22:14:00', ?7)",
+                    params![id, screenshot_id, x, y, x + 10.0, y + 10.0, deleted],
+                )
+                .unwrap();
+            }
+        }
+        (temp, storage)
+    }
+
+    fn assert_read_fixture(storage: &StorageState, browser_process: &str) {
+        let ocr = storage.get_screenshot_ocr_results(1).expect("OCR detail");
+        assert_eq!(
+            ocr.iter().map(|row| row.id).collect::<Vec<_>>(),
+            [11, 10, 12]
+        );
+        assert!(ocr
+            .iter()
+            .all(|row| row.screenshot_id == 1 && row.text.is_empty()));
+        assert_eq!(ocr[0].confidence, 0.75);
+        assert_eq!(
+            ocr[0].box_coords,
+            vec![
+                vec![0.0, 5.0],
+                vec![10.0, 5.0],
+                vec![10.0, 15.0],
+                vec![0.0, 15.0]
+            ]
+        );
+        assert_eq!(
+            ocr[0].created_at,
+            wire_time::from_sqlite_utc("2023-11-14 22:14:00")
+        );
+
+        let density = storage
+            .get_screenshot_density(
+                READ_TEST_TIMESTAMP as f64,
+                (READ_TEST_TIMESTAMP + 120) as f64,
+                60,
+                0,
+            )
+            .expect("timeline density");
+        assert_eq!(
+            density
+                .iter()
+                .map(|bucket| (bucket.timestamp, bucket.count))
+                .collect::<Vec<_>>(),
+            [(READ_TEST_TIMESTAMP, 2), (READ_TEST_TIMESTAMP + 60, 1)]
+        );
+        assert_eq!(
+            storage
+                .list_distinct_processes()
+                .expect("process statistics"),
+            vec![("Editor".to_string(), 2), (browser_process.to_string(), 1)]
+        );
+    }
+
+    #[test]
+    fn ui_reads_finish_while_primary_writer_is_held() {
+        for policy in [
+            mode::DatabaseModePolicy::Wal,
+            mode::DatabaseModePolicy::Delete,
+        ] {
+            let (_temp, storage) = initialized_read_storage(policy);
+            let mut primary = storage.get_connection_named("held_primary_writer").unwrap();
+            let tx = primary
+                .as_mut()
+                .unwrap()
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .unwrap();
+            tx.execute(
+                "UPDATE screenshots SET process_name = 'Updated' WHERE id = 3",
+                [],
+            )
+            .unwrap();
+
+            let reader_storage = Arc::clone(&storage);
+            let (finished_tx, finished_rx) = mpsc::channel();
+            let reader = thread::spawn(move || {
+                // All three application entry points must finish before the
+                // writer releases its mutex, and see only committed records.
+                assert_read_fixture(&reader_storage, "Browser");
+                finished_tx.send(()).unwrap();
+            });
+            let finished = finished_rx.recv_timeout(THREAD_TIMEOUT);
+            let write_result = if finished.is_ok() {
+                tx.commit()
+            } else {
+                tx.rollback()
+            };
+            // Release the writer even on failure so a regressed reader can exit.
+            drop(primary);
+            reader.join().expect("read worker exits");
+            finished.expect("UI reads must not wait for the primary database mutex");
+            write_result.expect("writer commits after concurrent reads");
+            assert_read_fixture(&storage, "Updated");
+        }
+    }
+
+    #[test]
+    fn shutdown_drains_independent_reads_and_reopens_storage() {
+        for policy in [
+            mode::DatabaseModePolicy::Wal,
+            mode::DatabaseModePolicy::Delete,
+        ] {
+            let (_temp, storage) = initialized_read_storage(policy);
+            assert_read_fixture(&storage, "Browser");
+            drop(
+                storage
+                    .try_database_maintenance("after_ui_reads")
+                    .expect("UI reads release permits"),
+            );
+            let generation = storage.db_generation();
+            let reader = storage
+                .open_read_connection_named("held_read_transaction")
+                .unwrap();
+            reader
+                .execute_batch("BEGIN; SELECT id FROM screenshots LIMIT 1;")
+                .unwrap();
+            assert!(storage
+                .try_database_maintenance("held_reader_check")
+                .is_none());
+
+            let shutdown_storage = Arc::clone(&storage);
+            let (finished_tx, finished_rx) = mpsc::channel();
+            let shutdown = thread::spawn(move || {
+                finished_tx.send(shutdown_storage.shutdown()).unwrap();
+            });
+            let deadline = Instant::now() + THREAD_TIMEOUT;
+            while !storage.is_database_maintenance_pending()
+                && !shutdown.is_finished()
+                && Instant::now() < deadline
+            {
+                thread::yield_now();
+            }
+            let pending = storage.is_database_maintenance_pending();
+            let early_completion = finished_rx.try_recv().ok();
+            let closed_early = early_completion.is_some();
+            drop(reader);
+            let result = early_completion.unwrap_or_else(|| {
+                finished_rx
+                    .recv_timeout(THREAD_TIMEOUT)
+                    .expect("shutdown finishes after reader closes")
+            });
+            shutdown.join().expect("shutdown worker exits");
+            result.expect("storage shutdown succeeds");
+            assert!(pending, "shutdown must wait for independent readers");
+            assert!(
+                !closed_early,
+                "shutdown must not overtake a live read connection"
+            );
+            assert!(!storage.is_initialized());
+
+            storage.initialize().expect("reopen after maintenance");
+            assert!(storage.db_generation() > generation);
+            assert_read_fixture(&storage, "Browser");
+            let committed = storage
+                .commit_screenshot(1, None, Some("work"), None)
+                .unwrap();
+            assert_eq!(committed.screenshot_id, Some(1));
+            {
+                let read = storage
+                    .open_read_connection_named("verify_reopened_write")
+                    .unwrap();
+                let record: (String, String) = read
+                    .query_row(
+                        "SELECT status, category FROM screenshots WHERE id = 1",
+                        [],
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )
+                    .unwrap();
+                assert_eq!(record, ("committed".to_string(), "work".to_string()));
+            }
+            storage.shutdown().expect("subsequent shutdown succeeds");
+        }
     }
 }

--- a/src-tauri/src/storage/mode.rs
+++ b/src-tauri/src/storage/mode.rs
@@ -22,8 +22,8 @@ pub(crate) const WAL_EXPERIMENT_ENV: &str = "CARBONPAPER_WAL_EXPERIMENT";
 
 /// The journal mode selected once for the lifetime of a process.
 ///
-/// DELETE is deliberately the only default. WAL is available solely to a
-/// debug build whose caller explicitly sets the experiment environment flag.
+/// DELETE remains the default. Both development and release builds can opt
+/// into WAL explicitly through the experiment environment flag.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DatabaseModePolicy {
     Delete,
@@ -47,47 +47,27 @@ impl DatabaseModePolicy {
     }
 }
 
-/// Parse the developer opt-in independently of the compiled build mode.
-///
-/// Keeping the `debug_build` argument explicit makes the safety boundary
-/// testable without mutating the process environment or pretending a release
-/// binary is a development binary.
-pub(crate) fn parse_database_mode_policy(
-    raw_value: Option<&str>,
-    debug_build: bool,
-) -> Result<DatabaseModePolicy, String> {
+/// Parse the explicit opt-in without depending on the build profile or
+/// mutating the process environment in tests. Invalid values warn and use
+/// the default DELETE policy so this optional flag cannot prevent startup.
+pub(crate) fn parse_database_mode_policy(raw_value: Option<&str>) -> DatabaseModePolicy {
     let value = raw_value.map(str::trim).filter(|value| !value.is_empty());
-    if !debug_build {
-        return Ok(DatabaseModePolicy::Delete);
-    }
-
     match value {
-        None | Some("0") => Ok(DatabaseModePolicy::Delete),
-        Some("1") => Ok(DatabaseModePolicy::Wal),
-        Some(value) => Err(format!(
-            "Invalid {WAL_EXPERIMENT_ENV} value '{value}'; expected 1 or 0"
-        )),
+        None | Some("0") => DatabaseModePolicy::Delete,
+        Some("1") => DatabaseModePolicy::Wal,
+        Some(value) => {
+            tracing::warn!(
+                "Invalid {WAL_EXPERIMENT_ENV} value {value:?}; expected 1 or 0; using DELETE startup policy"
+            );
+            DatabaseModePolicy::Delete
+        }
     }
 }
 
 /// Resolve the startup policy once, before the `StorageState` is constructed.
-pub(crate) fn database_mode_policy_from_environment() -> Result<DatabaseModePolicy, String> {
+pub(crate) fn database_mode_policy_from_environment() -> DatabaseModePolicy {
     let raw_value = std::env::var(WAL_EXPERIMENT_ENV).ok();
-    let policy = parse_database_mode_policy(raw_value.as_deref(), cfg!(debug_assertions))?;
-
-    if !cfg!(debug_assertions) {
-        if let Some(value) = raw_value
-            .as_deref()
-            .map(str::trim)
-            .filter(|v| !v.is_empty())
-        {
-            tracing::warn!(
-                "Ignoring {WAL_EXPERIMENT_ENV}={value} in a non-debug build; database mode remains DELETE"
-            );
-        }
-    }
-
-    Ok(policy)
+    parse_database_mode_policy(raw_value.as_deref())
 }
 
 const MODE_TABLE_SCHEMA: &str = r#"
@@ -849,24 +829,30 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn database_mode_policy_requires_an_explicit_debug_opt_in() {
-        assert_eq!(
-            parse_database_mode_policy(None, true).unwrap(),
-            DatabaseModePolicy::Delete
-        );
-        assert_eq!(
-            parse_database_mode_policy(Some("0"), true).unwrap(),
-            DatabaseModePolicy::Delete
-        );
-        assert_eq!(
-            parse_database_mode_policy(Some(" 1 "), true).unwrap(),
-            DatabaseModePolicy::Wal
-        );
-        assert!(parse_database_mode_policy(Some("true"), true).is_err());
-        assert_eq!(
-            parse_database_mode_policy(Some("1"), false).unwrap(),
-            DatabaseModePolicy::Delete
-        );
+    fn database_mode_policy_requires_an_explicit_opt_in_in_all_builds() {
+        for value in [None, Some(""), Some("  "), Some("0"), Some(" 0 ")] {
+            assert_eq!(
+                parse_database_mode_policy(value),
+                DatabaseModePolicy::Delete
+            );
+        }
+        for value in ["1", " 1 "] {
+            assert_eq!(
+                parse_database_mode_policy(Some(value)),
+                DatabaseModePolicy::Wal
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_database_mode_values_use_delete_policy() {
+        for value in ["true", "false", "2", "wal", "-1", "invalid", " 2 "] {
+            assert_eq!(
+                parse_database_mode_policy(Some(value)),
+                DatabaseModePolicy::Delete,
+                "invalid optional flag {value:?} must retain the default"
+            );
+        }
     }
 
     fn create_mode_table(conn: &Connection) {
@@ -992,6 +978,29 @@ mod tests {
         storage.initialize().unwrap();
 
         let metadata = storage.database_mode_metadata().unwrap();
+        assert_eq!(metadata.actual_journal_mode, "delete");
+        assert_eq!(metadata.requested_journal_mode, "delete");
+        assert_eq!(metadata.transition_state, TRANSITION_STABLE);
+    }
+
+    #[test]
+    fn invalid_database_mode_value_allows_storage_initialization() {
+        let temp = tempdir().unwrap();
+        let credential = Arc::new(CredentialManagerState::new(temp.path().to_path_buf()));
+        crate::credential_manager::save_public_key_to_file(&credential, b"invalid-mode-public-key")
+            .unwrap();
+        let storage = StorageState::new_with_mode_policy(
+            temp.path().to_path_buf(),
+            credential,
+            parse_database_mode_policy(Some("true")),
+        );
+
+        storage
+            .initialize()
+            .expect("invalid optional flag must not block storage startup");
+
+        let metadata = storage.database_mode_metadata().unwrap();
+        assert!(storage.is_initialized());
         assert_eq!(metadata.actual_journal_mode, "delete");
         assert_eq!(metadata.requested_journal_mode, "delete");
         assert_eq!(metadata.transition_state, TRANSITION_STABLE);

--- a/src-tauri/src/storage/process.rs
+++ b/src-tauri/src/storage/process.rs
@@ -12,13 +12,16 @@ impl StorageState {
     pub fn list_distinct_processes(&self) -> Result<Vec<(String, i64)>, String> {
         let fn_start = std::time::Instant::now();
 
-        // Phase 1: SQL aggregation + extract encrypted-only rows (hold mutex)
+        // Phase 1: aggregate and extract encrypted-only rows in one read
+        // snapshot, so a concurrent plaintext backfill cannot omit/double-count a row.
         let (mut counts, encrypted_rows): (
             std::collections::HashMap<String, i64>,
             Vec<(Option<Vec<u8>>, Option<Vec<u8>>)>,
         ) = {
-            let guard = self.get_connection_named("list_distinct_processes")?;
-            let conn = guard.as_ref().unwrap();
+            let reader = self.open_read_connection_named("list_distinct_processes")?;
+            let conn = reader
+                .unchecked_transaction()
+                .map_err(|e| format!("Failed to start process statistics read: {}", e))?;
 
             // Fast path: aggregate plaintext process_name via SQL.
             //
@@ -71,12 +74,17 @@ impl StorageState {
                 .filter_map(|r| r.ok())
                 .collect();
 
+            drop(enc_stmt);
+            drop(stmt);
+            conn.commit()
+                .map_err(|e| format!("Failed to finish process statistics read: {}", e))?;
             (counts, enc_rows)
-            // guard dropped — mutex released
+            // The read connection and its maintenance permit are released here.
         };
         let query_dur = fn_start.elapsed();
 
-        // Phase 2: Decrypt old records outside mutex (only if user has authenticated)
+        // Phase 2: decrypt old records after closing the read connection
+        // (only if the user has authenticated).
         let session_valid = self.credential_state.is_session_valid();
         let skipped_encrypted = !session_valid && !encrypted_rows.is_empty();
         if session_valid {

--- a/src-tauri/src/storage/screenshot.rs
+++ b/src-tauri/src/storage/screenshot.rs
@@ -61,6 +61,25 @@ struct EncryptedOcrResultRow {
     created_at: String,
 }
 
+impl EncryptedOcrResultRow {
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get(0)?,
+            screenshot_id: row.get(1)?,
+            text_enc: row.get(2)?,
+            text_key_encrypted: row.get(3)?,
+            confidence: row.get(4)?,
+            box_coords: vec![
+                vec![row.get::<_, f64>(5)?, row.get::<_, f64>(6)?],
+                vec![row.get::<_, f64>(7)?, row.get::<_, f64>(8)?],
+                vec![row.get::<_, f64>(9)?, row.get::<_, f64>(10)?],
+                vec![row.get::<_, f64>(11)?, row.get::<_, f64>(12)?],
+            ],
+            created_at: row.get(13)?,
+        })
+    }
+}
+
 struct EncryptedScreenshotSummaryRow {
     id: i64,
     window_title_plain: Option<String>,
@@ -1739,8 +1758,7 @@ impl StorageState {
         bucket_seconds: i64,
         bucket_offset_seconds: i64,
     ) -> Result<Vec<DensityBucket>, String> {
-        let guard = self.get_connection_named("get_screenshot_density")?;
-        let conn = guard.as_ref().unwrap();
+        let conn = self.open_read_connection_named("get_screenshot_density")?;
 
         let start_dt = DateTime::<Utc>::from_timestamp(start_ts as i64, 0)
             .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string())
@@ -2269,24 +2287,31 @@ impl StorageState {
         &self,
         screenshot_id: i64,
     ) -> Result<Vec<super::OcrResult>, String> {
-        let guard = self.get_connection_named("get_screenshot_ocr_results")?;
-        let conn = guard.as_ref().unwrap();
-
-        let mut stmt = conn
-            .prepare(
-                "SELECT id, screenshot_id, text_enc, text_key_encrypted, confidence,
+        let encrypted_rows = {
+            let conn = self.open_read_connection_named("get_screenshot_ocr_results")?;
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, screenshot_id, text_enc, text_key_encrypted, confidence,
                         box_x1, box_y1, box_x2, box_y2,
                         box_x3, box_y3, box_x4, box_y4, created_at
                  FROM ocr_results WHERE screenshot_id = ? AND is_deleted = 0
                  ORDER BY box_y1, box_x1",
-            )
-            .map_err(|e| format!("Failed to prepare query: {}", e))?;
+                )
+                .map_err(|e| format!("Failed to prepare query: {}", e))?;
+            let rows = stmt
+                .query_map([screenshot_id], EncryptedOcrResultRow::from_row)
+                .map_err(|e| format!("Failed to execute query: {}", e))?
+                .filter_map(|row| row.ok())
+                .collect::<Vec<_>>();
+            rows
+        };
 
-        let results = stmt
-            .query_map([screenshot_id], |row| {
-                let text_enc: Option<Vec<u8>> = row.get(2)?;
-                let text_key_enc: Option<Vec<u8>> = row.get(3)?;
-                let text = match (text_enc.as_ref(), text_key_enc.as_ref()) {
+        // CNG decryption can be slow or prompt the user. Close the SQLite
+        // cursor and read connection before starting it.
+        Ok(encrypted_rows
+            .into_iter()
+            .map(|row| {
+                let text = match (row.text_enc.as_deref(), row.text_key_encrypted.as_deref()) {
                     (Some(data), Some(key)) => self
                         .decrypt_payload_with_row_key(data, key)
                         .ok()
@@ -2294,25 +2319,16 @@ impl StorageState {
                     _ => None,
                 };
 
-                Ok(super::OcrResult {
-                    id: row.get(0)?,
-                    screenshot_id: row.get(1)?,
+                super::OcrResult {
+                    id: row.id,
+                    screenshot_id: row.screenshot_id,
                     text: text.unwrap_or_default(),
-                    confidence: row.get(4)?,
-                    box_coords: vec![
-                        vec![row.get::<_, f64>(5)?, row.get::<_, f64>(6)?],
-                        vec![row.get::<_, f64>(7)?, row.get::<_, f64>(8)?],
-                        vec![row.get::<_, f64>(9)?, row.get::<_, f64>(10)?],
-                        vec![row.get::<_, f64>(11)?, row.get::<_, f64>(12)?],
-                    ],
-                    created_at: wire_time::from_sqlite_utc(&row.get::<_, String>(13)?),
-                })
+                    confidence: row.confidence,
+                    box_coords: row.box_coords,
+                    created_at: wire_time::from_sqlite_utc(&row.created_at),
+                }
             })
-            .map_err(|e| format!("Failed to execute query: {}", e))?
-            .filter_map(|r| r.ok())
-            .collect();
-
-        Ok(results)
+            .collect())
     }
 
     /// Get OCR results for unattended recovery without allowing CNG to display UI.
@@ -2343,22 +2359,7 @@ impl StorageState {
                 })?;
 
             let rows = stmt
-                .query_map([screenshot_id], |row| {
-                    Ok(EncryptedOcrResultRow {
-                        id: row.get(0)?,
-                        screenshot_id: row.get(1)?,
-                        text_enc: row.get(2)?,
-                        text_key_encrypted: row.get(3)?,
-                        confidence: row.get(4)?,
-                        box_coords: vec![
-                            vec![row.get::<_, f64>(5)?, row.get::<_, f64>(6)?],
-                            vec![row.get::<_, f64>(7)?, row.get::<_, f64>(8)?],
-                            vec![row.get::<_, f64>(9)?, row.get::<_, f64>(10)?],
-                            vec![row.get::<_, f64>(11)?, row.get::<_, f64>(12)?],
-                        ],
-                        created_at: row.get(13)?,
-                    })
-                })
+                .query_map([screenshot_id], EncryptedOcrResultRow::from_row)
                 .map_err(|e| BackgroundReadError::Other(format!("Failed to execute query: {}", e)))?
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| {


### PR DESCRIPTION
This PR continues the WAL (Write-Ahead Logging) experiment from #192: UI reads move to independent read-only connections instead of contending for the primary write connection, and the experiment flag is now available to release builds.

Previously, OCR details, timeline density, and process statistics all had to acquire the primary write connection's mutex before querying, so reads and writes could block each other. These three read paths now run on independent read-only connections and can proceed in parallel with writes. Additionally, `CARBONPAPER_WAL_EXPERIMENT=1` is no longer restricted to debug builds; release builds can also enable the experiment explicitly. Invalid values log a warning and fall back to the default DELETE journal mode instead of preventing startup.

## Key Changes

- `src-tauri/src/storage/mode.rs`: remove the debug-build-only restriction on the experiment flag; invalid values now warn and continue with the DELETE policy, and `parse_database_mode_policy` no longer returns an error so the optional flag can never block startup.
- `src-tauri/src/lib.rs`: resolve the startup journal-mode policy without a failure branch; invalid configuration no longer exits the process.
- `src-tauri/src/storage/screenshot.rs`: `get_screenshot_ocr_results` and `get_screenshot_density` use independent read-only connections opened via `open_read_connection_named`; OCR details fetch the encrypted rows and close the connection before starting CNG (Windows Next Generation Cryptography) decryption, so a slow decryption no longer holds a connection; extract `EncryptedOcrResultRow::from_row` for reuse by both the regular read and the unattended recovery paths.
- `src-tauri/src/storage/process.rs`: `list_distinct_processes` performs aggregation and encrypted-row extraction in a single read-transaction snapshot on an independent read connection, preventing a concurrent plaintext backfill from omitting or double-counting rows; decryption runs after the read connection closes.
- `src-tauri/src/storage/mod.rs`: add application-layer regressions: under both WAL and DELETE policies, all three UI read entry points must finish within the timeout while the primary writer holds its transaction and observe only committed data; shutdown must wait for live independent read connections to drain, and storage reopens and continues accepting commits after maintenance.
- `scripts/verify-wal-foundation.ps1`: include `storage::tests` and `storage::screenshot::ocr_lifecycle_tests` in the WAL foundation verification script.
